### PR TITLE
Fix render context cleanup after http disconnect

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -278,6 +278,25 @@ class PageQLApp:
                     'body': result.body.encode('utf-8'),
                 })
                 print(f"Redirecting to: {result.redirect_to} (Status: {result.status_code})")
+
+                if client_id:
+                    async def cleanup_if_no_ws():
+                        try:
+                            msg = await receive()
+                        except Exception:
+                            return
+                        if not (
+                            isinstance(msg, dict)
+                            and msg.get("type") == "http.disconnect"
+                        ):
+                            return
+                        await asyncio.sleep(0.05)
+                        if client_id not in self.websockets:
+                            ctx = self.render_contexts.pop(client_id, None)
+                            if ctx:
+                                ctx.cleanup()
+
+                    asyncio.create_task(cleanup_if_no_ws())
             # --- Handle Normal Response ---
             else:
                 headers = [(b'Content-Type', b'text/html; charset=utf-8')]    
@@ -299,6 +318,25 @@ class PageQLApp:
                     'type': 'http.response.body',
                     'body': body_content.encode('utf-8'),
                 })
+
+                if client_id:
+                    async def cleanup_if_no_ws():
+                        try:
+                            msg = await receive()
+                        except Exception:
+                            return
+                        if not (
+                            isinstance(msg, dict)
+                            and msg.get("type") == "http.disconnect"
+                        ):
+                            return
+                        await asyncio.sleep(0.05)
+                        if client_id not in self.websockets:
+                            ctx = self.render_contexts.pop(client_id, None)
+                            if ctx:
+                                ctx.cleanup()
+
+                    asyncio.create_task(cleanup_if_no_ws())
 
         except sqlite3.Error as db_err:
             print(f"ERROR: Database error during render: {db_err}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -37,3 +37,32 @@ def test_app_returns_404_for_missing_route():
 
         assert status == 404
 
+
+def test_rendercontext_cleanup_without_ws():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "hello.pageql").write_text("{{#reactive on}}hi", encoding="utf-8")
+
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+
+            client_id = "cid"
+
+            def make_request():
+                conn = http.client.HTTPConnection("127.0.0.1", port)
+                conn.request("GET", f"/hello?clientId={client_id}")
+                resp = conn.getresponse()
+                resp.read()
+                conn.close()
+
+            await asyncio.to_thread(make_request)
+            await asyncio.sleep(0.2)
+            ctxs = dict(server.config.app.render_contexts)
+
+            server.should_exit = True
+            await task
+            return ctxs
+
+        ctxs = asyncio.run(run_test())
+
+        assert ctxs == {}
+


### PR DESCRIPTION
## Summary
- ensure render contexts clean up if no websocket connects
- test cleanup logic in async app

## Testing
- `pytest`