### PR TITLE
Implement remove_listener for SQL reactive components

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -87,6 +87,15 @@ class FallbackReactive:
         self.rows = rows
         self._counts = new_counts
 
+    def remove_listener(self, listener):
+        """Remove *listener* and detach from dependencies when unused."""
+        if listener in self.listeners:
+            self.listeners.remove(listener)
+        if not self.listeners:
+            for dep in self.deps:
+                if self._on_parent_event in getattr(dep, "listeners", []):
+                    dep.listeners.remove(self._on_parent_event)
+
 
 def build_reactive(expr, tables: Tables):
     if isinstance(expr, exp.Subquery):

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -540,6 +540,30 @@ def test_signal_remove_listener_detaches_dependencies():
     assert derived.listeners == []
 
 
+def test_where_remove_listener_detaches_from_parent():
+    conn = _db()
+    rt = ReactiveTable(conn, "items")
+    w = Where(rt, "name = 'x'")
+    cb = lambda e: None
+    w.listeners.append(cb)
+    assert w.onevent in rt.listeners
+    w.remove_listener(cb)
+    assert w.onevent not in rt.listeners
+    assert w.listeners == []
+
+
+def test_select_remove_listener_detaches_from_parent():
+    conn = _db()
+    rt = ReactiveTable(conn, "items")
+    sel = Select(rt, "name")
+    cb = lambda e: None
+    sel.listeners.append(cb)
+    assert sel.onevent in rt.listeners
+    sel.remove_listener(cb)
+    assert sel.onevent not in rt.listeners
+    assert sel.listeners == []
+
+
 def test_rendercontext_cleanup_detaches_dependency_listeners():
     ctx = RenderContext()
     src = Signal(1)


### PR DESCRIPTION
## Summary
- ensure FallbackReactive and all SQL reactive components detach from parents when unused
- add tests for Select and Where remove_listener behavior

## Testing
- `pytest`