### PR TITLE
Fix cleanup routines in reactive components

### DIFF
--- a/src/pageql/join.py
+++ b/src/pageql/join.py
@@ -212,7 +212,6 @@ class Join(Signal):
             self.listeners.remove(listener)
         if not self.listeners:
             for parent, cb in ((self.parent1, self._cb1), (self.parent2, self._cb2)):
-                if cb in getattr(parent, "listeners", []):
-                    parent.listeners.remove(cb)
+                parent.remove_listener(cb)
             self.listeners = None
 

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -58,6 +58,12 @@ class DerivedSignal(Signal):
     def update(self, _=None):
         self.set_value(self.f())
 
+    def remove_listener(self, listener):
+        super().remove_listener(listener)
+        if self.listeners is None:
+            for dep in self.deps:
+                dep.remove_listener(self.update)
+
     def replace(self, f, deps):
         """Replace the compute function and dependencies.
 

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -88,6 +88,12 @@ class FallbackReactive(Signal):
         self.rows = rows
         self._counts = new_counts
 
+    def remove_listener(self, listener):
+        super().remove_listener(listener)
+        if self.listeners is None:
+            for dep in self.deps:
+                dep.remove_listener(self._on_parent_event)
+
 
 
 def build_reactive(expr, tables: Tables):


### PR DESCRIPTION
## Summary
- ensure `DerivedSignal` detaches from dependencies when unused
- detach fallback SQL reactive components from tables
- use `remove_listener` in `Join` cleanup

## Testing
- `pytest`