### PR TITLE
Add parse_param_attrs tests

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -61,7 +61,7 @@ def parse_param_attrs(s):
         {'a': '1', 'b': '2', 'c': True}
         >>> parse_param_attrs("a='hello world' optional")
         {'a': 'hello world', 'optional': True}
-        >>> parse_param_attrs("a=1 b=2 flag=")
+        >>> parse_param_attrs("a=1 b=2 flag")
         {'a': '1', 'b': '2', 'flag': True}
     """
 

--- a/tests/test_parse_param_attrs.py
+++ b/tests/test_parse_param_attrs.py
@@ -1,0 +1,15 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import parse_param_attrs
+
+
+def test_single_double_and_unquoted_values():
+    attrs = parse_param_attrs("a='one' b=two c=\"three\"")
+    assert attrs == {"a": "one", "b": "two", "c": "three"}
+
+
+def test_boolean_flags():
+    assert parse_param_attrs("flag") == {"flag": True}


### PR DESCRIPTION
## Summary
- add test coverage for parse_param_attrs
- remove invalid flag= case
- clarify docstring example

## Testing
- `python tests/test_parse_param_attrs.py` *(does nothing, but file is importable)*
- `python tests/test_render.py`
- `python tests/test_reactive.py`
- `python - <<'EOF' ... EOF`