### PR TITLE
Support UPDATE statements without WHERE

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -156,6 +156,12 @@ class RenderContext:
         return mid
 
     def add_listener(self, signal, listener):
+        if signal.listeners is None:
+            signal.listeners = []
+            if hasattr(signal, "deps"):
+                for dep in signal.deps:
+                    if getattr(signal, "update", None) and signal.update not in getattr(dep, "listeners", []):
+                        dep.listeners.append(signal.update)
         signal.listeners.append(listener)
         self.listeners.append((signal, listener))
 

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -127,11 +127,14 @@ class ReactiveTable(Signal):
         """
         Update rows **one by one**, notifying listeners after each update.
         """
-        m = re.search(r'update\s+([^\s]+)\s+set\s+(.*?)\s+where\s+(.*?);?\s*$', sql, re.I | re.S)
+        m = re.search(r'update\s+([^\s]+)\s+set\s+(.*?)(?:\s+where\s+(.*?))?;?\s*$', sql, re.I | re.S)
         if not m:
             raise ValueError(f"Couldn’t parse UPDATE statement {sql}")
         table, set_sql, where = m.groups()
-        select_sql = f"SELECT * FROM {table} WHERE {where.rstrip()};"
+        select_sql = f"SELECT * FROM {table}"
+        if where:
+            select_sql += f" WHERE {where.rstrip()}"
+        select_sql += ";"
         cursor = self.conn.execute(select_sql, params)
         rows = cursor.fetchall()
         update_sql = f"UPDATE {table} SET {set_sql} WHERE {' AND '.join([f'{k} IS :_col{index}' for index, k in enumerate(self.columns)])} RETURNING * LIMIT 1"

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -321,15 +321,13 @@ def test_unionall_update():
     assert_eq(events[-1], [3, (1, 'x'), (1, 'y')])
 
 
-def test_update_invalid_sql_should_raise_value_error():
+def test_update_without_where_clause():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    try:
-        rt.update("UPDATE items SET name='z'", {})
-    except ValueError:
-        pass
-    else:
-        assert False, "expected ValueError"
+    rt.insert("INSERT INTO items(name) VALUES ('x')", {})
+    rt.update("UPDATE items SET name='z'", {})
+    result = conn.execute("SELECT name FROM items").fetchall()
+    assert result == [('z',)]
 
 
 def test_unionall_mismatched_columns():


### PR DESCRIPTION
## Summary
- restore listener state when signals are reused
- allow `ReactiveTable.update` to run without a WHERE clause
- adjust unit test to confirm update without WHERE works

## Testing
- `pytest`