### PR TITLE
Add reactive SELECT support

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -441,5 +441,8 @@ class Tables:
                 raise ValueError(f"Couldn't parse DELETE statement {sql}")
             table = m.group(1)
             self._get(table).delete(sql, params)
+        elif lsql.startswith("select"):
+            from .reactive_sql import parse_reactive
+            return parse_reactive(sql_strip, self)
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")


### PR DESCRIPTION
## Summary
- use `parse_reactive` when a SELECT query is passed to `Tables.executeone`
- test that executing a SELECT query returns a reactive component
- adjust invalid-statement test

## Testing
- `pip install wheels_deps/anyio-4.9.0-py3-none-any.whl wheels_deps/idna-3.10-py3-none-any.whl wheels_deps/iniconfig-2.1.0-py3-none-any.whl wheels_deps/packaging-25.0-py3-none-any.whl wheels_deps/pluggy-1.6.0-py3-none-any.whl wheels_deps/pytest-8.3.5-py3-none-any.whl wheels_deps/sniffio-1.3.1-py3-none-any.whl wheels_deps/sqlglot-26.17.1-py3-none-any.whl wheels_deps/typing_extensions-4.13.2-py3-none-any.whl wheels_deps/watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`
- `pytest -q`