### PR TITLE
Implement reactive parent registration

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -669,7 +669,7 @@ class PageQL:
         elif isinstance(node, list):
             directive = node[0]
             if directive == '#reactiveelement':
-                return self.process_nodes(
+                self.process_nodes(
                     node[1],
                     params,
                     path,
@@ -679,6 +679,11 @@ class PageQL:
                     ctx,
                     out,
                 )
+                if reactive and ctx:
+                    ctx.ensure_init()
+                    mid = ctx.marker_id()
+                    ctx.append_script(f"pparent({mid})", out)
+                return reactive
             if directive == '#if':
                 if reactive and ctx:
                     cond_exprs = []

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -403,6 +403,20 @@ def test_reactive_if_variable_and_table_dependency():
     )
     assert result.body == expected
 
+
+def test_reactiveelement_adds_pparent_script():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#reactive on}}<div {{#if 1}}class='x'{{/if}}></div>")
+    result = r.render("/m")
+    assert result.body == "<div class='x'><script>pparent(0)</script></div>"
+
+
+def test_reactiveelement_nonreactive_no_script():
+    r = PageQL(":memory:")
+    r.load_module("m", "<div {{#if 1}}class='x'{{/if}}></div>")
+    result = r.render("/m")
+    assert result.body == "<div class='x'></div>"
+
 def test_pupdatetag_in_base_script():
     from pageql.pageqlapp import base_script
     assert 'function pupdatetag' in base_script


### PR DESCRIPTION
## Summary
- capture parent elements during reactive rendering
- test pparent marker placement in reactive mode

## Testing
- `pytest`