### PR TITLE
Prevent redundant update events when row unchanged

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -131,6 +131,8 @@ class ReactiveTable:
             new_row = cursor.fetchone()
             if new_row is None:
                 raise Exception(f"Update on table {self.table_name} failed for query: {update_sql} with params: {params}")
+            if new_row == row:
+                continue
             for listener in self.listeners:
                 listener([3, row, new_row])
             

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -289,6 +289,21 @@ def test_where_no_event_on_same_value_update():
     assert_eq(len(events), initial_len)
 
 
+def test_reactive_table_no_event_on_same_value_update():
+    conn = _db()
+    rt = ReactiveTable(conn, "items")
+    events = []
+    rt.listeners.append(events.append)
+
+    rt.insert("INSERT INTO items(name) VALUES ('x')", {})
+    initial_len = len(events)
+
+    rid = conn.execute("SELECT id FROM items WHERE name='x'").fetchone()[0]
+    rt.update("UPDATE items SET name='x' WHERE id=:id", {"id": rid})
+
+    assert_eq(len(events), initial_len)
+
+
 def test_unionall_update():
     conn = sqlite3.connect(":memory:")
     for t in ("a", "b"):


### PR DESCRIPTION
## Summary
- avoid emitting update events in ReactiveTable if row doesn't change
- add regression test for no-op updates

## Testing
- `pytest`