### PR TITLE
Remove unused query dependency

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -159,8 +159,7 @@ def _read_block(node_list, i, stop, partials):
             if node_list[i][0] != "/from":
                 raise SyntaxError("missing {{/from}}")
             i += 1
-            deps = set(get_dependencies("SELECT * FROM " + query))
-            deps.update(ast_param_dependencies(loop_body))
+            deps = ast_param_dependencies(loop_body)
             body.append(["#from", (query, expr), deps, loop_body])
             continue
 

--- a/tests/test_from_dependencies.py
+++ b/tests/test_from_dependencies.py
@@ -11,4 +11,4 @@ def test_from_node_has_dependencies():
     body, _ = build_ast(tokens)
     from_node = body[0]
     assert from_node[0] == "#from"
-    assert from_node[2] == {"x", "y"}
+    assert from_node[2] == {"y"}


### PR DESCRIPTION
## Summary
- drop query dependencies for `#from` blocks in parser
- adjust test expectations

## Testing
- `pytest`