### PR TITLE
Remove Signal class

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -21,7 +21,7 @@ if __package__ is None:                      # script / doctest-by-path
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from pageql.parser import tokenize, parsefirstword, build_ast
-from pageql.reactive import Signal, DerivedSignal, get_dependencies
+from pageql.reactive import DerivedSignal, get_dependencies
 
 def flatten_params(params):
     """
@@ -388,13 +388,13 @@ class PageQL:
                     deps = []
                     for name in dep_names:
                         dep = params.get(name)
-                        if isinstance(dep, (Signal, DerivedSignal)):
+                        if isinstance(dep, DerivedSignal):
                             deps.append(dep)
 
                     def compute(args=args, params=params):
                         env = {}
                         for k, v in params.items():
-                            if isinstance(v, (Signal, DerivedSignal)):
+                            if isinstance(v, DerivedSignal):
                                 env[k] = v.value
                             else:
                                 env[k] = v
@@ -406,9 +406,6 @@ class PageQL:
                         signal = existing
                     else:
                         signal = DerivedSignal(compute, deps)
-                        if isinstance(existing, Signal):
-                            existing.set(signal.value)
-                            signal.listeners.append(lambda v: existing.set(v))
                         params[var] = signal
                 else:
                     params[var] = evalone(self.db, args, params)

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -1,16 +1,5 @@
 import re
 
-class Signal:
-    def __init__(self, value=None):
-        self.value = value
-        self.listeners = []
-    
-    def set(self, value):
-        if self.value != value:
-            self.value = value
-            for listener in self.listeners:
-                listener(value)
-
 def execute(conn, sql, params):
     try:
         cursor = conn.execute(sql, params)

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -56,7 +56,6 @@ import sqlite3
 from pageql.reactive import (
     ReactiveTable,
     CountAll,
-    Signal,
     DerivedSignal,
     Where,
     UnionAll,
@@ -139,14 +138,19 @@ def test_count_all():
 
 
 def test_signal_and_derived():
-    a, b = Signal(1), Signal(2)
+    a_val = [1]
+    b_val = [2]
+    a = DerivedSignal(lambda: a_val[0], [])
+    b = DerivedSignal(lambda: b_val[0], [])
     d = DerivedSignal(lambda: a.value + b.value, [a, b])
     seen = []
     d.listeners.append(seen.append)
-    a.set(2)
+    a_val[0] = 2
+    a.update()
     assert_eq(d.value, 4)
     assert_eq(seen[-1], 4)
-    a.set(2)  # no change
+    a_val[0] = 2  # no change
+    a.update()
     assert_eq(seen[-1], 4)
     assert len(seen) == 1
 
@@ -330,32 +334,43 @@ def test_union_mismatched_columns():
 
 
 def test_derived_signal_multiple_updates():
-    a, b = Signal(1), Signal(2)
+    a_val = [1]
+    b_val = [2]
+    a = DerivedSignal(lambda: a_val[0], [])
+    b = DerivedSignal(lambda: b_val[0], [])
     d = DerivedSignal(lambda: a.value * b.value, [a, b])
     seen = []
     d.listeners.append(seen.append)
-    b.set(3)
-    a.set(2)
+    b_val[0] = 3
+    b.update()
+    a_val[0] = 2
+    a.update()
     assert_eq(seen, [3, 6])
 
 
 def test_derived_signal_replace():
-    a, b = Signal(1), Signal(2)
+    a_val = [1]
+    b_val = [2]
+    a = DerivedSignal(lambda: a_val[0], [])
+    b = DerivedSignal(lambda: b_val[0], [])
     d = DerivedSignal(lambda: a.value + 1, [a])
     seen = []
     d.listeners.append(seen.append)
 
-    a.set(2)
+    a_val[0] = 2
+    a.update()
     assert_eq(seen[-1], 3)
 
     d.replace(lambda: b.value * 2, [b])
     assert_eq(d.value, 4)
     assert_eq(seen[-1], 4)
 
-    a.set(5)
+    a_val[0] = 5
+    a.update()
     assert_eq(seen[-1], 4)
 
-    b.set(3)
+    b_val[0] = 3
+    b.update()
     assert_eq(seen[-1], 6)
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,7 +8,7 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
-from pageql.reactive import Signal, DerivedSignal
+from pageql.reactive import DerivedSignal
 
 
 def test_render_nonexistent_returns_404():
@@ -27,7 +27,7 @@ def test_reactive_toggle():
 def test_set_signal_reactive_on():
     r = PageQL(":memory:")
     r.load_module("sig", "{{#reactive on}}{{#set foo 42}}")
-    s = Signal(0)
+    s = DerivedSignal(lambda: 0, [])
     r.render("/sig", {"foo": s})
     assert s.value == 42
 


### PR DESCRIPTION
## Summary
- drop `Signal` implementation
- adjust PageQL internals to use `DerivedSignal` only
- update tests to use `DerivedSignal`

## Testing
- `pytest -q`