### PR TITLE
Add pdelete for reactive deletes

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -22,7 +22,7 @@ def test_reactive_toggle():
     r.load_module("reactive", "{{reactive}} {{#reactive on}}{{reactive}} {{#reactive off}}{{reactive}}")
     result = r.render("/reactive")
     expected = (
-        "False <script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script>"
+        "False <script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}document.currentScript.remove()</script>"
         "<script>pstart(0)</script>True"
         "<script>pend(0)</script> False"
     )
@@ -81,7 +81,7 @@ def test_from_reactive_uses_parse(monkeypatch):
     h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script>"
+        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}document.currentScript.remove()</script>"
         f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
     )
@@ -109,12 +109,30 @@ def test_reactive_set_comments():
     result = r.render("/m")
     expected = (
         "\n"
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}document.currentScript.remove()</script><script>pstart(0)</script>1<script>pend(0)</script>\n"
+        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}document.currentScript.remove()</script><script>pstart(0)</script>1<script>pend(0)</script>\n"
         "<script>pstart(1)</script>2<script>pend(1)</script>\n"
         "<p><script>pstart(2)</script>4<script>pend(2)</script> = 4</p>\n"
         "<p><script>pstart(3)</script>4<script>pend(3)</script> = c = 4</p>\n"
         "<script>pset(0,\"2\")</script><script>pset(3,\"5\")</script>\n"
         "<p><script>pstart(4)</script>5<script>pend(4)</script> = 5</p>\n"
         "<p><script>pstart(5)</script>5<script>pend(5)</script> = c = 5</p>\n"
+    )
+    assert result.body == expected
+
+
+def test_from_reactive_delete_event():
+    r = PageQL(":memory:")
+    r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
+    r.load_module("m", "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}{{#delete from items where id=1}}")
+    result = r.render("/m")
+    import hashlib
+    h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
+    h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
+    expected = (
+        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}document.currentScript.remove()</script>"
+        f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pdelete('0_{h1}')</script>"
     )
     assert result.body == expected


### PR DESCRIPTION
## Summary
- extend page initialization script with `pdelete`
- emit `pdelete` when a row is removed in reactive `#from`
- route data-modifying directives through reactive table when reactive mode is enabled
- test deletion event output

## Testing
- `pytest -q`