### PR TITLE
Fix DerivedSignal2 listener removal

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -135,10 +135,8 @@ class DerivedSignal2(Signal):
             self.listeners.remove(listener)
         if not self.listeners:
             for dep in self.deps:
-                if self._on_dep in getattr(dep, "listeners", []):
-                    dep.listeners.remove(self._on_dep)
-            if self._on_main in getattr(self.main, "listeners", []):
-                self.main.listeners.remove(self._on_main)
+                dep.remove_listener(self._on_dep)
+            self.main.remove_listener(self._on_main)
             self.listeners = None
 
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -575,9 +575,29 @@ def test_derived_signal2_remove_listener_detaches():
     assert d._on_main in a.listeners
     assert d._on_dep in use_a.listeners
     d.remove_listener(cb)
-    assert d._on_main not in a.listeners
-    assert d._on_dep not in use_a.listeners
+    assert d._on_main not in (a.listeners or [])
+    assert d._on_dep not in (use_a.listeners or [])
     assert d.listeners is None
+
+
+def test_derived_signal2_remove_listener_uses_remove_listener():
+    class Tracker(Signal):
+        def __init__(self, value=0):
+            super().__init__(value)
+            self.removed = []
+
+        def remove_listener(self, listener):
+            self.removed.append(listener)
+            super().remove_listener(listener)
+
+    main = Tracker(1)
+    dep = Tracker()
+    d = DerivedSignal2(lambda: main, [dep])
+    cb = lambda _=None: None
+    d.listeners.append(cb)
+    d.remove_listener(cb)
+    assert d._on_dep in dep.removed
+    assert d._on_main in main.removed
 
 
 def test_where_remove_listener_detaches_from_parent():


### PR DESCRIPTION
## Summary
- use `remove_listener` directly when detaching dependencies in `DerivedSignal2`

## Testing
- `pytest`
