### PR TITLE
Remove VOID_ELEMENTS constant

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -20,11 +20,6 @@ import pathlib
 if __package__ is None:                      # script / doctest-by-path
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
-# HTML void elements do not use closing tags
-VOID_ELEMENTS = {
-    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link',
-    'meta', 'param', 'source', 'track', 'wbr'
-}
 
 from pageql.parser import tokenize, parsefirstword, build_ast, add_reactive_elements
 from pageql.reactive import Signal, DerivedSignal, DependentValue, get_dependencies, Tables
@@ -756,7 +751,6 @@ class PageQL:
                                 tag = m.group(1)
                         if (
                             tag
-                            and tag.lower() not in VOID_ELEMENTS
                             and not html_content.endswith('/>')
                             and not html_content.endswith(f'</{tag}>')
                         ):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -447,7 +447,7 @@ def test_reactiveelement_input_value():
     result = r.render("/m")
     expected = (
         "<input type='text' value='1'><script>pprevioustag(0)</script>"
-        "<script>pupdatetag(0,\"<input type='text' value='2'>\")</script>"
+        "<script>pupdatetag(0,\"<input type='text' value='2'></input>\")</script>"
     )
     assert result.body == expected
 
@@ -466,7 +466,7 @@ def test_reactiveelement_if_with_table_insert_updates_input():
     result = r.render("/m")
     expected = (
         "<p>Active count is 1: <input type='checkbox' ><script>pprevioustag(0)</script></p>"
-        "<script>pupdatetag(0,\"<input type='checkbox' checked>\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' checked></input>\")</script>"
     )
     assert result.body == expected
 
@@ -484,8 +484,8 @@ def test_reactiveelement_if_variable_updates_checked():
     result = r.render("/m")
     expected = (
         "<input type='checkbox' checked><script>pprevioustag(0)</script>"
-        "<script>pupdatetag(0,\"<input type='checkbox' >\")</script>"
-        "<script>pupdatetag(0,\"<input type='checkbox' checked>\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' ></input>\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' checked></input>\")</script>"
     )
     assert result.body == expected
 
@@ -506,7 +506,7 @@ def test_reactiveelement_delete_and_insert_updates_input_and_text():
     result = r.render("/m")
     expected = (
         "<p><input class=\"toggle3\" type=\"checkbox\" checked><script>pprevioustag(0)</script><input type=\"text\" value=\"0\"><script>pprevioustag(1)</script></p>"
-        "<script>pupdatetag(1,\"<input type=\\\"text\\\" value=\\\"1\\\">\")</script>"
+        "<script>pupdatetag(1,\"<input type=\\\"text\\\" value=\\\"1\\\"></input>\")</script>"
     )
     assert result.body == expected
 


### PR DESCRIPTION
## Summary
- drop the VOID_ELEMENTS constant
- always append a closing tag for non self-closing updates
- adjust tests for updated output

## Testing
- `pytest`