### PR TITLE
Update reactive parsing interface

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -1,4 +1,5 @@
 import re
+import sqlglot
 
 def execute(conn, sql, params):
     try:
@@ -681,7 +682,8 @@ class Tables:
             self._get(table).delete(sql, params)
         elif lsql.startswith("select"):
             from .reactive_sql import parse_reactive
-            return parse_reactive(sql_strip, self, params)
+            expr = sqlglot.parse_one(sql_strip)
+            return parse_reactive(expr, self, params)
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")
 

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -137,23 +137,24 @@ _CACHE: dict[tuple[int, str], Signal] = {}
 
 
 def parse_reactive(
-    sql: str,
+    expr: exp.Expression,
     tables: Tables,
     params: dict[str, object] | None = None,
     *,
     cache: bool = True,
 ):
-    """Parse a SQL SELECT into reactive components.
+    """Parse a SQL ``Expression`` into reactive components.
 
-    Placeholders in *sql* are replaced using *params* before building the
+    Placeholders in *expr* are replaced using *params* before building the
     reactive expression tree.
     """
-    expr = sqlglot.parse_one(sql)
+    expr = expr.copy()
     _replace_placeholders(expr, params)
+    sql = expr.sql()
 
     cache_key = None
     if cache:
-        cache_key = (id(tables), expr.sql())
+        cache_key = (id(tables), sql)
         comp = _CACHE.get(cache_key)
         if comp is not None and comp.listeners:
             return comp

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -119,9 +119,9 @@ def test_from_reactive_uses_parse(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(sql, tables, params=None):
-        seen.append(sql)
-        return original(sql, tables, params)
+    def wrapper(expr, tables, params=None):
+        seen.append(expr.sql())
+        return original(expr, tables, params)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql
@@ -152,9 +152,9 @@ def test_from_reactive_caches_queries(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(sql, tables, params=None):
-        seen.append(sql)
-        return original(sql, tables, params)
+    def wrapper(expr, tables, params=None):
+        seen.append(expr.sql())
+        return original(expr, tables, params)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql
@@ -171,7 +171,7 @@ def test_from_reactive_caches_queries(monkeypatch):
     )
     r.load_module("m", snippet)
     r.render("/m")
-    assert seen.count("SELECT * FROM items where id=:v") == 1
+    assert seen.count("SELECT * FROM items WHERE id = :v") == 1
 
 
 def test_from_reactive_reparses_after_cleanup(monkeypatch):
@@ -180,9 +180,9 @@ def test_from_reactive_reparses_after_cleanup(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(sql, tables, params=None):
-        seen.append(sql)
-        return original(sql, tables, params)
+    def wrapper(expr, tables, params=None):
+        seen.append(expr.sql())
+        return original(expr, tables, params)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql


### PR DESCRIPTION
## Summary
- update `parse_reactive` to accept an already parsed sqlglot expression
- avoid reparsing in `process_node` when handling `#from`
- adapt helpers and tests to new interface

## Testing
- `pytest`