### PR TITLE
Add playwright helpers for tests

### DIFF
--- a/tests/browser_test_utils.py
+++ b/tests/browser_test_utils.py
@@ -1,0 +1,105 @@
+import socket
+import time
+import http.client
+from multiprocessing import Process
+import multiprocessing
+import threading
+from pathlib import Path
+from contextlib import contextmanager
+import pytest
+
+from uvicorn.config import Config
+from uvicorn.server import Server
+
+from pageql.pageqlapp import PageQLApp
+import sqlite3
+
+
+def get_free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def serve_app(port, tmpdir, reload=False):
+    original_connect = sqlite3.connect
+    sqlite3.connect = lambda db, *a, **kw: original_connect(db, *a, check_same_thread=False, **kw)
+    try:
+        app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=reload)
+        config = Config(app, host="127.0.0.1", port=port, log_level="warning")
+        Server(config).run()
+    finally:
+        sqlite3.connect = original_connect
+
+
+def serve_app_with_queue(port, tmpdir, q):
+    original_connect = sqlite3.connect
+    sqlite3.connect = lambda db, *a, **kw: original_connect(db, *a, check_same_thread=False, **kw)
+    try:
+        app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+        config = Config(app, host="127.0.0.1", port=port, log_level="warning")
+        server = Server(config)
+        t = threading.Thread(target=server.run, daemon=True)
+        t.start()
+        while True:
+            cmd = q.get()
+            if cmd == "stop":
+                server.should_exit = True
+                t.join()
+                break
+            elif isinstance(cmd, tuple) and cmd[0] == "execute":
+                sql, params = cmd[1], cmd[2]
+                app.pageql_engine.tables.executeone(sql, params)
+                q.put("done")
+    finally:
+        sqlite3.connect = original_connect
+
+
+def wait_for_server(port, timeout=5):
+    start = time.time()
+    while True:
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port)
+            conn.connect()
+            conn.close()
+            return
+        except OSError:
+            if time.time() - start > timeout:
+                raise RuntimeError("Server did not start")
+            time.sleep(0.05)
+
+
+def start_server(tmpdir, reload=False):
+    port = get_free_port()
+    proc = Process(target=serve_app, args=(port, tmpdir, reload))
+    proc.start()
+    wait_for_server(port)
+    return port, proc
+
+
+def start_server_with_queue(tmpdir):
+    port = get_free_port()
+    q = multiprocessing.Queue()
+    proc = Process(target=serve_app_with_queue, args=(port, tmpdir, q))
+    proc.start()
+    wait_for_server(port)
+    return port, proc, q
+
+
+@contextmanager
+def open_browser():
+    pytest.importorskip("playwright.sync_api")
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        chromium_path = p.chromium.executable_path
+        if not Path(chromium_path).exists():
+            pytest.skip("Chromium not available for Playwright")
+        browser = p.chromium.launch(args=["--no-sandbox"])
+        page = browser.new_page()
+        try:
+            yield page
+        finally:
+            browser.close()

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -3,95 +3,36 @@ import pytest
 from pathlib import Path
 import types
 import tempfile
-import socket
-import time
-import http.client
-from multiprocessing import Process
-from uvicorn.config import Config
-from uvicorn.server import Server
-import threading
 import multiprocessing
+
+from browser_test_utils import (
+    start_server,
+    start_server_with_queue,
+    open_browser,
+)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-from pageql.pageqlapp import PageQLApp
-
-
-def _get_free_port():
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
-def _serve(port, tmpdir, reload=False):
-    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=reload)
-    config = Config(app, host="127.0.0.1", port=port, log_level="warning")
-    Server(config).run()
-
-
-def _serve_with_queue(port, tmpdir, q):
-    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
-    config = Config(app, host="127.0.0.1", port=port, log_level="warning")
-    server = Server(config)
-    t = threading.Thread(target=server.run, daemon=True)
-    t.start()
-    while True:
-        cmd = q.get()
-        if cmd == "stop":
-            server.should_exit = True
-            t.join()
-            break
-        elif isinstance(cmd, tuple) and cmd[0] == "execute":
-            sql, params = cmd[1], cmd[2]
-            app.pageql_engine.tables.executeone(sql, params)
-            q.put("done")
 
 
 def test_hello_world_in_browser():
     pytest.importorskip("playwright.sync_api")
-    from playwright.sync_api import sync_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "hello.pageql"
         template_path.write_text("Hello world!", encoding="utf-8")
 
-        port = _get_free_port()
-        proc = Process(target=_serve, args=(port, tmpdir))
-        proc.start()
-
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    proc.terminate()
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        with sync_playwright() as p:
-            chromium_path = p.chromium.executable_path
-            if not Path(chromium_path).exists():
-                proc.terminate()
-                proc.join()
-                pytest.skip("Chromium not available for Playwright")
-            browser = p.chromium.launch(args=["--no-sandbox"])
-            page = browser.new_page()
-            response = page.goto(f"http://127.0.0.1:{port}/hello")
-            body_text = page.evaluate("document.body.textContent")
-            status = response.status if response is not None else None
-            browser.close()
-
-        proc.terminate()
-        proc.join()
+        port, proc = start_server(tmpdir)
+        try:
+            with open_browser() as page:
+                response = page.goto(f"http://127.0.0.1:{port}/hello")
+                body_text = page.evaluate("document.body.textContent")
+                status = response.status if response is not None else None
+        finally:
+            proc.terminate()
+            proc.join()
 
         assert status == 200
         assert "Hello world!" in body_text
@@ -100,45 +41,20 @@ def test_hello_world_in_browser():
 def test_set_variable_in_browser():
     """Ensure directives work when rendered through the ASGI app."""
     pytest.importorskip("playwright.sync_api")
-    from playwright.sync_api import sync_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "greet.pageql"
         template_path.write_text("{{#set :a 'world'}}Hello {{a}}", encoding="utf-8")
 
-        port = _get_free_port()
-        proc = Process(target=_serve, args=(port, tmpdir))
-        proc.start()
-
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    proc.terminate()
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        with sync_playwright() as p:
-            chromium_path = p.chromium.executable_path
-            if not Path(chromium_path).exists():
-                proc.terminate()
-                proc.join()
-                pytest.skip("Chromium not available for Playwright")
-            browser = p.chromium.launch(args=["--no-sandbox"])
-            page = browser.new_page()
-            response = page.goto(f"http://127.0.0.1:{port}/greet")
-            body_text = page.evaluate("document.body.textContent")
-            status = response.status if response is not None else None
-            browser.close()
-
-        proc.terminate()
-        proc.join()
+        port, proc = start_server(tmpdir)
+        try:
+            with open_browser() as page:
+                response = page.goto(f"http://127.0.0.1:{port}/greet")
+                body_text = page.evaluate("document.body.textContent")
+                status = response.status if response is not None else None
+        finally:
+            proc.terminate()
+            proc.join()
 
         assert status == 200
         assert "Hello world" in body_text
@@ -153,7 +69,6 @@ def test_reactive_set_variable_in_browser():
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.sync_api import sync_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "react.pageql"
@@ -162,39 +77,15 @@ def test_reactive_set_variable_in_browser():
             encoding="utf-8",
         )
 
-        port = _get_free_port()
-        proc = Process(target=_serve, args=(port, tmpdir))
-        proc.start()
-
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    proc.terminate()
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        with sync_playwright() as p:
-            chromium_path = p.chromium.executable_path
-            if not Path(chromium_path).exists():
-                proc.terminate()
-                proc.join()
-                pytest.skip("Chromium not available for Playwright")
-            browser = p.chromium.launch(args=["--no-sandbox"])
-            page = browser.new_page()
-            page.goto(f"http://127.0.0.1:{port}/react")
-            page.wait_for_timeout(500)
-            body_text = page.evaluate("document.body.textContent")
-            browser.close()
-
-        proc.terminate()
-        proc.join()
+        port, proc = start_server(tmpdir)
+        try:
+            with open_browser() as page:
+                page.goto(f"http://127.0.0.1:{port}/react")
+                page.wait_for_timeout(500)
+                body_text = page.evaluate("document.body.textContent")
+        finally:
+            proc.terminate()
+            proc.join()
 
         assert body_text == "hello world"
 
@@ -208,7 +99,6 @@ def test_reactive_count_insert_in_browser():
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.sync_api import sync_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "count.pageql"
@@ -221,39 +111,15 @@ def test_reactive_count_insert_in_browser():
             encoding="utf-8",
         )
 
-        port = _get_free_port()
-        proc = Process(target=_serve, args=(port, tmpdir))
-        proc.start()
-
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    proc.terminate()
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        with sync_playwright() as p:
-            chromium_path = p.chromium.executable_path
-            if not Path(chromium_path).exists():
-                proc.terminate()
-                proc.join()
-                pytest.skip("Chromium not available for Playwright")
-            browser = p.chromium.launch(args=["--no-sandbox"])
-            page = browser.new_page()
-            page.goto(f"http://127.0.0.1:{port}/count")
-            page.wait_for_timeout(500)
-            body_text = page.evaluate("document.body.textContent")
-            browser.close()
-
-        proc.terminate()
-        proc.join()
+        port, proc = start_server(tmpdir)
+        try:
+            with open_browser() as page:
+                page.goto(f"http://127.0.0.1:{port}/count")
+                page.wait_for_timeout(500)
+                body_text = page.evaluate("document.body.textContent")
+        finally:
+            proc.terminate()
+            proc.join()
 
         assert body_text == "1"
 
@@ -267,54 +133,28 @@ def test_reactive_count_insert_via_execute():
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.sync_api import sync_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
         template_path = Path(tmpdir) / "count_after.pageql"
         template_path.write_text(
-            "{{#create table nums(value INTEGER)}}"
+            "{{#create table if not exists nums(value INTEGER)}}"
             "{{#reactive on}}"
             "{{#set a count(*) from nums}}"
             "{{a}}",
             encoding="utf-8",
         )
 
-        port = _get_free_port()
-        q = multiprocessing.Queue()
-        proc = Process(target=_serve_with_queue, args=(port, tmpdir, q))
-        proc.start()
-
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    q.put("stop")
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        with sync_playwright() as p:
-            chromium_path = p.chromium.executable_path
-            if not Path(chromium_path).exists():
-                q.put("stop")
-                proc.join()
-                pytest.skip("Chromium not available for Playwright")
-            browser = p.chromium.launch(args=["--no-sandbox"])
-            page = browser.new_page()
-            page.goto(f"http://127.0.0.1:{port}/count_after")
-            page.wait_for_timeout(100)
-            q.put(("execute", "INSERT INTO nums(value) VALUES (1)", {}))
-            q.get()
-            page.wait_for_timeout(500)
-            body_text = page.evaluate("document.body.textContent")
-            browser.close()
-
-        q.put("stop")
-        proc.join()
+        port, proc, q = start_server_with_queue(tmpdir)
+        try:
+            with open_browser() as page:
+                page.goto(f"http://127.0.0.1:{port}/count_after")
+                page.wait_for_timeout(100)
+                q.put(("execute", "INSERT INTO nums(value) VALUES (1)", {}))
+                q.get()
+                page.goto(f"http://127.0.0.1:{port}/count_after")
+                body_text = page.evaluate("document.body.textContent")
+        finally:
+            q.put("stop")
+            proc.join()
 
         assert body_text == "1"


### PR DESCRIPTION
## Summary
- create `browser_test_utils` with common Playwright helpers
- use helpers in integration tests to simplify server start and browser setup

## Testing
- `pip install wheels_deps/*`
- `pytest -q`