### PR TITLE
Implement self-removing script tags

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -104,7 +104,7 @@ class RenderContext:
 
     def ensure_init(self, out):
         if not self.initialized:
-            out.append("<script>window.pageqlMarkers={};</script>")
+            out.append("<script>window.pageqlMarkers={};document.currentScript.remove()</script>")
             self.initialized = True
 
     def marker_id(self) -> int:
@@ -543,7 +543,9 @@ class PageQL:
                 if ctx and reactive:
                     ctx.ensure_init(output_buffer)
                     mid = ctx.marker_id()
-                    output_buffer.append(f"<!--pageql-start:{mid}--><script>(window.pageqlMarkers||(window.pageqlMarkers={{}}))[{mid}]={{s:document.currentScript.previousSibling}}</script>")
+                    output_buffer.append(
+                        f"<!--pageql-start:{mid}--><script>(window.pageqlMarkers||(window.pageqlMarkers={{}}))[{mid}]={{s:document.currentScript.previousSibling}};document.currentScript.remove()</script>"
+                    )
 
                 saved_params = params.copy()
                 for row in rows:
@@ -560,7 +562,9 @@ class PageQL:
                 params.update(saved_params)
 
                 if ctx and reactive:
-                    output_buffer.append(f"<!--pageql-end:{mid}--><script>window.pageqlMarkers[{mid}].e=document.currentScript.previousSibling</script>")
+                    output_buffer.append(
+                        f"<!--pageql-end:{mid}--><script>window.pageqlMarkers[{mid}].e=document.currentScript.previousSibling;document.currentScript.remove()</script>"
+                    )
             return reactive
 
     def process_nodes(self, nodes, params, output_buffer, path, includes, http_verb=None, reactive=False, ctx=None):

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -46,6 +46,7 @@ reload_script = """
   socket.onerror = (event) => {
     setTimeout(forceReload, 100)
   };
+  document.currentScript.remove()
 </script>
 """
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -65,11 +65,11 @@ def test_from_reactive_uses_parse(monkeypatch):
     result = r.render("/m")
     assert seen == ["SELECT * FROM items"]
     expected = (
-        "<script>window.pageqlMarkers={};</script>"
+        "<script>window.pageqlMarkers={};document.currentScript.remove()</script>"
         "<!--pageql-start:0--><script>(window.pageqlMarkers||(window.pageqlMarkers={}))[0]="
-        "{s:document.currentScript.previousSibling}</script><1>\n<2>\n"
+        "{s:document.currentScript.previousSibling};document.currentScript.remove()</script><1>\n<2>\n"
         "<!--pageql-end:0--><script>window.pageqlMarkers[0].e="
-        "document.currentScript.previousSibling</script>"
+        "document.currentScript.previousSibling;document.currentScript.remove()</script>"
     )
     assert result.body == expected
 


### PR DESCRIPTION
## Summary
- scripts injected by PageQL now remove themselves from the DOM after execution
- update reload script with self-removal
- adjust render tests for new script behaviour

## Testing
- `pip install wheels_deps/watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl wheels_deps/*py3-none-any.whl`
- `pytest -q`