### PR TITLE
Fix reactive set comments test

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -201,6 +201,9 @@ class DependentValue:
         self.value = row[0] if row else None
         self.parent.listeners.append(self.onevent)
 
+    def __str__(self):
+        return str(self.value)
+
     def onevent(self, event):
         oldval = self.value
         if event[0] == 1:

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -1,6 +1,16 @@
 import sqlglot
 from sqlglot import expressions as exp
-from .reactive import Tables, ReactiveTable, Select, Where, Union, UnionAll, CountAll
+from .reactive import (
+    Tables,
+    ReactiveTable,
+    Select,
+    Where,
+    Union,
+    UnionAll,
+    CountAll,
+    DerivedSignal,
+    DependentValue,
+)
 
 
 def _replace_placeholders(expr: exp.Expression, params: dict[str, object] | None) -> None:
@@ -14,6 +24,10 @@ def _replace_placeholders(expr: exp.Expression, params: dict[str, object] | None
         if name not in params:
             continue
         val = params[name]
+        if isinstance(val, DerivedSignal):
+            val = val.value
+        if isinstance(val, DependentValue):
+            val = val.value
         if isinstance(val, (int, float)):
             lit = exp.Literal.number(val)
         else:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -106,12 +106,13 @@ def test_reactive_set_comments():
     r.load_module("m", snippet)
     result = r.render("/m")
     expected = (
-        "\n",
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,n=s.nextSibling;while(n&&n!==e){var nx=n.nextSibling;n.remove();n=nx;}var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script><script>pstart(0)</script>1<script>pend(0)</script>\n",
-        "<script>pstart(1)</script>2<script>pend(1)</script>\n",
-        "<p><script>pstart(2)</script>4<script>pend(2)</script> = 4</p>\n",
-        "<p><script>pstart(3)</script>4<script>pend(3)</script> = c = 4</p>\n",
-        "<script>pset(3,\"5\")</script>\n",
-        "<p><script>pstart(4)</script>5<script>pend(4)</script> = 5</p>\n",
-        "<p><script>pstart(5)</script>5<script>pend(5)</script> = c = 5</p>\n",
+        "\n"
+        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,n=s.nextSibling;while(n&&n!==e){var nx=n.nextSibling;n.remove();n=nx;}var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script><script>pstart(0)</script>1<script>pend(0)</script>\n"
+        "<script>pstart(1)</script>2<script>pend(1)</script>\n"
+        "<p><script>pstart(2)</script>4<script>pend(2)</script> = 4</p>\n"
+        "<p><script>pstart(3)</script>4<script>pend(3)</script> = c = 4</p>\n"
+        "<script>pset(3,\"5\")</script>\n"
+        "<p><script>pstart(4)</script>5<script>pend(4)</script> = 5</p>\n"
+        "<p><script>pstart(5)</script>5<script>pend(5)</script> = c = 5</p>\n"
     )
+    assert result.body == expected


### PR DESCRIPTION
## Summary
- add `__str__` to `DependentValue`
- handle `DerivedSignal` and `DependentValue` placeholders in `parse_reactive`
- correct `test_reactive_set_comments` and re-enable it

## Testing
- `pytest -q`