### PR TITLE
Remove unused imports

### DIFF
--- a/examples/before_test.py
+++ b/examples/before_test.py
@@ -1,7 +1,7 @@
 import pageql
 import argparse
 import uvicorn
-import sqlite3, base64
+import base64
 
 
 parser = argparse.ArgumentParser(description="Run the PageQL development server.")

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -4,8 +4,6 @@ PageQL command-line interface
 """
 
 import argparse
-import asyncio
-import os
 import sys
 import uvicorn
 

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -685,4 +685,4 @@ class Tables:
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")
 
-from .join import Join
+from .join import Join  # noqa: F401 - re-export for convenience

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -2,7 +2,6 @@ import sqlglot
 from sqlglot import expressions as exp
 from .reactive import (
     Tables,
-    ReactiveTable,
     Select,
     Where,
     Union,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,6 @@ import types
 import tempfile
 import http.client
 import asyncio
-import pytest
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))

--- a/tests/test_evalone.py
+++ b/tests/test_evalone.py
@@ -11,7 +11,7 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 import pytest
 
 from pageql.pageql import evalone
-from pageql.reactive import DerivedSignal, DependentValue, Tables
+from pageql.reactive import DerivedSignal, Tables
 
 
 def _db():

--- a/tests/test_quote_state.py
+++ b/tests/test_quote_state.py
@@ -3,7 +3,6 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
-import pytest
 
 from pageql.parser import quote_state
 


### PR DESCRIPTION
## Summary
- clean up unused imports in CLI and examples
- stop exporting unused DependentValue in tests
- remove leftover pytest imports
- keep Join re-export but ignore lint warning

## Testing
- `ruff check --select F401,F841 .`
- `pytest`