### PR TITLE
Implement derive_signal2 helper

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -26,6 +26,7 @@ from pageql.reactive import (
     Signal,
     DerivedSignal,
     DerivedSignal2,
+    derive_signal2,
     OneValue,
     get_dependencies,
     Tables,
@@ -295,7 +296,7 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         dv = _DV_CACHE.get(cache_key)
         if dv is not None and dv.listeners:
             return dv
-        dv = DerivedSignal2(_build, deps)
+        dv = derive_signal2(_build, deps)
         _DV_CACHE[cache_key] = dv
         return dv
 

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -150,6 +150,16 @@ class DerivedSignal2(Signal):
             self.listeners = None
 
 
+def derive_signal2(f, deps):
+    """Return a :class:`DerivedSignal2` tracking *deps* if any are writable."""
+
+    if not deps or all(isinstance(d, ReadOnly) for d in deps):
+        return f()
+
+    deps = [d for d in deps if isinstance(d, Signal)]
+    return DerivedSignal2(f, deps)
+
+
 def _normalize_params(params):
     """Return a copy of *params* with signal-like objects replaced by their values."""
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -59,6 +59,7 @@ from pageql.reactive import (
     OneValue,
     DerivedSignal,
     DerivedSignal2,
+    derive_signal2,
     Signal,
     Where,
     UnionAll,
@@ -67,6 +68,7 @@ from pageql.reactive import (
     Join,
     Select,
     get_dependencies,
+    ReadOnly,
 )
 from pageql.pageql import RenderContext, Tables, evalone
 
@@ -598,6 +600,13 @@ def test_derived_signal2_remove_listener_uses_remove_listener():
     d.remove_listener(cb)
     assert d._on_dep in dep.removed
     assert d._on_main in main.removed
+
+
+def test_derive_signal2_returns_signal_if_all_readonly():
+    main = Signal(1)
+    ro1 = ReadOnly(1)
+    res = derive_signal2(lambda: main, [ro1])
+    assert res is main
 
 
 def test_evalone_cache_without_params_reuses_signal():


### PR DESCRIPTION
## Summary
- add `derive_signal2` helper to skip wrapping when deps are read-only
- use it in `evalone`
- test `derive_signal2` behaviour

## Testing
- `pytest` *(fails: command not found)*