### PR TITLE
Enable doctest for render docstring test

### DIFF
--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -1,11 +1,12 @@
 import sys
 from pathlib import Path
 import types
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-"""
+__doc__ = """
 >>> from pageql.pageql import PageQL
 >>> r = PageQL(":memory:")
 >>> r.load_module("include_test", '''This is included


### PR DESCRIPTION
## Summary
- ensure `tests/test_render_docstring.py` is discovered by doctest

## Testing
- `pytest -q tests/test_render_docstring.py`
- `pytest -q` *(fails: KeyboardInterrupt after all tests passed)*