### PR TITLE
Fix invalid HTML in reactive tests

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -121,7 +121,7 @@ def test_from_reactive_uses_parse(monkeypatch):
     r = PageQL(":memory:")
     r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
-    r.load_module("m", "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}")
+    r.load_module("m", "{{#reactive on}}{{#from items}}[{{id}}]{{/from}}")
     result = r.render("/m")
     assert seen == ["SELECT * FROM items"]
     import hashlib
@@ -130,8 +130,8 @@ def test_from_reactive_uses_parse(monkeypatch):
     expected = (
         ""
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script>[1]<script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[2]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
     )
     assert result.body == expected
@@ -173,7 +173,7 @@ def test_from_reactive_delete_event():
     r = PageQL(":memory:")
     r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
-    r.load_module("m", "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}{{#delete from items where id=1}}")
+    r.load_module("m", "{{#reactive on}}{{#from items}}[{{id}}]{{/from}}{{#delete from items where id=1}}")
     result = r.render("/m")
     import hashlib
     h1 = base64.b64encode(hashlib.sha256(repr((1,"a",)).encode()).digest())[:8].decode()
@@ -181,8 +181,8 @@ def test_from_reactive_delete_event():
     expected = (
         ""
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script>[1]<script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[2]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
         f"<script>pdelete('0_{h1}')</script>"
     )
@@ -195,7 +195,7 @@ def test_from_reactive_update_event():
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     r.load_module(
         "m",
-        "{{#reactive on}}{{#from items}}<{{name}}>{{/from}}{{#update items set name='c' where id=1}}",
+        "{{#reactive on}}{{#from items}}[{{name}}]{{/from}}{{#update items set name='c' where id=1}}",
     )
     result = r.render("/m")
     import hashlib
@@ -205,10 +205,10 @@ def test_from_reactive_update_event():
     h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1_old}')</script><a><script>pend('0_{h1_old}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1_old}')</script>[a]<script>pend('0_{h1_old}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[b]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
-        f"<script>pupdate('0_{h1_old}','0_{h1_new}',\"<c>\")</script>"
+        f"<script>pupdate('0_{h1_old}','0_{h1_new}',\"[c]\")</script>"
     )
     assert result.body == expected
 
@@ -218,7 +218,7 @@ def test_from_reactive_insert_event():
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     r.load_module(
         "m",
-        "{{#reactive on}}{{#from items}}<{{name}}>{{/from}}{{#insert into items(name) values ('c')}}",
+        "{{#reactive on}}{{#from items}}[{{name}}]{{/from}}{{#insert into items(name) values ('c')}}",
     )
     result = r.render("/m")
     import hashlib
@@ -228,10 +228,10 @@ def test_from_reactive_insert_event():
     h3 = base64.b64encode(hashlib.sha256(repr((3, "c",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1}')</script><a><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script>[a]<script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[b]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
-        f"<script>pinsert('0_{h3}',\"<c>\")</script>"
+        f"<script>pinsert('0_{h3}',\"[c]\")</script>"
     )
     assert result.body == expected
 
@@ -242,7 +242,7 @@ def test_from_nonreactive_delete_event():
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     r.load_module(
         "m",
-        "{{#reactive on}}{{#from items}}<{{id}}>{{/from}}{{#reactive off}}{{#delete from items where id=1}}",
+        "{{#reactive on}}{{#from items}}[{{id}}]{{/from}}{{#reactive off}}{{#delete from items where id=1}}",
     )
     result = r.render("/m")
     import hashlib
@@ -252,8 +252,8 @@ def test_from_nonreactive_delete_event():
     expected = (
         ""
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1}')</script><1><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><2><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script>[1]<script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[2]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
         f"<script>pdelete('0_{h1}')</script>"
     )
@@ -266,7 +266,7 @@ def test_from_nonreactive_update_event():
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     r.load_module(
         "m",
-        "{{#reactive on}}{{#from items}}<{{name}}>{{/from}}{{#reactive off}}{{#update items set name='c' where id=1}}",
+        "{{#reactive on}}{{#from items}}[{{name}}]{{/from}}{{#reactive off}}{{#update items set name='c' where id=1}}",
     )
     result = r.render("/m")
     import hashlib
@@ -276,10 +276,10 @@ def test_from_nonreactive_update_event():
     h2 = base64.b64encode(hashlib.sha256(repr((2, "b",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1_old}')</script><a><script>pend('0_{h1_old}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1_old}')</script>[a]<script>pend('0_{h1_old}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[b]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
-        f"<script>pupdate('0_{h1_old}','0_{h1_new}',\"<c>\")</script>"
+        f"<script>pupdate('0_{h1_old}','0_{h1_new}',\"[c]\")</script>"
     )
     assert result.body == expected
 
@@ -290,7 +290,7 @@ def test_from_nonreactive_insert_event():
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     r.load_module(
         "m",
-        "{{#reactive on}}{{#from items}}<{{name}}>{{/from}}{{#reactive off}}{{#insert into items(name) values ('c')}}",
+        "{{#reactive on}}{{#from items}}[{{name}}]{{/from}}{{#reactive off}}{{#insert into items(name) values ('c')}}",
     )
     result = r.render("/m")
     import hashlib
@@ -300,10 +300,10 @@ def test_from_nonreactive_insert_event():
     h3 = base64.b64encode(hashlib.sha256(repr((3, "c",)).encode()).digest())[:8].decode()
     expected = (
         f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h1}')</script><a><script>pend('0_{h1}')</script>\n"
-        f"<script>pstart('0_{h2}')</script><b><script>pend('0_{h2}')</script>\n"
+        f"<script>pstart('0_{h1}')</script>[a]<script>pend('0_{h1}')</script>\n"
+        f"<script>pstart('0_{h2}')</script>[b]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
-        f"<script>pinsert('0_{h3}',\"<c>\")</script>"
+        f"<script>pinsert('0_{h3}',\"[c]\")</script>"
     )
     assert result.body == expected
 

--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -157,13 +157,13 @@ a is 5, c is cc
 >>> r.load_module("optional", "{{#param text optional}}cool{{/param}}")
 >>> print(r.render("/optional").body)
 cool
->>> r.load_module("delete_test", "{{#partial delete :id}}deleted<{{id}}>{{/partial}}")
+>>> r.load_module("delete_test", "{{#partial delete :id}}deleted[{{id}}]{{/partial}}")
 >>> print(r.render("/delete_test/1", http_verb="DELETE").body)
-deleted<1>
+deleted[1]
 >>> r.load_module("varnum", "{{#set idd0 3}}{{idd0}}")
 >>> print(r.render("/varnum").body)
 3
->>> r.load_module("fromtest", "{{#from (select 1 as id)}}<{{id}}>{{/from}}")
+>>> r.load_module("fromtest", "{{#from (select 1 as id)}}[{{id}}]{{/from}}")
 >>> print(r.render("/fromtest").body)
-<1>
+[1]
 """


### PR DESCRIPTION
## Summary
- use square brackets instead of HTML-like tags in reactive tests
- update docstring examples

## Testing
- `pytest`