### PR TITLE
Improve JS error logs

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -64,7 +64,7 @@ def reload_ws_script(client_id: str) -> str:
           try {{
             eval(event.data);
           }} catch (e) {{
-            console.error("Failed to eval script", e);
+            console.error("Failed to eval script", event.data, e);
           }}
         }}
       }};


### PR DESCRIPTION
## Summary
- include the faulty script in websocket error output

## Testing
- `pytest`