### PR TITLE
Add float parameter validation

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -425,9 +425,10 @@ class PageQL:
             try:
                 if param_type == 'integer':
                     param_value = int(param_value)
-                elif param_type == 'boolean': # Basic truthiness
+                elif param_type == 'float':
+                    param_value = float(param_value)
+                elif param_type == 'boolean':  # Basic truthiness
                     param_value = bool(param_value) and str(param_value).lower() not in ['0', 'false', '']
-                # Add float later if needed
                 else: # Default to string
                     param_value = str(param_value)
 
@@ -443,14 +444,18 @@ class PageQL:
                     pattern = attrs['pattern']
                     if not re.match(pattern, param_value):
                         raise ValueError(f"Parameter '{param_name}' does not match pattern '{pattern}'.")
-                if param_type == 'integer' and 'min' in attrs:
-                    minval = int(attrs['min'])
+                if param_type in ('integer', 'float') and 'min' in attrs:
+                    minval = float(attrs['min']) if param_type == 'float' else int(attrs['min'])
                     if param_value < minval:
-                        raise ValueError(f"Parameter '{param_name}' value {param_value} is less than min {minval}.")
-                if param_type == 'integer' and 'max' in attrs:
-                    maxval = int(attrs['max'])
+                        raise ValueError(
+                            f"Parameter '{param_name}' value {param_value} is less than min {minval}."
+                        )
+                if param_type in ('integer', 'float') and 'max' in attrs:
+                    maxval = float(attrs['max']) if param_type == 'float' else int(attrs['max'])
                     if param_value > maxval:
-                        raise ValueError(f"Parameter '{param_name}' value {param_value} is greater than max {maxval}.")
+                        raise ValueError(
+                            f"Parameter '{param_name}' value {param_value} is greater than max {maxval}."
+                        )
                 if param_type == 'boolean' and 'required' in attrs:
                     if param_value is None:
                         raise ValueError(f"Parameter '{param_name}' is required but was not provided.")

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -1,0 +1,24 @@
+import sys, types
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *a, **k: None
+sys.path.insert(0, "src")
+
+import pytest
+from pageql.pageql import PageQL
+
+
+def test_param_float_validation():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#param val type=float min=1.5 max=3.5}}{{val}}")
+    result = r.render("/m", {"val": "2.0"}, reactive=False)
+    assert result.body == "2.0"
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", {"val": "1"}, reactive=False)
+    assert "less than min 1.5" in str(exc.value)
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", {"val": "4"}, reactive=False)
+    assert "greater than max 3.5" in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", {"val": "abc"}, reactive=False)
+    assert "failed type/validation 'float'" in str(exc.value)


### PR DESCRIPTION
## Summary
- recognize `type=float` in `handle_param`
- validate float range with `min` and `max`
- test float parameter validation including errors

## Testing
- `pytest`