### PR TITLE
Use DerivedSignal.replace when re-setting derived signals

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -400,12 +400,16 @@ class PageQL:
                                 env[k] = v
                         return evalone(self.db, args, env)
 
-                    signal = DerivedSignal(compute, deps)
                     existing = params.get(var)
-                    if isinstance(existing, Signal):
-                        existing.set(signal.value)
-                        signal.listeners.append(lambda v: existing.set(v))
-                    params[var] = signal
+                    if isinstance(existing, DerivedSignal):
+                        existing.replace(compute, deps)
+                        signal = existing
+                    else:
+                        signal = DerivedSignal(compute, deps)
+                        if isinstance(existing, Signal):
+                            existing.set(signal.value)
+                            signal.listeners.append(lambda v: existing.set(v))
+                        params[var] = signal
                 else:
                     params[var] = evalone(self.db, args, params)
             elif node_type == '#render':

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,7 +8,7 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
-from pageql.reactive import Signal
+from pageql.reactive import Signal, DerivedSignal
 
 
 def test_render_nonexistent_returns_404():
@@ -30,6 +30,18 @@ def test_set_signal_reactive_on():
     s = Signal(0)
     r.render("/sig", {"foo": s})
     assert s.value == 42
+
+
+def test_set_signal_derived_replace():
+    r = PageQL(":memory:")
+    r.load_module("sig", "{{#reactive on}}{{#set foo 1}}")
+    sig = DerivedSignal(lambda: 0, [])
+    r.render("/sig", {"foo": sig})
+    assert sig.value == 1
+
+    r.load_module("sig", "{{#reactive on}}{{#set foo 2}}")
+    r.render("/sig", {"foo": sig})
+    assert sig.value == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- leverage DerivedSignal.replace in `PageQL` for `#set` when variable already a DerivedSignal
- extend rendering tests to cover replacing derived signals

## Testing
- `pip install wheels_deps/anyio-4.9.0-py3-none-any.whl wheels_deps/idna-3.10-py3-none-any.whl wheels_deps/iniconfig-2.1.0-py3-none-any.whl wheels_deps/packaging-25.0-py3-none-any.whl wheels_deps/pluggy-1.6.0-py3-none-any.whl wheels_deps/pytest-8.3.5-py3-none-any.whl wheels_deps/sniffio-1.3.1-py3-none-any.whl wheels_deps/typing_extensions-4.13.2-py3-none-any.whl wheels_deps/watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`
- `pytest -q`