### PR TITLE
Preparse #if expressions only

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -830,7 +830,7 @@ class PageQL:
                             j += 1
 
                     cond_vals = [
-                        evalone(self.db, ce, params, True, self.tables) if ce is not None else True
+                        evalone(self.db, ce[0], params, True, self.tables, ce[1]) if ce is not None else True
                         for ce in cond_exprs
                     ]
                     signals = [v for v in cond_vals if isinstance(v, Signal)]
@@ -903,7 +903,8 @@ class PageQL:
                     i = 1
                     while i < len(node):
                         if i + 1 < len(node):
-                            if not evalone(self.db, node[i], params, reactive, self.tables):
+                            expr = node[i]
+                            if not evalone(self.db, expr[0], params, reactive, self.tables, expr[1]):
                                 i += 2
                                 continue
                             i += 1

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -20,14 +20,14 @@ def test_no_wrap_when_closed_in_same_node():
 def test_wrap_across_directive():
     nodes = [
         ("text", "<div"),
-        ["#if", "cond", [("text", "class='x'")], []],
+        ["#if", ("cond", sqlglot.parse_one("SELECT cond")), [("text", "class='x'")], []],
         ("text", ">x</div>")
     ]
     res = add_reactive_elements(nodes)
     assert res == [
         ["#reactiveelement", [
             ("text", "<div"),
-            ["#if", "cond", [("text", "class='x'")], []],
+            ["#if", ("cond", sqlglot.parse_one("SELECT cond")), [("text", "class='x'")], []],
             ("text", ">")
         ]],
         ("text", "x</div>")
@@ -37,7 +37,7 @@ def test_wrap_across_directive():
 def test_wrap_with_directive_and_surrounding_text():
     nodes = [
         ("text", "hello <input "),
-        ["#if", "a", [("text", "checked")], []],
+        ["#if", ("a", sqlglot.parse_one("SELECT a")), [("text", "checked")], []],
         ("text", "type='submit'> world"),
     ]
     res = add_reactive_elements(nodes)
@@ -45,7 +45,7 @@ def test_wrap_with_directive_and_surrounding_text():
         ("text", "hello "),
         ["#reactiveelement", [
             ("text", "<input "),
-            ["#if", "a", [("text", "checked")], []],
+            ["#if", ("a", sqlglot.parse_one("SELECT a")), [("text", "checked")], []],
             ("text", "type='submit'>"),
         ]],
         ("text", " world"),
@@ -55,7 +55,7 @@ def test_wrap_with_directive_and_surrounding_text():
 def test_input_if_inside_paragraph():
     nodes = [
         ("text", "<p>Active count is 1: <input type='checkbox' "),
-        ["#if", ":active_count == 1", [("text", "checked")]],
+        ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1")), [("text", "checked")]],
         ("text", "></p>")
     ]
     res = add_reactive_elements(nodes)
@@ -63,7 +63,7 @@ def test_input_if_inside_paragraph():
         ("text", "<p>Active count is 1: "),
         ["#reactiveelement", [
             ("text", "<input type='checkbox' "),
-            ["#if", ":active_count == 1", [("text", "checked")]],
+            ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1")), [("text", "checked")]],
             ("text", ">")
         ]],
         ("text", "</p>")
@@ -98,7 +98,7 @@ def test_delete_insert_input_and_text():
                 ("text", "<input class=\"toggle"),
                 ("render_expression", "3"),
                 ("text", "\" type=\"checkbox\" "),
-                ["#if", "1", [("text", "checked")]],
+                ["#if", ("1", sqlglot.parse_one("SELECT 1")), [("text", "checked")]],
                 ("text", ">"),
             ],
         ],
@@ -126,7 +126,7 @@ def test_wrap_inside_else_branch():
         ("text", "<div>"),
         [
             "#if",
-            "1",
+            ("1", sqlglot.parse_one("SELECT 1")),
             [("text", "<span>hi</span>")],
             [
                 [


### PR DESCRIPTION
## Summary
- parse expressions for `#if` and `#elif` when building the AST
- revert changes to `#ifdef` and `#ifndef`
- keep runtime evaluation for `#if` tuples

## Testing
- `pytest`