### PR TITLE
Add --quiet option to pageql CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ pageql -path/to/your/database.sqlite ./templates
 *   `<path>`: (Required) Path to the SQLite database file.
 *   `<path>`: (Required) Path to the directory containing the PageQL template files (`.pageql`) to be served.
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
+*   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
 

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('--port', type=int, default=8000, help="Port number to run the server on.")
     parser.add_argument('--create', action='store_true', help="Create the database file if it doesn't exist.")
     parser.add_argument('--no-reload', action='store_true', help="Do not reload and refresh the templates on file changes.")
+    parser.add_argument('-q', '--quiet', action='store_true', help="Only show errors in output.")
 
     # If no arguments were provided (only the script name), print help and exit.
     if len(sys.argv) == 1:
@@ -28,15 +29,23 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
-    
-    app = PageQLApp(args.db_file, args.templates_dir, create_db=args.create, should_reload=not args.no_reload)
 
-    print(f"\nPageQL server running on http://localhost:{args.port}")
-    print(f"Using database: {args.db_file}")
-    print(f"Serving templates from: {args.templates_dir}")
-    print("Press Ctrl+C to stop.")
+    app = PageQLApp(
+        args.db_file,
+        args.templates_dir,
+        create_db=args.create,
+        should_reload=not args.no_reload,
+        quiet=args.quiet,
+    )
 
-    uvicorn.run(app, host="0.0.0.0", port=args.port)
+    if not args.quiet:
+        print(f"\nPageQL server running on http://localhost:{args.port}")
+        print(f"Using database: {args.db_file}")
+        print(f"Serving templates from: {args.templates_dir}")
+        print("Press Ctrl+C to stop.")
+
+    log_level = "error" if args.quiet else "info"
+    uvicorn.run(app, host="0.0.0.0", port=args.port, log_level=log_level)
 
 if __name__ == "__main__":
     main() 


### PR DESCRIPTION
## Summary
- add a `-q/--quiet` flag to the CLI to suppress info logs
- pass the quiet option through to `PageQLApp`
- respect quiet mode when printing startup information and internal messages
- document the new CLI flag in the README

## Testing
- `pytest`