### PR TITLE
Implement #error directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ pageql -path/to/your/database.sqlite ./templates
 
 *   `#statuscode <expression>`: Sets the HTTP response status code.
 *   `#redirect <url_expression>`: Performs an HTTP redirect by setting the `Location` header and status code to 302.
+*   `#error <expression>`: Raises an error with the evaluated expression.
 *   `#header <name> <value_expression>`: Sets an HTTP response header. The `<name>` (e.g., `Cache-Control`, `"X-Custom-Header"`) and `<value_expression>` (e.g., `"no-cache"`, `:some_variable`) are required positional arguments. Example: `#header Cache-Control "no-cache, no-store, must-revalidate"`.
 *   `#cookie <name> <expression> [options...]`: Sets an outgoing HTTP cookie. The `<name>` is a literal string and `<expression>` is evaluated to determine the cookie value. Optional attributes like `expires="..."`, `path="..."`, `domain="..."`, `secure`, and `httponly` may follow.
 *   [NOT IMPLEMENTED] `#contenttype <expression>`: Sets the `Content-Type` HTTP response header (e.g., `text/html; charset=utf-8`).

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -117,6 +117,7 @@ DIRECTIVE_HELP: dict[str, str] = {
     "#partial <name>": "define a reusable partial block",
     "#reactive on|off": "toggle reactive rendering mode",
     "#redirect <url>": "issue an HTTP redirect",
+    "#error <expr>": "raise an error with the evaluated expression",
     "#render <name>": "render a named partial",
     "#set <name> <expr>": "assign a variable from an expression",
     "#statuscode <code>": "set the HTTP status code",
@@ -737,6 +738,9 @@ class PageQL:
                         cookies=ctx.cookies,
                     )
                 )
+            elif node_type == '#error':
+                msg = evalone(self.db, node_content, params, reactive, self.tables)
+                raise ValueError(str(msg))
             elif node_type == '#statuscode':
                 code = evalone(self.db, node_content, params, reactive, self.tables)
                 raise RenderResultException(

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -380,7 +380,7 @@ def ast_param_dependencies(ast):
                 deps.update(get_dependencies(c))
             elif t == "#set":
                 deps.update(get_dependencies(c[1]))
-            elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#redirect", "#statuscode"}:
+            elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#redirect", "#statuscode", "#error"}:
                 deps.update(get_dependencies(c))
             elif t == "#header":
                 _, rest = parsefirstword(c)

--- a/tests/test_error_directive.py
+++ b/tests/test_error_directive.py
@@ -1,0 +1,23 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+import pytest
+from pageql.pageql import PageQL
+from pageql.parser import tokenize, build_ast, ast_param_dependencies
+
+
+def test_error_directive_raises():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#error 'boom'}}")
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", reactive=False)
+    assert "boom" in str(exc.value)
+
+
+def test_error_directive_dependencies():
+    tokens = tokenize("{{#error :msg}}")
+    ast = build_ast(tokens)
+    deps = ast_param_dependencies(ast)
+    assert deps == {"msg"}


### PR DESCRIPTION
## Summary
- support a `#error` directive that throws an error with a message
- track `#error` dependencies in the parser
- document the directive in README
- add tests for `#error`

## Testing
- `pytest`