### PR TITLE
Switch #set to create DerivedSignal

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -21,7 +21,7 @@ if __package__ is None:                      # script / doctest-by-path
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from pageql.parser import tokenize, parsefirstword, build_ast
-from pageql.reactive import Signal
+from pageql.reactive import Signal, DerivedSignal, get_dependencies
 
 def flatten_params(params):
     """
@@ -380,15 +380,26 @@ class PageQL:
                 if var[0] == ':':
                     var = var[1:]
                 var = var.replace('.', '__')
-                value = evalone(self.db, args, params)
                 if reactive:
                     existing = params.get(var)
-                    if isinstance(existing, Signal):
-                        existing.set(value)
-                        params[var] = existing
-                    else:
-                        params[var] = Signal(value)
+                    # Build derived signal based on dependencies
+                    def compute():
+                        return evalone(self.db, args, params)
+
+                    deps = []
+                    for dep_name in get_dependencies(args):
+                        dep = params.get(dep_name)
+                        if isinstance(dep, (Signal, DerivedSignal)):
+                            deps.append(dep)
+
+                    new_sig = DerivedSignal(compute, deps)
+
+                    if isinstance(existing, (Signal, DerivedSignal)):
+                        for listener in existing.listeners:
+                            new_sig.listeners.append(listener)
+                    params[var] = new_sig
                 else:
+                    value = evalone(self.db, args, params)
                     params[var] = value
             elif node_type == '#render':
                 rendered_content = self.handle_render(node_content, path, params, includes, None, reactive)

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -1,5 +1,23 @@
 import re
 
+
+def get_dependencies(exp):
+    """Return parameter names referenced in a SQL expression.
+
+    Only colon-prefixed names or single bare variables are considered.
+    Dot notation is converted to ``__`` form to match flattened params.
+    """
+    deps = set()
+    exp = exp.strip()
+    # Simple variable expression like :foo or foo.bar
+    m = re.match(r'^:?([a-zA-Z_][a-zA-Z0-9_.]*)$', exp)
+    if m:
+        deps.add(m.group(1).replace('.', '__'))
+    else:
+        for name in re.findall(r':([a-zA-Z_][a-zA-Z0-9_.]*)', exp):
+            deps.add(name.replace('.', '__'))
+    return list(deps)
+
 class Signal:
     def __init__(self, value=None):
         self.value = value

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,7 +8,7 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
-from pageql.reactive import Signal
+from pageql.reactive import Signal, DerivedSignal
 
 
 def test_render_nonexistent_returns_404():
@@ -27,9 +27,24 @@ def test_reactive_toggle():
 def test_set_signal_reactive_on():
     r = PageQL(":memory:")
     r.load_module("sig", "{{#reactive on}}{{#set foo 42}}")
-    s = Signal(0)
-    r.render("/sig", {"foo": s})
-    assert s.value == 42
+    params = {"foo": Signal(0)}
+    r.render("/sig", params)
+    assert isinstance(params["foo"], DerivedSignal)
+    assert params["foo"].value == 42
+
+
+def test_set_creates_derived_signal_with_dependencies():
+    r = PageQL(":memory:")
+    r.load_module("dep", "{{#reactive on}}{{#set result :val + 1}}")
+    params = {"val": Signal(1)}
+    r.render("/dep", params)
+    result_sig = params["result"]
+    assert isinstance(result_sig, DerivedSignal)
+    events = []
+    result_sig.listeners.append(events.append)
+    params["val"].set(2)
+    assert result_sig.value == 3
+    assert events[-1] == 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support dependency tracking via `get_dependencies`
- build DerivedSignals when evaluating `#set` in reactive mode
- update render tests for DerivedSignal behaviour

## Testing
- `pip install watchfiles uvicorn` *(fails: no network)*
- `pytest -q` *(fails: pytest not installed)*