### PR TITLE
Fix dotted params in reactive SQL commands

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -58,3 +58,14 @@ def test_tables_executeone_invalid():
     else:
         assert False, "expected ValueError"
 
+
+def test_tables_executeone_dotted_param():
+    conn = _db()
+    tables = Tables(conn)
+    tables.executeone(
+        "INSERT INTO items(name) VALUES (:file.name)",
+        {"file__name": "dot"},
+    )
+    row = conn.execute("SELECT name FROM items").fetchone()
+    assert row[0] == "dot"
+


### PR DESCRIPTION
## Summary
- support `:a.b` syntax in reactive table operations
- cover dotted parameter case in `Tables.executeone`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683aa8f2e520832fbcd23a4a05f776df