### PR TITLE
Add fallback URL option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ pageql -path/to/your/database.sqlite ./templates
 *   `<path>`: (Required) Path to the directory containing the PageQL template files (`.pageql`) to be served.
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
+*   `--fallback-url <url>`: (Optional) Forward unknown routes to this base URL.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
 

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('--create', action='store_true', help="Create the database file if it doesn't exist.")
     parser.add_argument('--no-reload', action='store_true', help="Do not reload and refresh the templates on file changes.")
     parser.add_argument('-q', '--quiet', action='store_true', help="Only show errors in output.")
+    parser.add_argument('--fallback-url', help="Forward unknown routes to this base URL")
 
     # If no arguments were provided (only the script name), print help and exit.
     if len(sys.argv) == 1:
@@ -35,6 +36,7 @@ def main():
         create_db=args.create,
         should_reload=not args.no_reload,
         quiet=args.quiet,
+        fallback_url=args.fallback_url,
     )
 
     if not args.quiet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+import pageql.cli as cli
+
+def test_cli_fallback_url(monkeypatch, tmp_path):
+    created = {}
+
+    class DummyApp:
+        def __init__(self, db_file, templates_dir, create_db=False, should_reload=True, quiet=False, fallback_app=None, fallback_url=None):
+            created["db"] = db_file
+            created["tpl"] = templates_dir
+            created["fallback_url"] = fallback_url
+
+    monkeypatch.setattr(cli, "PageQLApp", DummyApp)
+    monkeypatch.setattr(cli.uvicorn, "run", lambda *a, **kw: None)
+
+    argv = [
+        "pageql",
+        "test.db",
+        str(tmp_path),
+        "--fallback-url",
+        "http://example.com",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert created["fallback_url"] == "http://example.com"
+


### PR DESCRIPTION
## Summary
- add `--fallback-url` option to the command-line interface
- update README usage details
- test CLI argument handling

## Testing
- `pytest`