### PR TITLE
Fix reactive set listener

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -460,7 +460,7 @@ class PageQL:
                         output_buffer.append(f"<script>pstart({mid})</script>")
                         output_buffer.append(value)
                         output_buffer.append(f"<script>pend({mid})</script>")
-                        if signal and signal.deps:
+                        if signal:
                             def listener(v=None, *, sig=signal, mid=mid, out=output_buffer, ctx=ctx):
                                 ctx.ensure_init(out)
                                 out.append(f"<script>pset({mid},{json.dumps(html.escape(str(sig.value)))})</script>")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -111,7 +111,7 @@ def test_reactive_set_comments():
         "<script>pstart(1)</script>2<script>pend(1)</script>\n"
         "<p><script>pstart(2)</script>4<script>pend(2)</script> = 4</p>\n"
         "<p><script>pstart(3)</script>4<script>pend(3)</script> = c = 4</p>\n"
-        "<script>pset(3,\"5\")</script>\n"
+        "<script>pset(0,\"2\")</script><script>pset(3,\"5\")</script>\n"
         "<p><script>pstart(4)</script>5<script>pend(4)</script> = 5</p>\n"
         "<p><script>pstart(5)</script>5<script>pend(5)</script> = c = 5</p>\n"
     )


### PR DESCRIPTION
## Summary
- always attach DOM listeners for reactive params
- update expected output for changed `a` value

## Testing
- `pytest -q`