### PR TITLE
Implement ReadOnly returns for constant reactive queries

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -291,11 +291,14 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
                 expr = sqlglot.parse_one(sql)
             #print("parse_reactive: ", expr.sql())
             comp = parse_reactive(expr, tables, params, one_value=True)
+            if isinstance(comp, ReadOnly):
+                return DerivedSignal(lambda v=comp.value: v, [])
             return comp
         cache_key = (id(tables), sql, tuple(dep_keys))
         dv = _DV_CACHE.get(cache_key)
-        if dv is not None and dv.listeners:
-            return dv
+        if dv is not None:
+            if not hasattr(dv, "listeners") or dv.listeners:
+                return dv
         dv = derive_signal2(_build, deps)
         _DV_CACHE[cache_key] = dv
         return dv

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -169,6 +169,15 @@ def parse_reactive(
         except NotImplementedError:
             comp = FallbackReactive(tables, sql, expr)
 
+    # If the expression references no tables the result is constant, so
+    # return a simple ReadOnly wrapper instead of a reactive component.
+    if not list(expr.find_all(exp.Table)):
+        if one_value:
+            row = tables.conn.execute(sql).fetchone()
+            return ReadOnly(row[0] if row else None)
+        rows = tables.conn.execute(sql).fetchall()
+        return ReadOnly(rows)
+
     if one_value:
         comp = OneValue(comp)
 

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -11,6 +11,7 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.reactive import Tables, ReactiveTable, Select, Where, CountAll, UnionAll
 from pageql.reactive_sql import parse_reactive, FallbackReactive
+from pageql.reactive import ReadOnly
 
 
 def _db():
@@ -113,6 +114,5 @@ def test_parse_select_constant():
     sql = "SELECT 42 AS answer"
     expr = sqlglot.parse_one(sql)
     comp = parse_reactive(expr, tables, {})
-    assert isinstance(comp, FallbackReactive)
-    assert comp.deps == []
-    assert_sql_equivalent(conn, sql, comp.sql)
+    assert isinstance(comp, ReadOnly)
+    assert comp.value == [(42,)]


### PR DESCRIPTION
## Summary
- return a `ReadOnly` result from `parse_reactive` when the expression has no table dependencies
- handle `ReadOnly` objects in `evalone` caching
- ensure `evalone` always returns a `Signal` for reactive expressions
- update tests for constant queries

## Testing
- `pytest`