### PR TITLE
Fix boolean flag parsing and update tests

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -60,15 +60,16 @@ def parse_param_attrs(s):
     attrs = {}
     # Use regex to handle quoted values
     pattern = r'([^\s=]+)(?:=(?:"([^"]*)"|\'([^\']*)\'|([^\s]*)))?'
-    matches = re.findall(pattern, s.strip())
-    for match in matches:
-        key = match[0].strip()
+    matches = re.finditer(pattern, s.strip())
+    for m in matches:
+        key = m.group(1).strip()
         # Get the value from whichever group matched (double quote, single quote, or unquoted)
-        value = match[1] or match[2] or match[3]
-        if value == '':  # If there was an equals sign but empty value
-            attrs[key] = ''
-        elif '=' in s and key in s and s.find(key) + len(key) < len(s) and s[s.find(key) + len(key)] == '=':
-            attrs[key] = value
+        value = m.group(2) or m.group(3) or m.group(4)
+        if '=' in m.group(0):
+            if value == '':
+                attrs[key] = ''
+            else:
+                attrs[key] = value
         else:
             attrs[key] = True
     return attrs

--- a/tests/test_parse_param_attrs.py
+++ b/tests/test_parse_param_attrs.py
@@ -1,0 +1,36 @@
+import sys, types
+
+# Stub watchfiles so importing pageql doesn't fail
+if 'watchfiles' not in sys.modules:
+    sys.modules['watchfiles'] = types.ModuleType('watchfiles')
+    sys.modules['watchfiles'].awatch = None
+
+sys.path.insert(0, 'src')
+from pageql.pageql import parse_param_attrs
+
+
+def test_single_quotes():
+    result = parse_param_attrs("name='John Doe'")
+    assert result == {'name': 'John Doe'}
+
+
+def test_double_quotes():
+    result = parse_param_attrs('title="Hello World"')
+    assert result == {'title': 'Hello World'}
+
+
+def test_unquoted_value():
+    result = parse_param_attrs('count=5')
+    assert result == {'count': '5'}
+
+
+def test_boolean_flag():
+    result = parse_param_attrs('secure')
+    assert result == {'secure': True}
+
+
+if __name__ == '__main__':
+    test_single_quotes()
+    test_double_quotes()
+    test_unquoted_value()
+    test_boolean_flag()


### PR DESCRIPTION
## Summary
- ensure parse_param_attrs returns `True` for boolean flags
- adjust boolean flag test expectation

## Testing
- `python test_reactive.py && python tests/test_parse_param_attrs.py && echo ALLPASS`
