### PR TITLE
Add script collection after rendering

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -107,6 +107,8 @@ class RenderContext:
         self.initialized = False
         self.listeners = []
         self.out = []
+        self.scripts: list[str] = []
+        self.rendering = True
 
     def ensure_init(self):
         if not self.initialized:
@@ -133,7 +135,10 @@ class RenderContext:
     def append_script(self, content, out=None):
         if out is None:
             out = self.out
-        out.append(f"<script>{content}</script>")
+        if self.rendering:
+            out.append(f"<script>{content}</script>")
+        else:
+            self.scripts.append(content)
 
 
 class ReadOnly:
@@ -1000,6 +1005,7 @@ class PageQL:
 
                 # Process the output to match the expected format in tests
                 result.body = result.body.replace('\n\n', '\n')  # Normalize extra newlines
+                ctx.rendering = False
             else:
                 result.status_code = 404
                 result.body = f"Module {original_module_name} not found"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -17,6 +17,18 @@ def test_render_nonexistent_returns_404():
     assert result.status_code == 404
 
 
+def test_rendercontext_stops_rendering_and_collects_scripts():
+    r = PageQL(":memory:")
+    r.load_module("m", "hello")
+    result = r.render("/m")
+    ctx = result.context
+    assert ctx.rendering is False
+    assert ctx.scripts == []
+    ctx.append_script("foo")
+    assert ctx.scripts == ["foo"]
+    assert ctx.out == []
+
+
 def test_reactive_toggle():
     r = PageQL(":memory:")
     r.load_module("reactive", "{{reactive}} {{#reactive on}}{{reactive}} {{#reactive off}}{{reactive}}")


### PR DESCRIPTION
## Summary
- track script messages in `RenderContext`
- mark context as done rendering before returning
- test script list stays empty while rendering

## Testing
- `pytest`
