### PR TITLE
Remove sync helpers from tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,12 +2,7 @@ import sys
 from pathlib import Path
 import types
 import tempfile
-import socket
-import time
 import http.client
-from multiprocessing import Process
-from uvicorn.config import Config
-from uvicorn.server import Server
 import asyncio
 
 # Ensure the package can be imported without optional dependencies
@@ -15,56 +10,25 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-from pageql.pageqlapp import PageQLApp
-
-
-def _get_free_port():
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
-def _serve(port, tmpdir):
-    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
-    config = Config(app, host="127.0.0.1", port=port, log_level="warning")
-    Server(config).run()
+from playwright_helpers import run_server_in_task
 
 
 def test_app_returns_404_for_missing_route():
     with tempfile.TemporaryDirectory() as tmpdir:
-        app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            conn = http.client.HTTPConnection("127.0.0.1", port)
+            conn.request("GET", "/missing")
+            resp = conn.getresponse()
+            status_inner = resp.status
+            resp.read()
+            conn.close()
 
-        port = _get_free_port()
+            server.should_exit = True
+            await task
+            return status_inner
 
-        proc = Process(target=_serve, args=(port, tmpdir))
-        proc.start()
-
-        # Wait for the server to accept connections
-        start = time.time()
-        while True:
-            try:
-                conn = http.client.HTTPConnection("127.0.0.1", port)
-                conn.connect()
-                conn.close()
-                break
-            except OSError:
-                if time.time() - start > 5:
-                    proc.terminate()
-                    proc.join()
-                    raise RuntimeError("Server did not start")
-                time.sleep(0.05)
-
-        conn = http.client.HTTPConnection("127.0.0.1", port)
-        conn.request("GET", "/missing")
-        resp = conn.getresponse()
-        status = resp.status
-        resp.read()
-        conn.close()
-
-        proc.terminate()
-        proc.join()
+        status = asyncio.run(run_test())
 
         assert status == 404
 


### PR DESCRIPTION
## Summary
- drop unused sync server helpers
- refactor integration test to use async helper

## Testing
- `pip install wheels_deps/*`
- `pytest -q`