### PR TITLE
Add reactiveelement AST wrapper

### DIFF
--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -1,0 +1,31 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import add_reactive_elements
+
+
+def test_wrap_simple_element():
+    nodes = [("text", "<div"), ("text", ">hi</div>")]
+    assert add_reactive_elements(nodes) == [["#reactiveelement", nodes]]
+
+
+def test_no_wrap_when_closed_in_same_node():
+    nodes = [("text", "<div>hi</div>")]
+    assert add_reactive_elements(nodes) == nodes
+
+
+def test_entities_are_tracked():
+    nodes = [("text", "&lt;span"), ("text", "&gt;ok&lt;/span&gt;")]
+    assert add_reactive_elements(nodes) == [["#reactiveelement", nodes]]
+
+
+def test_wrap_across_directive():
+    nodes = [
+        ("text", "<div"),
+        ["#if", "cond", [("text", "class='x'")], []],
+        ("text", ">x</div>")
+    ]
+    res = add_reactive_elements(nodes)
+    assert res == [["#reactiveelement", [nodes[0], nodes[1], nodes[2]]]]


### PR DESCRIPTION
## Summary
- implement `add_reactive_elements` to group incomplete HTML tags
- roll back integration with `PageQL`
- test wrapping behavior including entity tracking

## Testing
- `pytest`
