### PR TITLE
Fix DerivedSignal rendering and parameter handling

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -44,6 +44,14 @@ def test_set_signal_derived_replace():
     assert sig.value == 2
 
 
+def test_render_derived_signal_value_and_eval():
+    r = PageQL(":memory:")
+    sig = DerivedSignal(lambda: 1, [])
+    r.load_module("m", "{{foo}} {{:foo + :foo}}")
+    result = r.render("/m", {"foo": sig})
+    assert result.body.strip() == "1 2"
+
+
 def test_from_reactive_uses_parse(monkeypatch):
     import pageql.reactive_sql as rsql
 


### PR DESCRIPTION
## Summary
- ensure `db_execute_dot` expands DerivedSignal values
- unwrap DerivedSignals when evaluating expressions
- render DerivedSignal values for simple parameters
- handle DerivedSignal params in `#from` reactive queries
- add regression test

## Testing
- `pip install wheels_deps/anyio-4.9.0-py3-none-any.whl wheels_deps/idna-3.10-py3-none-any.whl wheels_deps/iniconfig-2.1.0-py3-none-any.whl wheels_deps/packaging-25.0-py3-none-any.whl wheels_deps/pluggy-1.6.0-py3-none-any.whl wheels_deps/pytest-8.3.5-py3-none-any.whl wheels_deps/sniffio-1.3.1-py3-none-any.whl wheels_deps/sqlglot-26.17.1-py3-none-any.whl wheels_deps/typing_extensions-4.13.2-py3-none-any.whl wheels_deps/watchfiles-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`
- `pytest -q`