### PR TITLE
Fix render_param regex

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -43,7 +43,7 @@ def tokenize(source):
             elif part.startswith('#') or part.startswith('/'):
                 nodes.append(parsefirstword(part))
             else:
-                if re.match("^:?[a-zA-z._]+$", part):
+                if re.match("^:?[A-Za-z._]+$", part):
                     if part[0] == ':':
                         part = part[1:]
                     part = part.replace('.', '__')

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,15 @@
+import importlib.util
+import pathlib
+
+spec = importlib.util.spec_from_file_location('pageql.parser', 'src/pageql/parser.py')
+parser = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parser)
+
+def test_special_chars_are_expression():
+    tokens = parser.tokenize('Hello {{a^b}}')
+    assert tokens == [('text', 'Hello '), ('render_expression', 'a^b')]
+    tokens = parser.tokenize('Hi {{x[y]}}')
+    assert tokens == [('text', 'Hi '), ('render_expression', 'x[y]')]
+
+if __name__ == '__main__':
+    test_special_chars_are_expression()


### PR DESCRIPTION
## Summary
- restrict render_param regex to `A-Za-z` so `[` or `^` don't match
- test parser tokens with special characters

## Testing
- `python test_parser.py`
- `python test_reactive.py`