### PR TITLE
Fix reactive element handling of consecutive inputs

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -330,23 +330,38 @@ def add_reactive_elements(nodes):
                 captured = [("text", text[idx:])]
                 capturing = True
             elif capturing:
-                if not in_tag:
-                    idx = text.find(">")
-                    if idx != -1:
-                        after = text[idx + 1 :]
-                        captured.append(("text", text[: idx + 1]))
-                        if _has_dynamic(captured):
-                            result.append(["#reactiveelement", captured])
-                            if after:
-                                result.append(("text", after))
-                        else:
-                            last = captured.pop()
-                            result.extend(captured)
-                            result.append(("text", last[1] + after))
+                idx = None
+                q = q_before
+                for pos, ch in enumerate(text):
+                    if ch in ("'", '"'):
+                        if q == ch:
+                            q = None
+                        elif q is None:
+                            q = ch
+                    elif ch == '>' and q is None:
+                        idx = pos
+                        break
+                if idx is not None:
+                    after = text[idx + 1 :]
+                    prefix = text[: idx + 1]
+                    captured.append(("text", prefix))
+                    if _has_dynamic(captured):
+                        result.append(["#reactiveelement", captured])
                         captured = []
                         capturing = False
+                        quote, in_tag = scan(prefix, q_before, t_before)
+                        if after:
+                            nodes[i] = ("text", after)
+                            continue
                     else:
-                        captured.append(node)
+                        last = captured.pop()
+                        result.extend(captured)
+                        result.append(("text", last[1] + after))
+                        captured = []
+                        capturing = False
+                        quote, in_tag = scan(text, q_before, t_before)
+                    i += 1
+                    continue
                 else:
                     captured.append(node)
             else:

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -93,7 +93,13 @@ def test_delete_insert_input_and_text():
                 ("render_expression", "3"),
                 ("text", "\" type=\"checkbox\" "),
                 ["#if", "1", [("text", "checked")]],
-                ("text", "><input type=\"text\" value=\""),
+                ("text", ">"),
+            ],
+        ],
+        [
+            "#reactiveelement",
+            [
+                ("text", "<input type=\"text\" value=\""),
                 ("render_param", "active_count"),
                 ("text", "\">")
             ],

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -505,8 +505,8 @@ def test_reactiveelement_delete_and_insert_updates_input_and_text():
     r.load_module("m", snippet)
     result = r.render("/m")
     expected = (
-        "<p><input class=\"toggle3\" type=\"checkbox\" checked><input type=\"text\" value=\"0\"><script>pprevioustag(0)</script></p>"
-        "<script>pupdatetag(0,\"<input class=\\\"toggle3\\\" type=\\\"checkbox\\\" checked><input type=\\\"text\\\" value=\\\"1\\\">\")</script>"
+        "<p><input class=\"toggle3\" type=\"checkbox\" checked><script>pprevioustag(0)</script><input type=\"text\" value=\"0\"><script>pprevioustag(1)</script></p>"
+        "<script>pupdatetag(1,\"<input type=\\\"text\\\" value=\\\"1\\\">\")</script>"
     )
     assert result.body == expected
 


### PR DESCRIPTION
## Summary
- prevent reactive-element wrapper from spanning multiple HTML elements
- adjust tests for new behavior

## Testing
- `pytest`