### PR TITLE
Fix reactive set test

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -256,7 +256,8 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
                 return val.value
             return val
         
-    exp = "select " + exp
+    if not re.match(r"(?i)^\s*(select|\(select)", exp):
+        exp = "select " + exp
 
     if reactive:
         sql = re.sub(

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -163,8 +163,14 @@ def _read_block(node_list, i, stop, partials):
 
         if ntype == "#set":
             var, rest = parsefirstword(ncontent)
+            sql = rest or ""
+            sql_strip = sql.lstrip().lower()
+            if sql_strip.startswith("select") or sql_strip.startswith("(select"):
+                parse_sql = sql
+            else:
+                parse_sql = "SELECT " + sql
             try:
-                expr = sqlglot.parse_one("SELECT " + (rest or ""))
+                expr = sqlglot.parse_one(parse_sql)
             except Exception as e:  # pragma: no cover - invalid SQL
                 raise SyntaxError(f"bad SQL in #set: {e}")
             i += 1


### PR DESCRIPTION
## Summary
- handle subquery expressions in `#set`
- avoid adding an extra SELECT in `evalone`

## Testing
- `pytest tests/test_browser_integration.py::test_reactive_set_variable_in_browser -vv`
- `pytest tests/test_browser_integration.py::test_todos_add_partial_in_separate_page -vv`
- `pytest`