### PR TITLE
Rename DependentValue to OneValue

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -26,7 +26,7 @@ from pageql.reactive import (
     Signal,
     DerivedSignal,
     DerivedSignal2,
-    DependentValue,
+    OneValue,
     get_dependencies,
     Tables,
 )
@@ -281,7 +281,7 @@ def evalone(db, exp, params, reactive=False, tables=None):
         deps = [params[name] for name in dep_names if isinstance(params[name], Signal)]
         def _build():
             comp = parse_reactive(sql, tables, params)
-            return DependentValue(comp)
+            return OneValue(comp)
 
         dv = DerivedSignal2(_build, deps)
 

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -296,7 +296,7 @@ class CountAll(Signal):
             self.listeners = None
 
 
-class DependentValue(Signal):
+class OneValue(Signal):
     """Wrap a reactive relation expected to yield a single-column row."""
 
     def __init__(self, parent):
@@ -307,7 +307,7 @@ class DependentValue(Signal):
         if isinstance(cols, str):
             cols = [cols]
         if len(cols) != 1:
-            raise ValueError("DependentValue parent must have exactly one column")
+            raise ValueError("OneValue parent must have exactly one column")
         self.columns = cols[0]
         row = self.conn.execute(self.sql).fetchone()
         super().__init__(row[0] if row else None)
@@ -331,7 +331,7 @@ class DependentValue(Signal):
         if isinstance(cols, str):
             cols = [cols]
         if len(cols) != 1:
-            raise ValueError("DependentValue parent must have exactly one column")
+            raise ValueError("OneValue parent must have exactly one column")
 
         self.columns = cols[0]
         parent.listeners.append(self.onevent)

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -9,7 +9,7 @@ from .reactive import (
     CountAll,
     DerivedSignal,
     DerivedSignal2,
-    DependentValue,
+    OneValue,
     Signal,
 )
 
@@ -25,7 +25,7 @@ def _replace_placeholders(expr: exp.Expression, params: dict[str, object] | None
         if name not in params:
             continue
         val = params[name]
-        if isinstance(val, (DerivedSignal, DerivedSignal2, DependentValue)):
+        if isinstance(val, (DerivedSignal, DerivedSignal2, OneValue)):
             val = val.value
         if isinstance(val, (int, float)):
             lit = exp.Literal.number(val)

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -56,7 +56,7 @@ import sqlite3
 from pageql.reactive import (
     ReactiveTable,
     CountAll,
-    DependentValue,
+    OneValue,
     DerivedSignal,
     DerivedSignal2,
     Signal,
@@ -508,7 +508,7 @@ def test_dependent_value_reset():
     rt = ReactiveTable(conn, "items")
 
     cnt = CountAll(rt)
-    dv = DependentValue(cnt)
+    dv = OneValue(cnt)
     seen = []
     dv.listeners.append(seen.append)
 


### PR DESCRIPTION
## Summary
- rename `DependentValue` class to `OneValue`
- update imports and error messages
- adjust tests for new name

## Testing
- `pytest`