### PR TITLE
Add from-event caching

### DIFF
--- a/tests/test_onevent_cache.py
+++ b/tests/test_onevent_cache.py
@@ -1,0 +1,39 @@
+import sys, types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *a, **k: None
+
+from pageql.pageql import PageQL
+
+
+def setup_items(r):
+    r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
+
+
+def test_onevent_global_cache(monkeypatch):
+    r = PageQL(":memory:")
+    setup_items(r)
+    r.load_module("m", "{{#reactive on}}{{#from items}}[{{name}}]{{/from}}")
+
+    calls = []
+    original = PageQL.process_nodes
+
+    def wrapper(self, nodes, params, path, includes, http_verb=None, reactive=False, ctx=None, out=None):
+        calls.append(True)
+        return original(self, nodes, params, path, includes, http_verb, reactive, ctx, out)
+
+    monkeypatch.setattr(PageQL, "process_nodes", wrapper)
+
+    ctx1 = r.render("/m").context
+    ctx2 = r.render("/m").context
+    before = len(calls)
+
+    r.tables.executeone("INSERT INTO items(name) VALUES ('c')", {})
+
+    after = len(calls)
+    ctx1.cleanup()
+    ctx2.cleanup()
+    assert after - before == 1


### PR DESCRIPTION
## Summary
- add global `_ONEVENT_CACHE` for caching `#from` on_event output
- store cached rows for insert/update events and clear cache after rendering
- test that multiple listeners share cached event output

## Testing
- `pytest`