### PR TITLE
Fix test warnings

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -317,8 +317,8 @@ class PageQL:
         Args:
             db_path: Path to the SQLite database file to be used.
         """
-        self._modules = {} # Store parsed node lists here later
-        self._parse_errors = {} # Store errors here
+        self._modules = {}  # Store parsed node lists here later
+        self._parse_errors = {}  # Store errors here
         self.db = sqlite3.connect(db_path)
         # Configure SQLite for web server usage
         with self.db:
@@ -328,6 +328,18 @@ class PageQL:
             self.db.execute("PRAGMA cache_size=10000")
         self.tables = Tables(self.db)
         self._from_cache = {}
+
+    def close(self):
+        """Close the underlying SQLite connection."""
+        if getattr(self, "db", None):
+            self.db.close()
+            self.db = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def load_module(self, name, source):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,26 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r"websockets\.server\.WebSocketServerProtocol is deprecated",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore",
+    message="remove second argument of ws_handler",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore",
+    message=r"This process .* fork\(\) may lead to deadlocks in the child.",
+    category=DeprecationWarning,
+)
+warnings.filterwarnings(
+    "ignore",
+    message=r"websockets\.legacy is deprecated;.*",
+    category=DeprecationWarning,
+)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,6 +4,17 @@ import types
 import tempfile
 import http.client
 import asyncio
+import pytest
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:websockets.legacy is deprecated;.*", category=DeprecationWarning
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:websockets.server.WebSocketServerProtocol is deprecated",
+        category=DeprecationWarning,
+    ),
+]
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -3,11 +3,26 @@ import importlib.util
 import tempfile
 import types
 from pathlib import Path
+import warnings
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:websockets.server.WebSocketServerProtocol is deprecated",
+        category=DeprecationWarning,
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:remove second argument of ws_handler", category=DeprecationWarning
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:This process .* fork\\(\\) may lead to deadlocks in the child.",
+        category=DeprecationWarning,
+    ),
+]
 
 from pageql.pageqlapp import PageQLApp
 from playwright_helpers import load_page


### PR DESCRIPTION
## Summary
- close the SQLite connection when a PageQL engine is deleted
- ignore deprecation warnings from gevent and websockets in tests
- filter remaining warnings in integration and app tests

## Testing
- `pytest`