### PR TITLE
Fix hanging test_app by awaiting server start correctly

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -349,6 +349,7 @@ class PageQLApp:
                     n.set()
                 self.stop_event.set()
                 await send({"type": "lifespan.shutdown.complete"})
+                break
         
     def prepare_server(self, db_path, template_dir, create_db):
         """Loads templates and starts the HTTP server."""

--- a/tests/playwright_helpers.py
+++ b/tests/playwright_helpers.py
@@ -32,19 +32,21 @@ async def wait_for_server_async(
 ) -> None:
     start = time.time()
     while True:
-        try:
-            conn = http.client.HTTPConnection("127.0.0.1", port)
-            conn.connect()
-            conn.close()
-            break
-        except OSError:
-            if time.time() - start > timeout:
-                if server is not None:
-                    server.should_exit = True
-                if task is not None:
-                    await task
-                raise RuntimeError("Server did not start")
-            await asyncio.sleep(0.05)
+        if server is not None and server.started:
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", port)
+                conn.connect()
+                conn.close()
+                break
+            except OSError:
+                pass
+        if time.time() - start > timeout:
+            if server is not None:
+                server.should_exit = True
+            if task is not None:
+                await task
+            raise RuntimeError("Server did not start")
+        await asyncio.sleep(0.05)
 
 
 async def run_server_in_task(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,17 +13,21 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 from playwright_helpers import run_server_in_task
 
 
-@pytest.mark.skip(reason="Test disabled")
 def test_app_returns_404_for_missing_route():
     with tempfile.TemporaryDirectory() as tmpdir:
         async def run_test():
             server, task, port = await run_server_in_task(tmpdir)
-            conn = http.client.HTTPConnection("127.0.0.1", port)
-            conn.request("GET", "/missing")
-            resp = conn.getresponse()
-            status_inner = resp.status
-            resp.read()
-            conn.close()
+
+            def make_request():
+                conn = http.client.HTTPConnection("127.0.0.1", port)
+                conn.request("GET", "/missing")
+                resp = conn.getresponse()
+                status = resp.status
+                resp.read()
+                conn.close()
+                return status
+
+            status_inner = await asyncio.to_thread(make_request)
 
             server.should_exit = True
             await task


### PR DESCRIPTION
## Summary
- fix lifespan shutdown loop
- wait for server to start before sending requests
- avoid blocking event loop in test_app
- re-enable test_app

## Testing
- `pytest -q`