### PR TITLE
Fix reactiveelement script emission for ReadOnly content

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -785,7 +785,7 @@ class PageQL:
                 signals = ctx.reactiveelement
                 ctx.reactiveelement = prev
                 out.extend(buf)
-                if reactive and ctx:
+                if reactive and ctx and signals:
                     ctx.ensure_init()
                     mid = ctx.marker_id()
                     ctx.append_script(f"pprevioustag({mid})", out)


### PR DESCRIPTION
## Summary
- avoid emitting `pprevioustag` markers when a `#reactiveelement` contains no reactive signals
- adjust tests for new behaviour
- add regression test to ensure constant `#reactiveelement` output contains no script tags
- adapt pinsert escape test to include explicit script content

## Testing
- `pytest`