### PR TITLE
Track dependencies for #from nodes

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -924,7 +924,10 @@ class PageQL:
                     reactive = self.process_nodes(body, params, path, includes, http_verb, reactive, ctx, out)
             elif directive == '#from':
                 query, expr = node[1]
-                body = node[2]
+                if len(node) == 4:
+                    _, _, deps, body = node
+                else:
+                    body = node[2]
 
                 if reactive:
                     sql = "SELECT * FROM " + query

--- a/tests/test_from_dependencies.py
+++ b/tests/test_from_dependencies.py
@@ -1,0 +1,14 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast
+
+
+def test_from_node_has_dependencies():
+    tokens = tokenize("{{#from items where id=:x}}{{#if :y}}ok{{/if}}{{/from}}")
+    body, _ = build_ast(tokens)
+    from_node = body[0]
+    assert from_node[0] == "#from"
+    assert from_node[2] == {"x", "y"}


### PR DESCRIPTION
## Summary
- capture SQL parameter dependencies for `#from` directives during parsing
- keep `#from` AST handling compatible in reactive element wrapping and dependency walks
- test that dependency sets are recorded in the AST

## Testing
- `pytest`