### PR TITLE
Fix reactiveelement input handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -522,24 +522,30 @@ class PageQL:
                 out.append(node_content)
             elif node_type == 'render_expression':
                 result = evalone(self.db, node_content, params, reactive, self.tables)
-                if reactive and isinstance(result, Signal):
-                    value = html.escape(str(result.value))
+                if isinstance(result, Signal):
+                    signal = result
+                    result = result.value
+                else:
+                    signal = None
+                value = html.escape(str(result))
+                if ctx.reactiveelement is not None:
+                    out.append(value)
+                    if signal:
+                        ctx.reactiveelement.append(signal)
+                elif reactive and signal is not None:
                     ctx.ensure_init()
                     mid = ctx.marker_id()
                     ctx.append_script(f"pstart({mid})", out)
                     out.append(value)
                     ctx.append_script(f"pend({mid})", out)
-                    def listener(v=None, *, sig=result, mid=mid, ctx=ctx):
+                    def listener(v=None, *, sig=signal, mid=mid, ctx=ctx):
                         ctx.ensure_init()
                         ctx.append_script(
                             f"pset({mid},{json.dumps(html.escape(str(sig.value)))})",
                             out,
                         )
-                    ctx.add_listener(result, listener)
+                    ctx.add_listener(signal, listener)
                 else:
-                    if isinstance(result, ReadOnly):
-                        result = result.value
-                    value = html.escape(str(result))
                     out.append(value)
             elif node_type == 'render_param':
                 try:
@@ -551,7 +557,11 @@ class PageQL:
                         if isinstance(val, Signal):
                             val = val.value
                         value = html.escape(str(val))
-                        if reactive:
+                        if ctx.reactiveelement is not None:
+                            out.append(value)
+                            if signal:
+                                ctx.reactiveelement.append(signal)
+                        elif reactive:
                             ctx.ensure_init()
                             mid = ctx.marker_id()
                             ctx.append_script(f"pstart({mid})", out)
@@ -567,7 +577,32 @@ class PageQL:
                 except KeyError:
                     raise ValueError(f"Parameter `{node_content}` not found in params `{params}`")
             elif node_type == 'render_raw':
-                out.append(str(evalone(self.db, node_content, params, reactive, self.tables)))
+                result = evalone(self.db, node_content, params, reactive, self.tables)
+                if isinstance(result, Signal):
+                    signal = result
+                    result = result.value
+                else:
+                    signal = None
+                value = str(result)
+                if ctx.reactiveelement is not None:
+                    out.append(value)
+                    if signal:
+                        ctx.reactiveelement.append(signal)
+                elif reactive and signal is not None:
+                    ctx.ensure_init()
+                    mid = ctx.marker_id()
+                    ctx.append_script(f"pstart({mid})", out)
+                    out.append(value)
+                    ctx.append_script(f"pend({mid})", out)
+                    def listener(v=None, *, sig=signal, mid=mid, ctx=ctx):
+                        ctx.ensure_init()
+                        ctx.append_script(
+                            f"pset({mid},{json.dumps(str(sig.value))})",
+                            out,
+                        )
+                    ctx.add_listener(signal, listener)
+                else:
+                    out.append(value)
             elif node_type == '#param':
                 param_name, param_value = self.handle_param(node_content, params)
                 params[param_name] = param_value

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -435,6 +435,22 @@ def test_reactiveelement_updates_node():
     )
     assert result.body == expected
 
+def test_reactiveelement_input_value():
+    r = PageQL(":memory:")
+    snippet = (
+        "{{#reactive on}}"
+        "{{#set c 1}}"
+        "<input type='text' value='{{c}}'>"
+        "{{#set c 2}}"
+    )
+    r.load_module("m", snippet)
+    result = r.render("/m")
+    expected = (
+        "<input type='text' value='1'><script>pparent(0)</script>"
+        "<script>pupdatetag(window.pageqlMarkers[0],\"<input type='text' value='2'></input>\")</script>"
+    )
+    assert result.body == expected
+
 def test_pupdatetag_in_base_script():
     from pageql.pageqlapp import base_script
     assert 'function pupdatetag' in base_script


### PR DESCRIPTION
## Summary
- avoid injecting pstart/pend inside reactiveelement
- collect signals for render_param and render_expression when inside reactiveelement
- test `<input>` value updates without extra scripts

## Testing
- `pytest`