### PR TITLE
Fix memory leak on 404 in pageqlapp

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -495,6 +495,11 @@ class PageQLApp:
         else:
             client_id = await self.pageql_handler(scope, receive, send)
             message = await receive()
+            while isinstance(message, dict) and message.get("type") == "http.request":
+                if not message.get("more_body"):
+                    message = await receive()
+                    break
+                message = await receive()
             if (
                 isinstance(message, dict)
                 and message.get("type") == "http.disconnect"


### PR DESCRIPTION
## Summary
- swallow any leftover `http.request` events before waiting for `http.disconnect`

## Testing
- `pytest`