### PR TITLE
Add watchers benchmark for Todos

### DIFF
--- a/benchmarks/benchmark_todos_with_watchers.py
+++ b/benchmarks/benchmark_todos_with_watchers.py
@@ -1,0 +1,58 @@
+import os
+import time
+import tempfile
+from pathlib import Path
+from pageql.pageql import PageQL
+import cProfile
+import pstats
+import io
+
+RENDER_WATCHERS = 1000
+INSERTS = 20
+TOGGLE_ITERATIONS = 100
+
+
+def run_benchmark(db_path: str) -> None:
+    print(f"Benchmarking todos.pageql watchers using {db_path} ...")
+    pql = PageQL(db_path)
+    pql.db.execute(
+        "CREATE TABLE IF NOT EXISTS todos (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT, completed BOOLEAN)"
+    )
+    pql.db.commit()
+    src_path = Path(__file__).resolve().parents[1] / "website" / "todos.pageql"
+    pql.load_module("todos", src_path.read_text(encoding="utf-8"))
+
+    # create watchers
+    ctx = None
+    for _ in range(RENDER_WATCHERS):
+        ctx = pql.render("/todos", reactive=True).context
+    # insert todos
+    for i in range(INSERTS):
+        pql.db.execute(
+            "INSERT INTO todos (text, completed) VALUES (?, 0)",
+            (f"Todo {i}",),
+        )
+    pql.db.commit()
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    start = time.perf_counter()
+    for i in range(TOGGLE_ITERATIONS):
+        tid = (i % INSERTS) + 1
+        pql.render("/todos", partial=f"{tid}/toggle", http_verb="POST")
+    elapsed = time.perf_counter() - start
+    profiler.disable()
+
+    pql.db.close()
+    assert ctx is not None
+    print(f"{(elapsed/TOGGLE_ITERATIONS)*1000:.4f}ms per toggle")
+    s = io.StringIO()
+    pstats.Stats(profiler, stream=s).strip_dirs().sort_stats("cumulative").print_stats(20)
+    print(s.getvalue())
+    print("scripts array length:", len(ctx.scripts))
+    assert len(ctx.scripts) == TOGGLE_ITERATIONS * 3
+
+
+if __name__ == "__main__":
+    with tempfile.TemporaryDirectory() as tmp:
+        run_benchmark(os.path.join(tmp, "bench.db"))


### PR DESCRIPTION
## Summary
- add `benchmark_todos_with_watchers` to measure toggle performance with many watchers

## Testing
- `pytest`