### PR TITLE
Fix reactive updates without page reload

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -684,7 +684,7 @@ class PageQL:
                     self.process_nodes(body, row_params, path, includes, http_verb, reactive, ctx, out=row_buffer)
                     row_content = ''.join(row_buffer).strip()
                     if ctx and reactive:
-                        row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(row)).encode()).digest())[:8]}"
+                        row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(row)).encode()).digest())[:8].decode()}"
                         ctx.ensure_init()
                         ctx.append_script(f"pstart('{row_id}')")
                         ctx.out.append(row_content)
@@ -700,11 +700,11 @@ class PageQL:
                                    includes=includes, http_verb=http_verb,
                                    saved_params=saved_params):
                         if ev[0] == 2:
-                            row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8]}"
+                            row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8].decode()}"
                             ctx.ensure_init()
                             ctx.append_script(f"pdelete('{row_id}')")
                         elif ev[0] == 1:
-                            row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8]}"
+                            row_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8].decode()}"
                             row_params = saved_params.copy()
                             for i, col_name in enumerate(col_names):
                                 row_params[col_name] = ReadOnly(ev[1][i])
@@ -714,8 +714,8 @@ class PageQL:
                             ctx.ensure_init()
                             ctx.append_script(f"pinsert('{row_id}',{json.dumps(row_content)})")
                         elif ev[0] == 3:
-                            old_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8]}"
-                            new_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[2])).encode()).digest())[:8]}"
+                            old_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8].decode()}"
+                            new_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[2])).encode()).digest())[:8].decode()}"
                             row_params = saved_params.copy()
                             for i, col_name in enumerate(col_names):
                                 row_params[col_name] = ReadOnly(ev[2][i])

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -14,12 +14,12 @@ from .pageql import PageQL
 base_script = """
 <script>
   window.pageqlMarkers={};
-  function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);s.replaceWith(c);window.pageqlMarkers[i]=c;document.currentScript.remove();}
-  function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);s.replaceWith(c);window.pageqlMarkers[i].e=c;document.currentScript.remove();}
-  function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);document.currentScript.remove();}
-  function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];document.currentScript.remove();}
-  function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);document.currentScript.remove();}
-  function pinsert(i,v){var m=window.pageqlMarkers[i],e=m.e;var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);document.currentScript.remove();}
+  function pstart(i){var s=document.currentScript,c=document.createComment('pageql-start:'+i);var p=s.parentNode;if(p&&p.tagName==='HEAD'&&document.body){p.removeChild(s);document.body.appendChild(c);}else{s.replaceWith(c);}window.pageqlMarkers[i]=c;if(document.currentScript)document.currentScript.remove();}
+  function pend(i){var s=document.currentScript,c=document.createComment('pageql-end:'+i);var p=s.parentNode;if(p&&p.tagName==='HEAD'&&document.body){p.removeChild(s);document.body.appendChild(c);}else{s.replaceWith(c);}if(window.pageqlMarkers[i])window.pageqlMarkers[i].e=c;else{window.pageqlMarkers[i]={e:c};}if(document.currentScript)document.currentScript.remove();}
+  function pset(i,v){var s=window.pageqlMarkers[i],e=s.e,r=document.createRange();r.setStartAfter(s);r.setEndBefore(e);r.deleteContents();var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);if(document.currentScript)document.currentScript.remove();}
+  function pdelete(i){var m=window.pageqlMarkers[i],e=m.e,r=document.createRange();r.setStartBefore(m);r.setEndAfter(e);r.deleteContents();delete window.pageqlMarkers[i];if(document.currentScript)document.currentScript.remove();}
+  function pupdate(o,n,v){var m=window.pageqlMarkers[o],e=m.e;m.textContent='pageql-start:'+n;e.textContent='pageql-end:'+n;delete window.pageqlMarkers[o];window.pageqlMarkers[n]=m;pset(n,v);if(document.currentScript)document.currentScript.remove();}
+  function pinsert(i,v){var m=window.pageqlMarkers[i];if(!m){var mid=i.split('_')[0];var c=window.pageqlMarkers[mid];if(!c){return;}m=document.createComment('pageql-start:'+i);var e=document.createComment('pageql-end:'+i);m.e=e;window.pageqlMarkers[i]=m;c.e.parentNode.insertBefore(m,c.e);var t=document.createElement('template');t.innerHTML=v;c.e.parentNode.insertBefore(t.content,c.e);c.e.parentNode.insertBefore(e,c.e);}else{var e=m.e;var t=document.createElement('template');t.innerHTML=v;e.parentNode.insertBefore(t.content,e);}if(document.currentScript)document.currentScript.remove();}
   document.currentScript.remove()
 </script>
 """
@@ -269,9 +269,15 @@ class PageQLApp:
                     'headers': headers,
                 })
                 scripts = base_script + (reload_ws_script(client_id) if self.should_reload else '')
+                body_content = scripts + result.body
+                low = result.body.lower()
+                if '<body' not in low:
+                    body_content = '<body>' + body_content + '</body>'
+                if '<html' not in low:
+                    body_content = '<html>' + body_content + '</html>'
                 await send({
                     'type': 'http.response.body',
-                    'body': (scripts + result.body).encode('utf-8'),
+                    'body': body_content.encode('utf-8'),
                 })
 
         except sqlite3.Error as db_err:

--- a/tests/playwright_helpers.py
+++ b/tests/playwright_helpers.py
@@ -91,7 +91,7 @@ async def _load_page_async(
             else:
                 after(pg, port, app)
         await pg.wait_for_timeout(500)
-        body = await pg.evaluate("document.body.textContent")
+        body = (await pg.evaluate("document.body.textContent")).strip()
         status = response.status if response is not None else None
         await browser.close()
 

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -178,8 +178,7 @@ def test_insert_via_execute_after_click():
             app.pageql_engine.tables.executeone(
                 "INSERT INTO msgs(text) VALUES (:text)", {"text": "hello"}
             )
-            await page.reload()
-            await page.wait_for_load_state("networkidle")
+            await page.wait_for_timeout(500)
 
         result = load_page(tmpdir, "msgs", after, reload=True)
         if result is None:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -125,8 +125,8 @@ def test_from_reactive_uses_parse(monkeypatch):
     result = r.render("/m")
     assert seen == ["SELECT * FROM items"]
     import hashlib
-    h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
-    h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
+    h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8].decode()
+    h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8].decode()
     expected = (
         ""
         f"<script>pstart(0)</script>"
@@ -176,8 +176,8 @@ def test_from_reactive_delete_event():
     r.load_module("m", "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}{{#delete from items where id=1}}")
     result = r.render("/m")
     import hashlib
-    h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8]
-    h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8]
+    h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8].decode()
+    h2 = base64.b64encode(hashlib.sha256(repr((2,"b",)).encode()).digest())[:8].decode()
     expected = (
         ""
         f"<script>pstart(0)</script>"
@@ -200,9 +200,9 @@ def test_from_reactive_update_event():
     result = r.render("/m")
     import hashlib
 
-    h1_old = base64.b64encode(hashlib.sha256(repr((1, "a",)).encode()).digest())[:8]
-    h1_new = base64.b64encode(hashlib.sha256(repr((1, "c",)).encode()).digest())[:8]
-    h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8]
+    h1_old = base64.b64encode(hashlib.sha256(repr((1, "a",)).encode()).digest())[:8].decode()
+    h1_new = base64.b64encode(hashlib.sha256(repr((1, "c",)).encode()).digest())[:8].decode()
+    h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1_old}')</script><a><script>pend('0_{h1_old}')</script>\n"
@@ -223,9 +223,9 @@ def test_from_reactive_insert_event():
     result = r.render("/m")
     import hashlib
 
-    h1 = base64.b64encode(hashlib.sha256(repr((1, "a",)).encode()).digest())[:8]
-    h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8]
-    h3 = base64.b64encode(hashlib.sha256(repr((3, "c",)).encode()).digest())[:8]
+    h1 = base64.b64encode(hashlib.sha256(repr((1, "a",)).encode()).digest())[:8].decode()
+    h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8].decode()
+    h3 = base64.b64encode(hashlib.sha256(repr((3, "c",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h1}')</script><a><script>pend('0_{h1}')</script>\n"


### PR DESCRIPTION
## Summary
- ensure DOM markers aren't stuck in `<head>` by moving them to `<body>`
- wrap responses in minimal HTML when needed so reactive updates appear in body
- generate stable row IDs for reactive lists
- trim body text in browser helper
- remove unnecessary reload in integration test

## Testing
- `pytest -q`