### PR TITLE
Add nested element reactive test

### DIFF
--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -49,3 +49,20 @@ def test_wrap_with_directive_and_surrounding_text():
         ]],
         ("text", " world"),
     ]
+
+
+def test_wrap_nested_element():
+    nodes = [
+        ("text", "<p>Active count is 1: <input type='checkbox' "),
+        ["#if", ":active_count == 1", [("text", "checked")]],
+        ("text", "></p>")
+    ]
+    res = add_reactive_elements(nodes)
+    assert res == [
+        ["#reactiveelement", [
+            ("text", "<p>Active count is 1: <input type='checkbox' "),
+            ["#if", ":active_count == 1", [("text", "checked")]],
+            ("text", ">")
+        ]],
+        ("text", "</p>")
+    ]


### PR DESCRIPTION
## Summary
- reproduce HTML AST for nested reactive elements
- add failing scenario to `test_add_reactive_elements`

## Testing
- `pytest`