### PR TITLE
Avoid markers around readonly values

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -82,8 +82,8 @@ def test_from_reactive_uses_parse(monkeypatch):
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
         "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,n=s.nextSibling;while(n&&n!==e){var nx=n.nextSibling;n.remove();n=nx;}var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script>"
-        f"<script>pstart('0_{h1}')</script><<script>pstart(1)</script>1<script>pend(1)</script>><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><<script>pstart(2)</script>2<script>pend(2)</script>><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
     )
     assert result.body == expected
 


### PR DESCRIPTION
## Summary
- avoid converting ReadOnly params to signals in `evalone`
- skip pstart/pend generation for ReadOnly values
- update expected output in rendering tests

## Testing
- `pytest -q`