### PR TITLE
Fix reactive DOM marker script

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -544,7 +544,7 @@ class PageQL:
                     ctx.ensure_init(output_buffer)
                     mid = ctx.marker_id()
                     output_buffer.append(
-                        f"<!--pageql-start:{mid}--><script>(window.pageqlMarkers||(window.pageqlMarkers={{}}))[{mid}]={{s:document.currentScript.previousSibling}};document.currentScript.remove()</script>"
+                        f"<!--pageql-start:{mid}--><script>(window.pageqlMarkers||(window.pageqlMarkers={{}}))[{mid}]=document.currentScript.previousSibling;document.currentScript.remove()</script>"
                     )
 
                 saved_params = params.copy()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -66,8 +66,7 @@ def test_from_reactive_uses_parse(monkeypatch):
     assert seen == ["SELECT * FROM items"]
     expected = (
         "<script>window.pageqlMarkers={};document.currentScript.remove()</script>"
-        "<!--pageql-start:0--><script>(window.pageqlMarkers||(window.pageqlMarkers={}))[0]="
-        "{s:document.currentScript.previousSibling};document.currentScript.remove()</script><1>\n<2>\n"
+        "<!--pageql-start:0--><script>(window.pageqlMarkers||(window.pageqlMarkers={}))[0]=document.currentScript.previousSibling;document.currentScript.remove()</script><1>\n<2>\n"
         "<!--pageql-end:0--><script>window.pageqlMarkers[0].e="
         "document.currentScript.previousSibling;document.currentScript.remove()</script>"
     )


### PR DESCRIPTION
## Summary
- correct JS snippet for assigning DOM markers
- update tests for new marker output

## Testing
- `pip install wheels_deps/watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl wheels_deps/anyio-4.9.0-py3-none-any.whl wheels_deps/idna-3.10-py3-none-any.whl wheels_deps/iniconfig-2.1.0-py3-none-any.whl wheels_deps/packaging-25.0-py3-none-any.whl wheels_deps/pluggy-1.6.0-py3-none-any.whl wheels_deps/pytest-8.3.5-py3-none-any.whl wheels_deps/sniffio-1.3.1-py3-none-any.whl wheels_deps/sqlglot-26.17.1-py3-none-any.whl wheels_deps/typing_extensions-4.13.2-py3-none-any.whl`
- `pytest -q`