### PR TITLE
Add send_script to RenderContext

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -108,6 +108,7 @@ class RenderContext:
         self.listeners = []
         self.out = []
         self.scripts: list[str] = []
+        self.send_script = None
         self.rendering = True
         self.websocket = None
         self.websocket_connected = False
@@ -140,7 +141,10 @@ class RenderContext:
         if self.rendering:
             out.append(f"<script>{content}</script>")
         else:
-            self.scripts.append(content)
+            if self.send_script is not None:
+                self.send_script(content)
+            else:
+                self.scripts.append(content)
 
 
 class ReadOnly:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,7 +7,7 @@ import types
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-from pageql.pageql import PageQL
+from pageql.pageql import PageQL, RenderContext
 from pageql.reactive import DerivedSignal
 
 
@@ -27,6 +27,16 @@ def test_rendercontext_stops_rendering_and_collects_scripts():
     ctx.append_script("foo")
     assert ctx.scripts == ["foo"]
     assert ctx.out == []
+
+
+def test_append_script_send_script():
+    ctx = RenderContext()
+    ctx.rendering = False
+    sent = []
+    ctx.send_script = sent.append
+    ctx.append_script("bar")
+    assert sent == ["bar"]
+    assert ctx.scripts == []
 
 
 def test_reactive_toggle():


### PR DESCRIPTION
## Summary
- enable sending scripts in real time
- test that RenderContext respects `send_script`

## Testing
- `pytest -q`