### PR TITLE
Simplify browser integration tests

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -1,55 +1,27 @@
 import sys
-import pytest
-from pathlib import Path
-import types
+import importlib.util
 import tempfile
-import http.client
-import time
-from uvicorn.config import Config
-from uvicorn.server import Server
-import asyncio
+import types
+from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageqlapp import PageQLApp
-from playwright_helpers import (
-    chromium_available,
-    get_free_port,
-    run_server_in_task,
-)
+from playwright_helpers import load_page
 
 
 
 
 def test_hello_world_in_browser():
     pytest.importorskip("playwright.async_api")
-    from playwright.async_api import async_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_path = Path(tmpdir) / "hello.pageql"
-        template_path.write_text("Hello world!", encoding="utf-8")
+        Path(tmpdir, "hello.pageql").write_text("Hello world!", encoding="utf-8")
 
-        async def run_test():
-            server, task, port = await run_server_in_task(tmpdir)
-            async with async_playwright() as p:
-                if not chromium_available(p):
-                    server.should_exit = True
-                    await task
-                    return None
-                browser = await p.chromium.launch(args=["--no-sandbox"])
-                page = await browser.new_page()
-                response = await page.goto(f"http://127.0.0.1:{port}/hello")
-                body_text_inner = await page.evaluate("document.body.textContent")
-                status_inner = response.status if response is not None else None
-                await browser.close()
-
-            server.should_exit = True
-            await task
-            return status_inner, body_text_inner
-
-        result = asyncio.run(run_test())
+        result = load_page(tmpdir, "hello")
         if result is None:
             pytest.skip("Chromium not available for Playwright")
         status, body_text = result
@@ -61,31 +33,11 @@ def test_hello_world_in_browser():
 def test_set_variable_in_browser():
     """Ensure directives work when rendered through the ASGI app."""
     pytest.importorskip("playwright.async_api")
-    from playwright.async_api import async_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_path = Path(tmpdir) / "greet.pageql"
-        template_path.write_text("{{#set :a 'world'}}Hello {{a}}", encoding="utf-8")
+        Path(tmpdir, "greet.pageql").write_text("{{#set :a 'world'}}Hello {{a}}", encoding="utf-8")
 
-        async def run_test():
-            server, task, port = await run_server_in_task(tmpdir)
-            async with async_playwright() as p:
-                if not chromium_available(p):
-                    server.should_exit = True
-                    await task
-                    return None
-                browser = await p.chromium.launch(args=["--no-sandbox"])
-                page = await browser.new_page()
-                response = await page.goto(f"http://127.0.0.1:{port}/greet")
-                body_text_inner = await page.evaluate("document.body.textContent")
-                status_inner = response.status if response is not None else None
-                await browser.close()
-
-            server.should_exit = True
-            await task
-            return status_inner, body_text_inner
-
-        result = asyncio.run(run_test())
+        result = load_page(tmpdir, "greet")
         if result is None:
             pytest.skip("Chromium not available for Playwright")
         status, body_text = result
@@ -97,60 +49,37 @@ def test_set_variable_in_browser():
 def test_reactive_set_variable_in_browser():
     """Ensure reactive mode updates are sent to the browser."""
     pytest.importorskip("playwright.async_api")
-    import importlib.util
     if (
         importlib.util.find_spec("websockets") is None
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.async_api import async_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_path = Path(tmpdir) / "react.pageql"
-        template_path.write_text(
+        Path(tmpdir, "react.pageql").write_text(
             "{{#reactive on}}{{#set a 'ww'}}hello {{a}}{{#set a 'world'}}",
             encoding="utf-8",
         )
 
-        async def run_test():
-            server, task, port = await run_server_in_task(tmpdir)
-            async with async_playwright() as p:
-                if not chromium_available(p):
-                    server.should_exit = True
-                    await task
-                    return None
-                browser = await p.chromium.launch(args=["--no-sandbox"])
-                page = await browser.new_page()
-                await page.goto(f"http://127.0.0.1:{port}/react")
-                await page.wait_for_timeout(500)
-                body_text_inner = await page.evaluate("document.body.textContent")
-                await browser.close()
-
-            server.should_exit = True
-            await task
-            return body_text_inner
-
-        body_text = asyncio.run(run_test())
+        body_text = load_page(tmpdir, "react")
         if body_text is None:
             pytest.skip("Chromium not available for Playwright")
+        _, text = body_text
 
-        assert body_text == "hello world"
+        assert text == "hello world"
 
 
 def test_reactive_count_insert_in_browser():
     """Count updates should be delivered to the browser when rows are inserted."""
     pytest.importorskip("playwright.async_api")
-    import importlib.util
     if (
         importlib.util.find_spec("websockets") is None
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.async_api import async_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_path = Path(tmpdir) / "count.pageql"
-        template_path.write_text(
+        Path(tmpdir, "count.pageql").write_text(
             "{{#create table nums(value INTEGER)}}"
             "{{#reactive on}}"
             "{{#set a count(*) from nums}}"
@@ -159,27 +88,10 @@ def test_reactive_count_insert_in_browser():
             encoding="utf-8",
         )
 
-        async def run_test():
-            server, task, port = await run_server_in_task(tmpdir)
-            async with async_playwright() as p:
-                if not chromium_available(p):
-                    server.should_exit = True
-                    await task
-                    return None
-                browser = await p.chromium.launch(args=["--no-sandbox"])
-                page = await browser.new_page()
-                await page.goto(f"http://127.0.0.1:{port}/count")
-                await page.wait_for_timeout(500)
-                body_text_inner = await page.evaluate("document.body.textContent")
-                await browser.close()
-
-            server.should_exit = True
-            await task
-            return body_text_inner
-
-        body_text = asyncio.run(run_test())
-        if body_text is None:
+        result = load_page(tmpdir, "count")
+        if result is None:
             pytest.skip("Chromium not available for Playwright")
+        _, body_text = result
 
         assert body_text == "1"
 
@@ -187,17 +99,14 @@ def test_reactive_count_insert_in_browser():
 def test_reactive_count_insert_via_execute():
     """Count updates should propagate when inserting after initial load."""
     pytest.importorskip("playwright.async_api")
-    import importlib.util
     if (
         importlib.util.find_spec("websockets") is None
         and importlib.util.find_spec("wsproto") is None
     ):
         pytest.skip("WebSocket library not available for reactive test")
-    from playwright.async_api import async_playwright
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        template_path = Path(tmpdir) / "count_after.pageql"
-        template_path.write_text(
+        Path(tmpdir, "count_after.pageql").write_text(
             "{{#create table if not exists nums(value INTEGER)}}"
             "{{#reactive on}}"
             "{{#set a count(*) from nums}}"
@@ -205,51 +114,16 @@ def test_reactive_count_insert_via_execute():
             encoding="utf-8",
         )
 
-        port = get_free_port()
-        app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
-        config = Config(app, host="127.0.0.1", port=port, log_level="warning")
-        server = Server(config)
+        async def after(page, port, app: PageQLApp):
+            await page.wait_for_timeout(500)
+            app.pageql_engine.tables.executeone(
+                "INSERT INTO nums(value) VALUES (1)", {}
+            )
+            await page.reload()
 
-        async def run_test():
-            server_task = asyncio.create_task(server.serve())
-            start = time.time()
-            while True:
-                try:
-                    conn = http.client.HTTPConnection("127.0.0.1", port)
-                    conn.connect()
-                    conn.close()
-                    break
-                except OSError:
-                    if time.time() - start > 5:
-                        server.should_exit = True
-                        await server_task
-                        raise RuntimeError("Server did not start")
-                    await asyncio.sleep(0.05)
-
-            async with async_playwright() as p:
-                if not chromium_available(p):
-                    server.should_exit = True
-                    await server_task
-                    return None
-                browser = await p.chromium.launch(args=["--no-sandbox"])
-                page = await browser.new_page()
-                await page.goto(f"http://127.0.0.1:{port}/count_after")
-                await page.wait_for_timeout(500)
-                body_text_inner = await page.evaluate("document.body.textContent")
-                app.pageql_engine.tables.executeone(
-                    "INSERT INTO nums(value) VALUES (1)", {}
-                )
-                await page.reload()
-                await page.wait_for_timeout(500)
-                body_text_inner = await page.evaluate("document.body.textContent")
-                await browser.close()
-
-            server.should_exit = True
-            await server_task
-            return body_text_inner
-
-        body_text = asyncio.run(run_test())
-        if body_text is None:
+        result = load_page(tmpdir, "count_after", after)
+        if result is None:
             pytest.skip("Chromium not available for Playwright")
+        _, body_text = result
 
         assert body_text == "1"


### PR DESCRIPTION
## Summary
- add `load_page` helper to open a PageQL page in a headless browser
- refactor browser integration tests to use `load_page`

## Testing
- `pip install wheels_deps/*`
- `pytest -q`