### PR TITLE
Move marker init code to reload script

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -108,15 +108,6 @@ class RenderContext:
 
     def ensure_init(self, out):
         if not self.initialized:
-            out.append(
-                "<script>window.pageqlMarkers={};"
-                "function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}"
-                "function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}"
-                "function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}"
-                "function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}"
-                "function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}"
-                "document.currentScript.remove()</script>"
-            )
             self.initialized = True
 
     def marker_id(self) -> int:

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -12,19 +12,27 @@ from .pageql import PageQL
 # Global PageQL engine instance (simpler for this example)
 reload_script = """
 <script>
-    const host = window.location.hostname; // e.g., "localhost"
-    const port = window.location.port;     // e.g., "3000" or "8080"
-    const clientId = Math.random().toString(36).substring(2);
-    const ws_url = `ws://${host}:${port}/reload-request-ws?clientId=${clientId}`;
+  window.pageqlMarkers={};
+  function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}
+  function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}
+  function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}
+  function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}
+  function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}
+  document.currentScript.remove()
+</script>
+<script>
+  const host = window.location.hostname;
+  const port = window.location.port;
+  const clientId = Math.random().toString(36).substring(2);
+  const ws_url = `ws://${host}:${port}/reload-request-ws?clientId=${clientId}`;
 
   function forceReload() {
-    console.log("forceReload")
     const socket = new WebSocket(ws_url);
     socket.onopen = () => {
       window.location.reload();
     };
     socket.onerror = () => {
-      setTimeout(forceReload, 100)
+      setTimeout(forceReload, 100);
     };
   }
 
@@ -34,18 +42,17 @@ reload_script = """
   };
 
   socket.onmessage = (event) => {
-    console.log("Server says:", event.data);
     if (event.data == "reload") {
       window.location.reload();
     }
   };
 
   socket.onclose = () => {
-    setTimeout(forceReload, 100)
+    setTimeout(forceReload, 100);
   };
 
-  socket.onerror = (event) => {
-    setTimeout(forceReload, 100)
+  socket.onerror = () => {
+    setTimeout(forceReload, 100);
   };
   document.currentScript.remove()
 </script>

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -22,7 +22,7 @@ def test_reactive_toggle():
     r.load_module("reactive", "{{reactive}} {{#reactive on}}{{reactive}} {{#reactive off}}{{reactive}}")
     result = r.render("/reactive")
     expected = (
-        "False <script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}document.currentScript.remove()</script>"
+        "False "
         "<script>pstart(0)</script>True"
         "<script>pend(0)</script> False"
     )
@@ -44,7 +44,7 @@ def test_reactive_count_with_param_dependency():
     r.load_module("m", snippet)
     result = r.render("/m")
     expected = (
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}document.currentScript.remove()</script>"
+        ""
         "<script>pstart(0)</script>2<script>pend(0)</script>"
     )
     assert result.body == expected
@@ -102,7 +102,7 @@ def test_from_reactive_uses_parse(monkeypatch):
     h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}document.currentScript.remove()</script>"
+        ""
         f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
     )
@@ -130,7 +130,7 @@ def test_reactive_set_comments():
     result = r.render("/m")
     expected = (
         "\n"
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}document.currentScript.remove()</script><script>pstart(0)</script>1<script>pend(0)</script>\n"
+        "<script>pstart(0)</script>1<script>pend(0)</script>\n"
         "<script>pstart(1)</script>2<script>pend(1)</script>\n"
         "<p><script>pstart(2)</script>4<script>pend(2)</script> = 4</p>\n"
         "<p><script>pstart(3)</script>4<script>pend(3)</script> = c = 4</p>\n"
@@ -151,7 +151,7 @@ def test_from_reactive_delete_event():
     h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
-        "<script>window.pageqlMarkers={};function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;}function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;}function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];}function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);}document.currentScript.remove()</script>"
+        ""
         f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
         f"<script>pdelete('0_{h1}')</script>"


### PR DESCRIPTION
## Summary
- include pageql marker functions inside `reload_script`
- stop emitting the init script during rendering
- update tests for new output

## Testing
- `pytest -q`