### PR TITLE
Prevent #set from overwriting parameters

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -650,8 +650,8 @@ class PageQL:
                 if var[0] == ':':
                     var = var[1:]
                 var = var.replace('.', '__')
-                #if var in params:
-                #    raise ValueError(f"Parameter '{var}' is already set")
+                if var in params:
+                    raise ValueError(f"Parameter '{var}' is already set")
                 if isinstance(params.get(var), ReadOnly):
                     raise ValueError(f"Parameter '{var}' is read only")
                 if reactive:


### PR DESCRIPTION
## Summary
- disallow overwriting existing parameter values in `#set`

## Testing
- `pytest` *(fails: ValueError when tests expect overwriting to work)*
