### PR TITLE
Add DOM markers for reactive sections

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -64,7 +64,14 @@ def test_from_reactive_uses_parse(monkeypatch):
     r.load_module("m", "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}")
     result = r.render("/m")
     assert seen == ["SELECT * FROM items"]
-    assert result.body.strip() == "<1>\n<2>"
+    expected = (
+        "<script>window.pageqlMarkers={};</script>"
+        "<!--pageql-start:0--><script>(window.pageqlMarkers||(window.pageqlMarkers={}))[0]="
+        "{s:document.currentScript.previousSibling}</script><1>\n<2>\n"
+        "<!--pageql-end:0--><script>window.pageqlMarkers[0].e="
+        "document.currentScript.previousSibling</script>"
+    )
+    assert result.body == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support comment-based DOM markers for reactive fragments
- introduce `RenderContext` to manage marker IDs and initialization
- wrap `#from` output with comment markers and scripts
- update tests accordingly

## Testing
- `pytest -q`