### PR TITLE
Enable WAL and caching for sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ pageql -path/to/your/database.sqlite ./templates
 *   `<path>`: (Required) Path to the SQLite database file.
 *   `<path>`: (Required) Path to the directory containing the PageQL template files (`.pageql`) to be served.
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
+*   PageQL automatically configures new SQLite databases with write-ahead logging
+    and an increased cache for better concurrency.
 
 *(Note: Actual command name and argument flags are subject to change.)*
 

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -320,6 +320,12 @@ class PageQL:
         self._modules = {} # Store parsed node lists here later
         self._parse_errors = {} # Store errors here
         self.db = sqlite3.connect(db_path)
+        # Configure SQLite for web server usage
+        with self.db:
+            self.db.execute("PRAGMA journal_mode=WAL")
+            self.db.execute("PRAGMA synchronous=NORMAL")
+            self.db.execute("PRAGMA temp_store=MEMORY")
+            self.db.execute("PRAGMA cache_size=10000")
         self.tables = Tables(self.db)
         self._from_cache = {}
 


### PR DESCRIPTION
## Summary
- configure SQLite with WAL and caching when PageQL opens a database
- document WAL defaults in README

## Testing
- `pytest` *(fails: test_render_cleanup_no_leaks)*