### PR TITLE
Add server-side token utilities

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -7,8 +7,26 @@ from .pageql import PageQL, RenderResult
 from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
+from .tokens import (
+    generate_token,
+    hash_token,
+    create_tokens_table,
+    store_token,
+    get_and_delete_token,
+)
 # Define the version
 __version__ = "0.1.0"
 
 # Make these classes available directly from the package
-__all__ = ["PageQL", "RenderResult", "ReadOnly", "PageQLApp", "parse_reactive"]
+__all__ = [
+    "PageQL",
+    "RenderResult",
+    "ReadOnly",
+    "PageQLApp",
+    "parse_reactive",
+    "generate_token",
+    "hash_token",
+    "create_tokens_table",
+    "store_token",
+    "get_and_delete_token",
+]

--- a/src/pageql/tokens.py
+++ b/src/pageql/tokens.py
@@ -1,0 +1,66 @@
+import hashlib
+import os
+import base64
+import sqlite3
+from typing import Optional, Tuple
+
+
+def generate_token(nbytes: int = 15) -> str:
+    """Return a cryptographically secure base32 token."""
+    return base64.b32encode(os.urandom(nbytes)).decode("ascii").lower()
+
+
+def hash_token(token: str) -> str:
+    """Return a hex encoded SHA-256 hash of *token*."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_tokens_table(conn: sqlite3.Connection) -> None:
+    """Create the token table if it doesn't exist."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS token(
+            token TEXT NOT NULL UNIQUE,
+            expires_at INTEGER NOT NULL,
+            user_id INTEGER NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
+def store_token(
+    conn: sqlite3.Connection,
+    token: str,
+    user_id: int,
+    expires_at: int,
+    *,
+    hashed: bool = False,
+) -> None:
+    """Insert ``token`` into ``token`` table."""
+    tval = hash_token(token) if hashed else token
+    conn.execute(
+        "INSERT INTO token(token, expires_at, user_id) VALUES(?, ?, ?)",
+        (tval, expires_at, user_id),
+    )
+    conn.commit()
+
+
+def get_and_delete_token(
+    conn: sqlite3.Connection, token: str, *, hashed: bool = False
+) -> Optional[Tuple[int, int]]:
+    """Retrieve ``(expires_at, user_id)`` and delete the row atomically."""
+    tval = hash_token(token) if hashed else token
+    cur = conn.cursor()
+    try:
+        cur.execute("BEGIN")
+        row = cur.execute(
+            "SELECT expires_at, user_id FROM token WHERE token=?", (tval,)
+        ).fetchone()
+        if row is not None:
+            cur.execute("DELETE FROM token WHERE token=?", (tval,))
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return row

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pageql.tokens import (
+    generate_token,
+    hash_token,
+    create_tokens_table,
+    store_token,
+    get_and_delete_token,
+)
+
+
+def test_store_and_retrieve_token():
+    conn = sqlite3.connect(":memory:")
+    create_tokens_table(conn)
+    tok = generate_token()
+    store_token(conn, tok, 1, 123)
+    row = get_and_delete_token(conn, tok)
+    assert row == (123, 1)
+    assert get_and_delete_token(conn, tok) is None
+
+
+def test_hashed_token_storage():
+    conn = sqlite3.connect(":memory:")
+    create_tokens_table(conn)
+    tok = generate_token()
+    store_token(conn, tok, 2, 0, hashed=True)
+    stored = conn.execute("select token from token").fetchone()[0]
+    assert stored == hash_token(tok)
+    row = get_and_delete_token(conn, tok, hashed=True)
+    assert row == (0, 2)


### PR DESCRIPTION
## Summary
- implement token generation, storage and retrieval helpers
- export token helpers via package init
- test server-side token handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683aa92b7784832fbbe8f80c7ecf59b8