### PR TITLE
Support reactive signals in #set

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,6 +8,7 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
+from pageql.reactive import Signal
 
 
 def test_render_nonexistent_returns_404():
@@ -21,6 +22,14 @@ def test_reactive_toggle():
     r.load_module("reactive", "{{reactive}} {{#reactive on}}{{reactive}} {{#reactive off}}{{reactive}}")
     result = r.render("/reactive")
     assert result.body.strip() == "False True False"
+
+
+def test_set_signal_reactive_on():
+    r = PageQL(":memory:")
+    r.load_module("sig", "{{#reactive on}}{{#set foo 42}}")
+    s = Signal(0)
+    r.render("/sig", {"foo": s})
+    assert s.value == 42
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- create Signal objects when `#set` is used in reactive mode
- update existing signals instead of replacing them
- add regression test to ensure signals are updated

## Testing
- `pytest -q` *(fails: command not found)*