### PR TITLE
Update integration tests to run async server with Playwright

### DIFF
--- a/tests/playwright_helpers.py
+++ b/tests/playwright_helpers.py
@@ -4,6 +4,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Tuple, Optional
+import asyncio
 
 from uvicorn.config import Config
 from uvicorn.server import Server
@@ -59,3 +60,43 @@ def run_server_in_thread(tmpdir: str, reload: bool = False) -> Tuple[Server, thr
 
 def chromium_available(playwright) -> bool:
     return Path(playwright.chromium.executable_path).exists()
+
+
+async def wait_for_server_async(
+    port: int,
+    server: Optional[Server] = None,
+    task: Optional["asyncio.Task"] = None,
+    timeout: float = 5.0,
+) -> None:
+    start = time.time()
+    while True:
+        try:
+            conn = http.client.HTTPConnection("127.0.0.1", port)
+            conn.connect()
+            conn.close()
+            break
+        except OSError:
+            if time.time() - start > timeout:
+                if server is not None:
+                    server.should_exit = True
+                if task is not None:
+                    await task
+                raise RuntimeError("Server did not start")
+            await asyncio.sleep(0.05)
+
+
+async def run_server_in_task(
+    tmpdir: str, reload: bool = False
+) -> Tuple[Server, "asyncio.Task", int]:
+    port = get_free_port()
+    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=reload)
+    config = Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = Server(config)
+    task = asyncio.create_task(server.serve())
+    try:
+        await wait_for_server_async(port, server, task)
+    except Exception:
+        server.should_exit = True
+        await task
+        raise
+    return server, task, port


### PR DESCRIPTION
## Summary
- add async helpers for integration tests
- run async PageQL server and Playwright API in the same thread

## Testing
- `pip install wheels_deps/*`
- `pytest -q`