### PR TITLE
Move ReadOnly wrapper

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -3,7 +3,8 @@ PageQL: A template language for embedding SQL inside HTML directly
 """
 
 # Import the main classes from the PageQL modules
-from .pageql import PageQL, RenderResult, ReadOnly
+from .pageql import PageQL, RenderResult
+from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
 # Define the version

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -29,6 +29,7 @@ from pageql.reactive import (
     DependentValue,
     get_dependencies,
     Tables,
+    ReadOnly,
 )
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 import sqlglot
@@ -200,16 +201,6 @@ class RenderContext:
                 self.send_script(content)
             else:
                 self.scripts.append(content)
-
-
-class ReadOnly:
-    """Simple wrapper for read-only parameters."""
-
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self) -> str:  # pragma: no cover - trivial
-        return str(self.value)
 
 
 def db_execute_dot(db, exp, params):

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -31,6 +31,16 @@ class Signal:
             self.listeners = None
 
 
+class ReadOnly:
+    """Simple wrapper for read-only parameters."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return str(self.value)
+
+
 def get_dependencies(expr):
     """Return parameter names referenced in *expr*.
 
@@ -145,7 +155,7 @@ def _normalize_params(params):
 
     normalized = {}
     for k, v in params.items():
-        if isinstance(v, Signal) or getattr(v, "__class__", None).__name__ == "ReadOnly":
+        if isinstance(v, (Signal, ReadOnly)):
             normalized[k] = v.value
         else:
             normalized[k] = v


### PR DESCRIPTION
## Summary
- move the `ReadOnly` wrapper from `pageql.py` to `reactive.py`
- import `ReadOnly` from `reactive` in `pageql` and package `__init__`
- update normalization logic to check for the class directly

## Testing
- `pytest`