### PR TITLE
Handle HTML void elements

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -749,9 +749,14 @@ class PageQL:
                             m = re.match(r'<([A-Za-z0-9_-]+)', html_content)
                             if m:
                                 tag = m.group(1)
+                        void_elements = {
+                            'area','base','br','col','embed','hr','img','input',
+                            'link','meta','param','source','track','wbr'
+                        }
                         if (
                             tag
-                            and not html_content.endswith('/>')
+                            and tag.lower() not in void_elements
+                            and not re.search(r'/\s*>$', html_content)
                             and not html_content.endswith(f'</{tag}>')
                         ):
                             html_content += f"</{tag}>"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -447,7 +447,24 @@ def test_reactiveelement_input_value():
     result = r.render("/m")
     expected = (
         "<input type='text' value='1'><script>pprevioustag(0)</script>"
-        "<script>pupdatetag(0,\"<input type='text' value='2'></input>\")</script>"
+        "<script>pupdatetag(0,\"<input type='text' value='2'>\")</script>"
+    )
+    assert result.body == expected
+
+
+def test_reactiveelement_self_closing_input():
+    r = PageQL(":memory:")
+    snippet = (
+        "{{#reactive on}}"
+        "{{#set c 1}}"
+        "<input type='text' value='{{c}}' />"
+        "{{#set c 2}}"
+    )
+    r.load_module("m", snippet)
+    result = r.render("/m")
+    expected = (
+        "<input type='text' value='1' /><script>pprevioustag(0)</script>"
+        "<script>pupdatetag(0,\"<input type='text' value='2' />\")</script>"
     )
     assert result.body == expected
 
@@ -466,7 +483,7 @@ def test_reactiveelement_if_with_table_insert_updates_input():
     result = r.render("/m")
     expected = (
         "<p>Active count is 1: <input type='checkbox' ><script>pprevioustag(0)</script></p>"
-        "<script>pupdatetag(0,\"<input type='checkbox' checked></input>\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' checked>\")</script>"
     )
     assert result.body == expected
 
@@ -484,8 +501,8 @@ def test_reactiveelement_if_variable_updates_checked():
     result = r.render("/m")
     expected = (
         "<input type='checkbox' checked><script>pprevioustag(0)</script>"
-        "<script>pupdatetag(0,\"<input type='checkbox' ></input>\")</script>"
-        "<script>pupdatetag(0,\"<input type='checkbox' checked></input>\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' >\")</script>"
+        "<script>pupdatetag(0,\"<input type='checkbox' checked>\")</script>"
     )
     assert result.body == expected
 
@@ -506,7 +523,7 @@ def test_reactiveelement_delete_and_insert_updates_input_and_text():
     result = r.render("/m")
     expected = (
         "<p><input class=\"toggle3\" type=\"checkbox\" checked><script>pprevioustag(0)</script><input type=\"text\" value=\"0\"><script>pprevioustag(1)</script></p>"
-        "<script>pupdatetag(1,\"<input type=\\\"text\\\" value=\\\"1\\\"></input>\")</script>"
+        "<script>pupdatetag(1,\"<input type=\\\"text\\\" value=\\\"1\\\">\")</script>"
     )
     assert result.body == expected
 


### PR DESCRIPTION
## Summary
- avoid adding closing tags for HTML void elements like `<input>`
- update tests accordingly

## Testing
- `pytest`