### PR TITLE
Add reactive count insert test

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -9,6 +9,8 @@ import http.client
 from multiprocessing import Process
 from uvicorn.config import Config
 from uvicorn.server import Server
+import threading
+import multiprocessing
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
@@ -29,6 +31,24 @@ def _serve(port, tmpdir, reload=False):
     app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=reload)
     config = Config(app, host="127.0.0.1", port=port, log_level="warning")
     Server(config).run()
+
+
+def _serve_with_queue(port, tmpdir, q):
+    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+    config = Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = Server(config)
+    t = threading.Thread(target=server.run, daemon=True)
+    t.start()
+    while True:
+        cmd = q.get()
+        if cmd == "stop":
+            server.should_exit = True
+            t.join()
+            break
+        elif isinstance(cmd, tuple) and cmd[0] == "execute":
+            sql, params = cmd[1], cmd[2]
+            app.pageql_engine.tables.executeone(sql, params)
+            q.put("done")
 
 
 def test_hello_world_in_browser():
@@ -233,6 +253,68 @@ def test_reactive_count_insert_in_browser():
             browser.close()
 
         proc.terminate()
+        proc.join()
+
+        assert body_text == "1"
+
+
+def test_reactive_count_insert_via_execute():
+    """Count updates should propagate when inserting after initial load."""
+    pytest.importorskip("playwright.sync_api")
+    import importlib.util
+    if (
+        importlib.util.find_spec("websockets") is None
+        and importlib.util.find_spec("wsproto") is None
+    ):
+        pytest.skip("WebSocket library not available for reactive test")
+    from playwright.sync_api import sync_playwright
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        template_path = Path(tmpdir) / "count_after.pageql"
+        template_path.write_text(
+            "{{#create table nums(value INTEGER)}}"
+            "{{#reactive on}}"
+            "{{#set a count(*) from nums}}"
+            "{{a}}",
+            encoding="utf-8",
+        )
+
+        port = _get_free_port()
+        q = multiprocessing.Queue()
+        proc = Process(target=_serve_with_queue, args=(port, tmpdir, q))
+        proc.start()
+
+        start = time.time()
+        while True:
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port)
+                conn.connect()
+                conn.close()
+                break
+            except OSError:
+                if time.time() - start > 5:
+                    q.put("stop")
+                    proc.join()
+                    raise RuntimeError("Server did not start")
+                time.sleep(0.05)
+
+        with sync_playwright() as p:
+            chromium_path = p.chromium.executable_path
+            if not Path(chromium_path).exists():
+                q.put("stop")
+                proc.join()
+                pytest.skip("Chromium not available for Playwright")
+            browser = p.chromium.launch(args=["--no-sandbox"])
+            page = browser.new_page()
+            page.goto(f"http://127.0.0.1:{port}/count_after")
+            page.wait_for_timeout(100)
+            q.put(("execute", "INSERT INTO nums(value) VALUES (1)", {}))
+            q.get()
+            page.wait_for_timeout(500)
+            body_text = page.evaluate("document.body.textContent")
+            browser.close()
+
+        q.put("stop")
         proc.join()
 
         assert body_text == "1"


### PR DESCRIPTION
## Summary
- add threaded queue helper to allow executing SQL commands during browser tests
- integrate a new playwright test that uses PageQL `tables.executeone` to update the page

## Testing
- `pip install wheels_deps/*`
- `pytest -q`