### PR TITLE
Add ReadOnly wrapper for SQL rows

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -3,11 +3,11 @@ PageQL: A template language for embedding SQL inside HTML directly
 """
 
 # Import the main classes from the PageQL modules
-from .pageql import PageQL, RenderResult
+from .pageql import PageQL, RenderResult, ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
 # Define the version
 __version__ = "0.1.0"
 
 # Make these classes available directly from the package
-__all__ = ["PageQL", "RenderResult", "PageQLApp", "parse_reactive"]
+__all__ = ["PageQL", "RenderResult", "ReadOnly", "PageQLApp", "parse_reactive"]

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -1,0 +1,11 @@
+import pytest
+from pageql.pageql import PageQL
+
+
+def test_from_row_columns_readonly():
+    r = PageQL(":memory:")
+    r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    r.db.execute("INSERT INTO items(name) VALUES ('x')")
+    r.load_module("m", "{{#from items}}{{#set id 2}}{{/from}}")
+    with pytest.raises(ValueError):
+        r.render("/m")


### PR DESCRIPTION
## Summary
- introduce `ReadOnly` class for parameters that shouldn't be modified
- wrap row values returned by `#from` with `ReadOnly`
- prevent `#set` from overwriting read-only params
- handle `ReadOnly` in SQL helpers
- export `ReadOnly` from package
- test the new behaviour

## Testing
- `pip install wheels_deps/*`
- `pytest -q`