### PR TITLE
Adjust tests for param reset restriction

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -53,7 +53,12 @@ def test_reactive_set_variable_in_browser():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         Path(tmpdir, "react.pageql").write_text(
-            "{{#reactive on}}{{#set a 'ww'}}hello {{a}}{{#set a 'world'}}",
+            "{{#create table vars(val TEXT)}}"
+            "{{#insert into vars(val) values ('ww')}}"
+            "{{#reactive on}}"
+            "{{#set a (select val from vars)}}"
+            "hello {{a}}"
+            "{{#update vars set val = 'world'}}",
             encoding="utf-8",
         )
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -67,11 +67,13 @@ def test_reactive_count_with_param_dependency():
         "{{#insert into nums(value) values (1)}}"
         "{{#insert into nums(value) values (2)}}"
         "{{#insert into nums(value) values (3)}}"
+        "{{#create table vars(val INTEGER)}}"
+        "{{#insert into vars(val) values (1)}}"
         "{{#reactive on}}"
-        "{{#set a 1}}"
+        "{{#set a (select val from vars)}}"
         "{{#set cnt count(*) from nums where value > :a}}"
         "{{cnt}}"
-        "{{#set a 2}}"
+        "{{#update vars set val = 2}}"
         "{{#delete from nums where value = 3}}"
     )
     r.load_module("m", snippet)


### PR DESCRIPTION
## Summary
- update one reactive count test to use a helper table so params aren't reset
- tweak browser reactive variable test to assert the full value again

## Testing
- `pytest` *(fails: 11 failed, 116 passed)*