### PR TITLE
Fix reactive #set evaluation

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -534,6 +534,8 @@ class PageQL:
                             deps.append(dep)
 
                     def compute(args=args, params=params):
+                        if re.search(r"\bfrom\b", args, re.I):
+                            return evalone(self.db, args, params, True, self.tables)
                         return evalone(self.db, args, params, False, self.tables)
 
                     existing = params.get(var)


### PR DESCRIPTION
## Summary
- only enable reactive SQL evaluation in `#set` when the expression selects from a table
- update compute lambda to check for SQL `FROM`

## Testing
- `pip install wheels_deps/*`
- `pytest -q`