### PR TITLE
Track websocket connections in render context

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -109,6 +109,8 @@ class RenderContext:
         self.out = []
         self.scripts: list[str] = []
         self.rendering = True
+        self.websocket = None
+        self.websocket_connected = False
 
     def ensure_init(self):
         if not self.initialized:


### PR DESCRIPTION
## Summary
- add websocket and connection state to `RenderContext`
- record websocket instances in `PageQLApp`
- mark render context as connected when websocket connects and disconnects
- inject websocket info into contexts during HTTP handling

## Testing
- `python -m pip install wheels_deps/*`
- `pytest -q`