### PR TITLE
Fix Where reactivity for no-op updates

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -158,6 +158,8 @@ class Where:
         else:
             contains_old_row = self.contains_row(event[1])
             contains_new_row = self.contains_row(event[2])
+            if event[1] == event[2]:
+                return
             if contains_old_row and not contains_new_row:
                 for listener in self.listeners:
                     listener([2, event[1]])

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -273,6 +273,22 @@ def test_select_no_change_on_same_value_update():
     assert_eq(len(events), initial_event_count)  # no new event emitted
 
 
+def test_where_no_event_on_same_value_update():
+    conn = _db()
+    rt = ReactiveTable(conn, "items")
+    w = Where(rt, "name = 'x'")
+    events = []
+    w.listeners.append(events.append)
+
+    rt.insert("INSERT INTO items(name) VALUES ('x')", {})
+    initial_len = len(events)
+
+    rid = conn.execute("SELECT id FROM items WHERE name='x'").fetchone()[0]
+    rt.update("UPDATE items SET name='x' WHERE id=:id", {"id": rid})
+
+    assert_eq(len(events), initial_len)
+
+
 def test_unionall_update():
     conn = sqlite3.connect(":memory:")
     for t in ("a", "b"):


### PR DESCRIPTION
## Summary
- avoid emitting Where events when update doesn't change the row
- test the new behaviour

## Testing
- `pytest`