### PR TITLE
Add SQL equivalence checks in reactive SQL tests

### DIFF
--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -15,29 +15,44 @@ from pageql.reactive_sql import parse_reactive
 def _db():
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    # Populate with a bit of data so that result comparisons are meaningful
+    conn.executemany("INSERT INTO items(name) VALUES (?)", [("x",), ("y",)])
     return conn
+
+
+def assert_sql_equivalent(conn, original_sql, built_sql):
+    """Execute *original_sql* and *built_sql* and ensure the results match."""
+    res_original = list(conn.execute(original_sql).fetchall())
+    res_built = list(conn.execute(built_sql).fetchall())
+    assert res_original == res_built
 
 
 def test_parse_select_basic():
     conn = _db()
     tables = Tables(conn)
-    comp = parse_reactive("SELECT * FROM items", tables)
+    sql = "SELECT * FROM items"
+    comp = parse_reactive(sql, tables)
     assert isinstance(comp, ReactiveTable)
+    assert_sql_equivalent(conn, sql, comp.sql)
 
 
 def test_parse_select_where():
     conn = _db()
     tables = Tables(conn)
-    comp = parse_reactive("SELECT name FROM items WHERE name='x'", tables)
+    sql = "SELECT name FROM items WHERE name='x'"
+    comp = parse_reactive(sql, tables)
     assert isinstance(comp, Select)
     assert isinstance(comp.parent, Where)
+    assert_sql_equivalent(conn, sql, comp.sql)
 
 
 def test_parse_count():
     conn = _db()
     tables = Tables(conn)
-    comp = parse_reactive("SELECT COUNT(*) FROM items", tables)
+    sql = "SELECT COUNT(*) FROM items"
+    comp = parse_reactive(sql, tables)
     assert isinstance(comp, CountAll)
+    assert_sql_equivalent(conn, sql, comp.sql)
 
 
 def test_parse_union_all():
@@ -45,5 +60,10 @@ def test_parse_union_all():
     for t in ("a", "b"):
         conn.execute(f"CREATE TABLE {t}(id INTEGER PRIMARY KEY, name TEXT)")
     tables = Tables(conn)
-    comp = parse_reactive("SELECT * FROM a UNION ALL SELECT * FROM b", tables)
+    sql = "SELECT * FROM a UNION ALL SELECT * FROM b"
+    # Add sample rows so result comparison is non-trivial
+    conn.execute("INSERT INTO a(name) VALUES ('a1')")
+    conn.execute("INSERT INTO b(name) VALUES ('b1')")
+    comp = parse_reactive(sql, tables)
     assert isinstance(comp, UnionAll)
+    assert_sql_equivalent(conn, sql, comp.sql)


### PR DESCRIPTION
## Summary
- populate `_db` helper with initial rows
- add `assert_sql_equivalent` utility
- verify built SQL yields same results as the original in reactive SQL tests

## Testing
- `pytest -q`