### PR TITLE
Add cachable flag to #from events

### DIFF
--- a/tests/test_cachable_onevent.py
+++ b/tests/test_cachable_onevent.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+from pageql.pageql import PageQL
+
+
+def setup_items(r):
+    r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
+
+
+def test_from_cachable_true_with_column_param():
+    r = PageQL(":memory:")
+    setup_items(r)
+    r.load_module(
+        "m",
+        "{{#reactive on}}{{#from items}}{{#if :name}}x{{/if}}{{/from}}",
+    )
+    result = r.render("/m")
+    listener = result.context.listeners[0][1]
+    assert listener.__kwdefaults__["cachable"] is True
+
+
+def test_from_cachable_false_with_external_param():
+    r = PageQL(":memory:")
+    setup_items(r)
+    r.load_module(
+        "m",
+        "{{#reactive on}}{{#from items}}{{#if :other}}x{{/if}}{{/from}}",
+    )
+    result = r.render("/m", params={"other": 1})
+    listener = result.context.listeners[0][1]
+    assert listener.__kwdefaults__["cachable"] is False


### PR DESCRIPTION
## Summary
- compute whether parameters used inside `#from` come from the table columns
- expose this as `cachable` for the `onevent` listener
- adjust variable name in `#dump` directive to avoid masking builtins
- test cachable flag behavior

## Testing
- `pytest`