### PR TITLE
Add sqlglot dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ requires-python = ">=3.7"
 dependencies = [
     "uvicorn",
     "watchfiles",
+    "sqlglot",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add `sqlglot` to runtime dependencies

## Testing
- `pip install wheels_deps/*`
- `pytest -q`