### PR TITLE
Add block markers for reactive #from

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -657,6 +657,7 @@ class PageQL:
                 if ctx and reactive:
                     ctx.ensure_init()
                     mid = ctx.marker_id()
+                    ctx.append_script(f"pstart({mid})")
                 saved_params = params.copy()
                 for row in rows:
                     row_params = params.copy()
@@ -677,6 +678,7 @@ class PageQL:
                     ctx.out.append('\n')
 
                 if ctx and reactive:
+                    ctx.append_script(f"pend({mid})")
                     def on_event(ev, *, mid=mid, ctx=ctx,
                                    body=body, col_names=col_names, path=path,
                                    includes=includes, http_verb=http_verb,

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -105,8 +105,10 @@ def test_from_reactive_uses_parse(monkeypatch):
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
         ""
+        f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pend(0)</script>"
     )
     assert result.body == expected
 
@@ -154,8 +156,10 @@ def test_from_reactive_delete_event():
     h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
     expected = (
         ""
+        f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pend(0)</script>"
         f"<script>pdelete('0_{h1}')</script>"
     )
     assert result.body == expected
@@ -176,8 +180,10 @@ def test_from_reactive_update_event():
     h1_new = base64.b64encode(hashlib.sha256(repr((1, "c",)).encode()).digest())[:8]
     h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8]
     expected = (
+        f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1_old}')</script><a><script>pend('0_{h1_old}')</script>\n"
         f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pend(0)</script>"
         f"<script>pupdate('0_{h1_old}','0_{h1_new}',\"<c>\")</script>"
     )
     assert result.body == expected
@@ -197,8 +203,10 @@ def test_from_reactive_insert_event():
     h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8]
     h3 = base64.b64encode(hashlib.sha256(repr((3, "c",)).encode()).digest())[:8]
     expected = (
+        f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1}')</script><a><script>pend('0_{h1}')</script>\n"
         f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pend(0)</script>"
         f"<script>pinsert('0_{h3}',\"<c>\")</script>"
     )
     assert result.body == expected


### PR DESCRIPTION
## Summary
- wrap reactive `#from` output with `pstart`/`pend` markers
- update tests to expect these markers

## Testing
- `pytest -q`