### PR TITLE
Add reactive SQL parsing

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -5,8 +5,9 @@ PageQL: A template language for embedding SQL inside HTML directly
 # Import the main classes from the PageQL modules
 from .pageql import PageQL, RenderResult
 from .pageqlapp import PageQLApp
+from .reactive_sql import parse_reactive
 # Define the version
 __version__ = "0.1.0"
 
 # Make these classes available directly from the package
-__all__ = ["PageQL", "RenderResult", "PageQLApp"]
+__all__ = ["PageQL", "RenderResult", "PageQLApp", "parse_reactive"]

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -1,0 +1,47 @@
+import sqlglot
+from sqlglot import expressions as exp
+from .reactive import Tables, ReactiveTable, Select, Where, Union, UnionAll, CountAll
+
+
+def build_reactive(expr, tables: Tables):
+    if isinstance(expr, exp.Subquery):
+        return build_reactive(expr.this, tables)
+    if isinstance(expr, exp.Union):
+        left = build_reactive(expr.this, tables)
+        right = build_reactive(expr.expression, tables)
+        if expr.args.get("distinct", True):
+            return Union(left, right)
+        return UnionAll(left, right)
+    if isinstance(expr, exp.Select):
+        from_expr = expr.args.get("from")
+        if from_expr is None:
+            raise ValueError("SELECT missing FROM clause")
+        parent = build_from(from_expr.this, tables)
+        if expr.args.get("where"):
+            parent = Where(parent, expr.args["where"].this.sql())
+        select_list = expr.args.get("expressions") or [exp.Star()]
+        if len(select_list) == 1:
+            col = select_list[0]
+            if isinstance(col, exp.Star):
+                return parent
+            if isinstance(col, exp.Count) and isinstance(col.this, exp.Star):
+                return CountAll(parent)
+        select_sql = ", ".join(col.sql() for col in select_list)
+        return Select(parent, select_sql)
+    if isinstance(expr, exp.Table):
+        return tables._get(expr.name)
+    raise NotImplementedError(f"Unsupported expression type: {type(expr)}")
+
+
+def build_from(expr, tables: Tables):
+    if isinstance(expr, exp.Table):
+        return tables._get(expr.name)
+    if isinstance(expr, (exp.Select, exp.Union, exp.Subquery)):
+        return build_reactive(expr, tables)
+    raise NotImplementedError(f"Unsupported FROM expression: {type(expr)}")
+
+
+def parse_reactive(sql: str, tables: Tables):
+    """Parse a SQL SELECT into reactive components."""
+    expr = sqlglot.parse_one(sql)
+    return build_reactive(expr, tables)

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -1,0 +1,49 @@
+import sqlite3
+from pathlib import Path
+import types
+import sys
+
+# Ensure import path and stub watchfiles
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+from pageql.reactive import Tables, ReactiveTable, Select, Where, CountAll, UnionAll
+from pageql.reactive_sql import parse_reactive
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    return conn
+
+
+def test_parse_select_basic():
+    conn = _db()
+    tables = Tables(conn)
+    comp = parse_reactive("SELECT * FROM items", tables)
+    assert isinstance(comp, ReactiveTable)
+
+
+def test_parse_select_where():
+    conn = _db()
+    tables = Tables(conn)
+    comp = parse_reactive("SELECT name FROM items WHERE name='x'", tables)
+    assert isinstance(comp, Select)
+    assert isinstance(comp.parent, Where)
+
+
+def test_parse_count():
+    conn = _db()
+    tables = Tables(conn)
+    comp = parse_reactive("SELECT COUNT(*) FROM items", tables)
+    assert isinstance(comp, CountAll)
+
+
+def test_parse_union_all():
+    conn = sqlite3.connect(":memory:")
+    for t in ("a", "b"):
+        conn.execute(f"CREATE TABLE {t}(id INTEGER PRIMARY KEY, name TEXT)")
+    tables = Tables(conn)
+    comp = parse_reactive("SELECT * FROM a UNION ALL SELECT * FROM b", tables)
+    assert isinstance(comp, UnionAll)


### PR DESCRIPTION
## Summary
- add `parse_reactive` function to build reactive query objects from SQL
- export `parse_reactive` in package init
- test parsing of select, where, count and union all

## Testing
- `pytest`