### PR TITLE
Add fallback app to PageQLApp

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,3 +36,40 @@ def test_app_returns_404_for_missing_route():
 
         assert status == 404
 
+
+def test_fallback_app_handles_unknown_route():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        async def run_test():
+            async def fallback(scope, receive, send):
+                await send(
+                    {
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [(b"content-type", b"text/plain")],
+                    }
+                )
+                await send({"type": "http.response.body", "body": b"fallback"})
+
+            server, task, port = await run_server_in_task(tmpdir)
+            server.config.app.fallback_app = fallback
+
+            def make_request():
+                conn = http.client.HTTPConnection("127.0.0.1", port)
+                conn.request("GET", "/missing")
+                resp = conn.getresponse()
+                body = resp.read().decode()
+                status = resp.status
+                conn.close()
+                return status, body
+
+            status_body = await asyncio.to_thread(make_request)
+
+            server.should_exit = True
+            await task
+            return status_body
+
+        status, body = asyncio.run(run_test())
+
+        assert status == 200
+        assert body == "fallback"
+


### PR DESCRIPTION
## Summary
- allow PageQLApp to delegate unknown paths to a fallback ASGI app
- test fallback handler behavior

## Testing
- `pytest`