### PR TITLE
Add header and cookie directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ pageql -path/to/your/database.sqlite ./templates
 
 *   `#statuscode <expression>`: Sets the HTTP response status code.
 *   `#redirect <url_expression>`: Performs an HTTP redirect by setting the `Location` header and status code to 302.
-*   [NOT IMPLEMENTED] `#header <name> <value_expression>`: Sets an HTTP response header. The `<name>` (e.g., `Cache-Control`, `"X-Custom-Header"`) and `<value_expression>` (e.g., `"no-cache"`, `:some_variable`) are required positional arguments. Must typically be used before any HTML output. Example: `#header Cache-Control "no-cache, no-store, must-revalidate"`
-*   [NOT IMPLEMENTED] `#cookie <name> <expression> [options...]`: Sets an outgoing HTTP cookie. The `<name>` is a literal string, and the `<expression>` is evaluated to determine the cookie's value. Standard cookie options like `expires="..."`, `path="..."`, `domain="..."`, `secure`, and `httponly` can be provided as subsequent optional attributes. (Reading incoming cookies is handled via standard variable access, e.g., `:param_name` or potentially a dedicated scope like `:cookie_name`).
+*   `#header <name> <value_expression>`: Sets an HTTP response header. The `<name>` (e.g., `Cache-Control`, `"X-Custom-Header"`) and `<value_expression>` (e.g., `"no-cache"`, `:some_variable`) are required positional arguments. Example: `#header Cache-Control "no-cache, no-store, must-revalidate"`.
+*   `#cookie <name> <expression> [options...]`: Sets an outgoing HTTP cookie. The `<name>` is a literal string and `<expression>` is evaluated to determine the cookie value. Optional attributes like `expires="..."`, `path="..."`, `domain="..."`, `secure`, and `httponly` may follow.
 *   [NOT IMPLEMENTED] `#contenttype <expression>`: Sets the `Content-Type` HTTP response header (e.g., `text/html; charset=utf-8`).
 
 When a directive is mistyped or unrecognized, PageQL prints a list of valid directives with short syntax hints. These hints show minimal syntax like `#insert into <table> (cols) values (vals)`, `#update <table> set ... where ...`, or `#delete from <table> where ...`. This quick reference can help diagnose typos during development.

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -303,12 +303,19 @@ class PageQLApp:
 
             # --- Handle Redirect ---
             if result.redirect_to:
+                headers = [(b'Location', result.redirect_to)]
+                for name, value in result.headers:
+                    headers.append((name.encode('utf-8'), value.encode('utf-8')))
+                for name, value, opts in result.cookies:
+                    parts = [f"{name}={value}"]
+                    for k, v in opts.items():
+                        parts.append(k if v is True else f"{k}={v}")
+                    headers.append((b'Set-Cookie', "; ".join(parts).encode('utf-8')))
                 await send({
                     'type': 'http.response.start',
                     'status': result.status_code,
-                    'headers': [(b'Location', result.redirect_to)],
+                    'headers': headers,
                 })
-                # Send other headers added by #header or #cookie? (Currently not implemented in RenderResult)
                 await send({
                     'type': 'http.response.body',
                     'body': result.body.encode('utf-8'),
@@ -316,9 +323,14 @@ class PageQLApp:
                 self._log(f"Redirecting to: {result.redirect_to} (Status: {result.status_code})")
             # --- Handle Normal Response ---
             else:
-                headers = [(b'Content-Type', b'text/html; charset=utf-8')]    
+                headers = [(b'Content-Type', b'text/html; charset=utf-8')]
                 for name, value in result.headers:
                     headers.append((name.encode('utf-8'), value.encode('utf-8')))
+                for name, value, opts in result.cookies:
+                    parts = [f"{name}={value}"]
+                    for k, v in opts.items():
+                        parts.append(k if v is True else f"{k}={v}")
+                    headers.append((b'Set-Cookie', "; ".join(parts).encode('utf-8')))
                 await send({
                     'type': 'http.response.start',
                     'status': result.status_code,

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -382,6 +382,16 @@ def ast_param_dependencies(ast):
                 deps.update(get_dependencies(c[1]))
             elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#redirect", "#statuscode"}:
                 deps.update(get_dependencies(c))
+            elif t == "#header":
+                _, rest = parsefirstword(c)
+                if rest:
+                    deps.update(get_dependencies(rest))
+            elif t == "#cookie":
+                _, rest = parsefirstword(c)
+                if rest:
+                    m = re.match(r'("[^"]*"|\'[^\']*\'|\S+)', rest)
+                    if m:
+                        deps.update(get_dependencies(m.group(1)))
             elif t == "#render":
                 _, rest = parsefirstword(c)
                 if rest:

--- a/tests/test_headers_cookies.py
+++ b/tests/test_headers_cookies.py
@@ -1,0 +1,48 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+from pageql.pageqlapp import PageQLApp
+from pageql.pageql import PageQL
+
+
+def test_header_cookie_in_render_result():
+    r = PageQL(":memory:")
+    r.load_module("mod", "{{#header X-Test 'v'}}{{#cookie sess 'val' path='/'}}ok")
+    res = r.render("/mod")
+    assert ("X-Test", "v") in res.headers
+    assert ("sess", "val", {"path": "/"}) in res.cookies
+
+
+def test_header_cookie_sent():
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "h.pageql").write_text(
+                "{{#header X-Mode 'on'}}{{#cookie cid 'c123' path='/' httponly}}hi",
+                encoding="utf-8",
+            )
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+            sent = []
+
+            async def send(msg):
+                sent.append(msg)
+
+            async def receive():
+                return {"type": "http.request"}
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/h",
+                "headers": [],
+                "query_string": b"",
+            }
+            await app.pageql_handler(scope, receive, send)
+            start = next(m for m in sent if m["type"] == "http.response.start")
+            headers = {k.decode().lower(): v.decode() for k, v in start["headers"]}
+            assert headers["x-mode"] == "on"
+            cookie = [v.decode() for k, v in start["headers"] if k == b"Set-Cookie"][0]
+            assert cookie.startswith("cid=c123")
+            assert "httponly" in cookie.lower()
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- implement `#header` and `#cookie` directives
- include headers and cookies in ASGI responses
- document header/cookie syntax
- test new header/cookie behaviour

## Testing
- `pytest`