### PR TITLE
Set reactive mode as default

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -1024,7 +1024,7 @@ class PageQL:
         return reactive
 
     def render(self, path, params={}, partial=None, http_verb=None,
-               in_render_directive=False, reactive=False, ctx=None):
+               in_render_directive=False, reactive=True, ctx=None):
         """
         Renders a module using its parsed AST.
 

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -11,7 +11,7 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
-from benchmarks.benchmark_pageql import MODULES, SCENARIOS, bench_factory, reset_items
+from benchmarks.benchmark_pageql import MODULES, SCENARIOS, bench_factory, reset_items, PARAMS
 
 ITERATIONS = 1000
 
@@ -25,7 +25,7 @@ def test_render_cleanup_no_leaks(tmp_path):
             if m != 'other' and m != name:
                 continue
             pql.load_module(m, src)
-        bench = bench_factory(name)
+        bench = lambda p, n=name: p.render('/' + n, PARAMS.get(n, {}), reactive=False)
         # Warm up caches
         result = bench(pql)
         if result.context:

--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -9,6 +9,11 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 __doc__ = """
 >>> from pageql.pageql import PageQL
 >>> r = PageQL(":memory:")
+>>> _render = r.render
+>>> def render_nonreactive(*a, **k):
+...     k.setdefault('reactive', False)
+...     return _render(*a, **k)
+>>> r.render = render_nonreactive
 >>> r.load_module("include_test", '''This is included
 ... {{#partial p}}
 ...   included partial {{z}}


### PR DESCRIPTION
## Summary
- default `PageQL.render` reactive mode to `True`
- adapt tests for new default
  - adjust reactive toggle expectations
  - override rendering in doctest to keep outputs non-reactive
  - call render with `reactive=False` in leak test
- keep todos example working without explicit `#reactive on`

## Testing
- `pytest`