### PR TITLE
Update evalone reactive output

### DIFF
--- a/tests/test_evalone.py
+++ b/tests/test_evalone.py
@@ -11,7 +11,7 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 import pytest
 
 from pageql.pageql import evalone
-from pageql.reactive import DerivedSignal, Tables
+from pageql.reactive import DerivedSignal, DependentValue, Tables
 
 
 def _db():
@@ -60,12 +60,12 @@ def test_evalone_reactive_sql_updates():
     conn.execute("INSERT INTO items(name) VALUES ('a')")
     tables = Tables(conn)
     sig = evalone(conn, "name from items where id=1", {}, reactive=True, tables=tables)
-    assert isinstance(sig, DerivedSignal)
-    assert sig.value.value == "a"
+    assert isinstance(sig, DependentValue)
+    assert sig.value == "a"
 
     rt = tables._get("items")
     rt.update("UPDATE items SET name='b' WHERE id=1", {})
-    assert sig.value.value == "b"
+    assert sig.value == "b"
 
 
 def test_evalone_reactive_param_and_table_updates():
@@ -80,13 +80,13 @@ def test_evalone_reactive_param_and_table_updates():
         reactive=True,
         tables=tables,
     )
-    assert isinstance(sig, DerivedSignal)
-    assert sig.value.value == "a"
+    assert isinstance(sig, DependentValue)
+    assert sig.value == "a"
 
     params["rid"].set_value(2)
-    assert sig.value.value == "b"
+    assert sig.value == "b"
 
     rt = tables._get("items")
     rt.update("UPDATE items SET name='c' WHERE id=2", {})
-    assert sig.value.value == "c"
+    assert sig.value == "c"
 


### PR DESCRIPTION
## Summary
- return `DependentValue` from `evalone` when evaluating reactive SQL
- reset the dependent value when dependencies change
- treat all `Signal` types when rendering reactive expressions
- update tests for new behaviour

## Testing
- `pip install wheels_deps/*`
- `pytest -q`