### PR TITLE
Fix DerivedSignal listener callback

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -43,9 +43,9 @@ class DerivedSignal:
         self.value = f()
         self.listeners = []
         for dep in deps:
-            dep.listeners.append(lambda _: self.update())
-        
-    def update(self):
+            dep.listeners.append(self.update)
+
+    def update(self, _=None):
         value = self.f()
         if self.value != value:
             self.value = value


### PR DESCRIPTION
## Summary
- simplify DerivedSignal listener hookup
- allow update to accept unused argument

## Testing
- `pytest -q`