### PR TITLE
Fix evalone single value reactive handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -272,8 +272,8 @@ def evalone(db, exp, params, reactive=False, tables=None):
         deps = [params[name] for name in dep_names if isinstance(params[name], Signal)]
         def _build():
             expr = sqlglot.parse_one(sql)
-            comp = parse_reactive(expr, tables, params)
-            return OneValue(comp)
+            comp = parse_reactive(expr, tables, params, one_value=True)
+            return comp
 
         dv = DerivedSignal2(_build, deps)
 

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -143,6 +143,7 @@ def parse_reactive(
     params: dict[str, object] | None = None,
     *,
     cache: bool = True,
+    one_value: bool = False,
 ):
     """Parse a SQL ``Expression`` into reactive components.
 
@@ -155,7 +156,7 @@ def parse_reactive(
 
     cache_key = None
     if cache:
-        cache_key = (id(tables), sql)
+        cache_key = (id(tables), sql, one_value)
         comp = _CACHE.get(cache_key)
         if comp is not None and comp.listeners:
             return comp
@@ -167,6 +168,9 @@ def parse_reactive(
             comp = build_reactive(expr, tables)
         except NotImplementedError:
             comp = FallbackReactive(tables, sql, expr)
+
+    if one_value:
+        comp = OneValue(comp)
 
     if cache:
         _CACHE[cache_key] = comp

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -119,9 +119,9 @@ def test_from_reactive_uses_parse(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(expr, tables, params=None):
+    def wrapper(expr, tables, params=None, **kwargs):
         seen.append(expr.sql())
-        return original(expr, tables, params)
+        return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql
@@ -152,9 +152,9 @@ def test_from_reactive_caches_queries(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(expr, tables, params=None):
+    def wrapper(expr, tables, params=None, **kwargs):
         seen.append(expr.sql())
-        return original(expr, tables, params)
+        return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql
@@ -180,9 +180,9 @@ def test_from_reactive_reparses_after_cleanup(monkeypatch):
     seen = []
     original = rsql.parse_reactive
 
-    def wrapper(expr, tables, params=None):
+    def wrapper(expr, tables, params=None, **kwargs):
         seen.append(expr.sql())
-        return original(expr, tables, params)
+        return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
     import pageql.pageql as pql


### PR DESCRIPTION
## Summary
- let parse_reactive optionally return a single value
- use parse_reactive(one_value=True) in `evalone`
- update tests for new parse_reactive argument

## Testing
- `pytest`