### PR TITLE
Fix add_reactive_elements handling for else bodies

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -248,12 +248,22 @@ def _apply_add_reactive(n):
 
     if isinstance(n, list):
         name = n[0]
-        if name in {"#if", "#ifdef", "#ifndef"}:
+        if name == "#if":
             res = [name, n[1], add_reactive_elements(n[2])]
-            for i in range(3, len(n), 2):
+            i = 3
+            while i < len(n):
+                if i == len(n) - 1:
+                    res.append(add_reactive_elements(n[i]))
+                    break
                 res.append(n[i])
                 if i + 1 < len(n):
                     res.append(add_reactive_elements(n[i + 1]))
+                i += 2
+            return res
+        if name in {"#ifdef", "#ifndef"}:
+            res = [name, n[1], add_reactive_elements(n[2])]
+            if len(n) > 3:
+                res.append(add_reactive_elements(n[3]))
             return res
         if name == "#from":
             return [name, n[1], add_reactive_elements(n[2])]

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -107,3 +107,31 @@ def test_delete_insert_input_and_text():
         ("text", "</p>"),
         ("#insert", "into todos(text, completed) values ('test', 0)"),
     ]
+
+
+def test_wrap_inside_else_branch():
+    snippet = (
+        "<div>{{#if 1}}<span>hi</span>{{#else}}<input value='{{x}}'>{{/if}}</div>"
+    )
+    tokens = tokenize(snippet)
+    body, _ = build_ast(tokens)
+    res = add_reactive_elements(body)
+    assert res == [
+        ("text", "<div>"),
+        [
+            "#if",
+            "1",
+            [("text", "<span>hi</span>")],
+            [
+                [
+                    "#reactiveelement",
+                    [
+                        ("text", "<input value='"),
+                        ("render_param", "x"),
+                        ("text", "'>"),
+                    ],
+                ]
+            ],
+        ],
+        ("text", "</div>"),
+    ]


### PR DESCRIPTION
## Summary
- ensure add_reactive_elements recursively processes `else` blocks
- add regression test for wrapping tags inside `else`

## Testing
- `pytest`