### PR TITLE
Add DB URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It was inspired by ColdFusion language that allows embedding SQL and Handlebars 
 
 PageQL is **reactive-first**: rendered HTML automatically updates when the underlying database data changes.
 
-Usage: ```pageql data.db templates --create```
+Usage: ```pageql <database> templates [--create]```
 
 Install: pip install pageql
 
@@ -60,18 +60,20 @@ To maintain focus and simplicity, several design choices have been made:
 
 ## Usage (Preliminary)
 
-PageQL is intended to be run via a command-line tool. The basic usage involves pointing the tool at a directory of `.pageql` files and specifying the SQLite database to use.
+PageQL is intended to be run via a command-line tool. The basic usage involves pointing the tool at a directory of `.pageql` files and specifying the SQLite database or a database URL to use.
 
 ```bash
 pageql -path/to/your/database.sqlite ./templates
 ```
 
-*   `<path>`: (Required) Path to the SQLite database file.
+*   `<database>`: (Required) Path to the SQLite database file or a PostgreSQL/MySQL connection URL.
 *   `<path>`: (Required) Path to the directory containing the PageQL template files (`.pageql`) to be served.
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
+*   When a PostgreSQL or MySQL URL is provided, `--create` is ignored and the
+    database must already exist.
 
 *(Note: Actual command name and argument flags are subject to change.)*
 

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -14,7 +14,7 @@ def main():
     parser = argparse.ArgumentParser(description="Run the PageQL development server.")
     
     # Add positional arguments - these will be the primary way to use the command
-    parser.add_argument('db_file', help="Path to the SQLite database file")
+    parser.add_argument('db_file', help="Path to the SQLite database file or a database URL")
     parser.add_argument('templates_dir', help="Path to the directory containing .pageql template and static files")
     parser.add_argument('--host', default='127.0.0.1', help="Host interface to bind the server.")
     parser.add_argument('--port', type=int, default=8000, help="Port number to run the server on.")

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -16,6 +16,7 @@ import doctest
 import sqlite3
 import html
 import pathlib
+from urllib.parse import urlparse
 
 if __package__ is None:                      # script / doctest-by-path
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
@@ -34,6 +35,50 @@ from pageql.reactive import (
 )
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 import sqlglot
+
+
+def connect_database(db_path: str):
+    """Return a DB-API connection for the given path or URL."""
+    if db_path.startswith("postgres://") or db_path.startswith("postgresql://"):
+        try:
+            import psycopg
+            return psycopg.connect(db_path)
+        except ImportError:
+            try:
+                import psycopg2
+                return psycopg2.connect(db_path)
+            except ImportError:  # pragma: no cover - optional deps
+                raise ImportError(
+                    "PostgreSQL support requires psycopg or psycopg2 to be installed"
+                )
+    if db_path.startswith("mysql://"):
+        parsed = urlparse(db_path)
+        try:
+            import mysql.connector
+            return mysql.connector.connect(
+                user=parsed.username,
+                password=parsed.password,
+                host=parsed.hostname,
+                port=parsed.port or 3306,
+                database=parsed.path.lstrip("/"),
+            )
+        except ImportError:
+            try:
+                import pymysql
+                return pymysql.connect(
+                    host=parsed.hostname,
+                    user=parsed.username,
+                    password=parsed.password,
+                    database=parsed.path.lstrip("/"),
+                    port=parsed.port or 3306,
+                )
+            except ImportError:  # pragma: no cover - optional deps
+                raise ImportError(
+                    "MySQL support requires mysql-connector-python or PyMySQL"
+                )
+    if db_path.startswith("sqlite://"):
+        db_path = db_path.split("://", 1)[1]
+    return sqlite3.connect(db_path)
 
 def flatten_params(params):
     """
@@ -320,10 +365,10 @@ class RenderResultException(Exception):
 
 class PageQL:
     """
-    Manages and renders PageQL templates against an SQLite database.
+    Manages and renders PageQL templates against a database.
 
     Attributes:
-        db_path: Path to the SQLite database file.
+        db_path: Path to the SQLite database file or a database URL.
         _modules: Internal storage for loaded module source strings or parsed nodes.
     """
 
@@ -332,17 +377,18 @@ class PageQL:
         Initializes the PageQL engine instance.
 
         Args:
-            db_path: Path to the SQLite database file to be used.
+            db_path: Path to the SQLite database file or database URL.
         """
         self._modules = {} # Store parsed node lists here later
         self._parse_errors = {} # Store errors here
-        self.db = sqlite3.connect(db_path)
-        # Configure SQLite for web server usage
-        with self.db:
-            self.db.execute("PRAGMA journal_mode=WAL")
-            self.db.execute("PRAGMA synchronous=NORMAL")
-            self.db.execute("PRAGMA temp_store=MEMORY")
-            self.db.execute("PRAGMA cache_size=10000")
+        self.db = connect_database(db_path)
+        if isinstance(self.db, sqlite3.Connection):
+            # Configure SQLite for web server usage
+            with self.db:
+                self.db.execute("PRAGMA journal_mode=WAL")
+                self.db.execute("PRAGMA synchronous=NORMAL")
+                self.db.execute("PRAGMA temp_store=MEMORY")
+                self.db.execute("PRAGMA cache_size=10000")
         self.tables = Tables(self.db)
         self._from_cache = {}
 

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -472,7 +472,9 @@ class PageQLApp:
         self.stop_event = asyncio.Event()
 
         # --- Database File Handling ---
-        db_exists = os.path.isfile(db_path)
+        parsed = urlparse(db_path)
+        is_url = parsed.scheme in ("postgres", "postgresql", "mysql")
+        db_exists = os.path.isfile(db_path) if not is_url else True
 
         if not db_exists:
             if create_db:
@@ -596,7 +598,7 @@ if __name__ == "__main__":
         exit(1)
 
     parser = argparse.ArgumentParser(description="Run the PageQL development server.")
-    parser.add_argument('--db', required=True, help="Path to the SQLite database file.")
+    parser.add_argument('--db', required=True, help="Path to the SQLite database file or a database URL.")
     parser.add_argument('--dir', required=True, help="Path to the directory containing .pageql template files.")
     parser.add_argument('--host', default='127.0.0.1', help="Host interface to bind the server.")
     parser.add_argument('--port', type=int, default=8000, help="Port number to run the server on.")


### PR DESCRIPTION
## Summary
- allow CLI to accept PostgreSQL/MySQL URLs
- connect to external DB URLs when provided
- skip SQLite setup for non-sqlite connections
- document database URL usage

## Testing
- `PYTHONPATH=src pytest`