### PR TITLE
Skip reattaching dependencies when adding listeners

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -158,10 +158,6 @@ class RenderContext:
     def add_listener(self, signal, listener):
         if signal.listeners is None:
             signal.listeners = []
-            if hasattr(signal, "deps"):
-                for dep in signal.deps:
-                    if getattr(signal, "update", None) and signal.update not in getattr(dep, "listeners", []):
-                        dep.listeners.append(signal.update)
         signal.listeners.append(listener)
         self.listeners.append((signal, listener))
 


### PR DESCRIPTION
## Summary
- simplify `RenderContext.add_listener` by not reattaching signal dependencies

## Testing
- `pytest`