### PR TITLE
Implement remove_listener for reactive components

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -87,6 +87,14 @@ class FallbackReactive:
         self.rows = rows
         self._counts = new_counts
 
+    def remove_listener(self, listener):
+        if listener in self.listeners:
+            self.listeners.remove(listener)
+        if not self.listeners:
+            for dep in self.deps:
+                if self._on_parent_event in getattr(dep, "listeners", []):
+                    dep.listeners.remove(self._on_parent_event)
+
 
 def build_reactive(expr, tables: Tables):
     if isinstance(expr, exp.Subquery):


### PR DESCRIPTION
## Summary
- add `remove_listener` to reactive SQL classes
- detach parent listeners when last listener removed
- ensure tests use the new method
- cover `remove_listener` behaviour with tests

## Testing
- `pytest`