### PR TITLE
Fix async integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,9 @@ import types
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+async def _awatch_stub(*args, **kwargs):
+    if False:
+        yield None
+
+sys.modules["watchfiles"].awatch = _awatch_stub


### PR DESCRIPTION
## Summary
- mark browser integration tests for async execution and call async helpers
- switch to a headless Playwright browser
- provide async `awatch` stub for tests

## Testing
- `pytest`