### PR TITLE
Add pytest to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,11 @@ dependencies = [
     "watchfiles",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
 [project.scripts]
 pageql = "pageql.cli:main"
 


### PR DESCRIPTION
## Summary
- add pytest to optional dev dependencies

## Testing
- `pytest` *(fails: command not found)*