### PR TITLE
Move async HTTP helpers to dedicated module

### DIFF
--- a/src/pageql/http_utils.py
+++ b/src/pageql/http_utils.py
@@ -1,0 +1,114 @@
+"""Utility helpers for async HTTP interactions."""
+
+import asyncio
+import re
+from urllib.parse import urlparse
+from typing import Dict, List, Tuple
+
+__all__ = ["_http_get", "_parse_multipart_data", "_read_chunked_body"]
+
+
+async def _read_chunked_body(reader: asyncio.StreamReader) -> bytes:
+    """Read a HTTP chunked body from ``reader``."""
+    chunks: List[bytes] = []
+    while True:
+        size_line = await reader.readline()
+        size = int(size_line.strip(), 16)
+        if size == 0:
+            await reader.readline()
+            break
+        chunk = await reader.readexactly(size)
+        chunks.append(chunk)
+        await reader.readline()
+    return b"".join(chunks)
+
+
+def _parse_multipart_data(body: bytes, boundary: str) -> Dict[str, object]:
+    """Parse ``multipart/form-data`` payloads.
+
+    Returns a mapping of field names to either string values or
+    ``{"filename": str, "body": bytes}`` for file uploads.
+    """
+    result: Dict[str, object] = {}
+    if not boundary:
+        return result
+    delim = b"--" + boundary.encode()
+    parts = body.split(delim)
+    for part in parts[1:]:
+        part = part.strip()
+        if not part or part == b"--":
+            continue
+        if part.startswith(b"\r\n"):
+            part = part[2:]
+        if part.endswith(b"\r\n"):
+            part = part[:-2]
+        header_end = part.find(b"\r\n\r\n")
+        if header_end == -1:
+            continue
+        header_bytes = part[:header_end].decode("utf-8", "ignore")
+        content = part[header_end + 4 :]
+        headers = {}
+        for line in header_bytes.split("\r\n"):
+            if ":" not in line:
+                continue
+            k, v = line.split(":", 1)
+            headers[k.strip().lower()] = v.strip()
+        disp = headers.get("content-disposition", "")
+        m = re.findall(r"([a-zA-Z0-9_-]+)=\"([^\"]*)\"", disp)
+        disp_dict = {k: v for k, v in m}
+        name = disp_dict.get("name")
+        filename = disp_dict.get("filename")
+        if not name:
+            continue
+        if filename is not None:
+            result[name] = {"filename": filename, "body": content}
+        else:
+            result[name] = content.decode("utf-8")
+    return result
+
+
+async def _http_get(url: str) -> Tuple[int, List[Tuple[bytes, bytes]], bytes]:
+    """Perform a minimal async HTTP GET request."""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    path = parsed.path or "/"
+    if parsed.query:
+        path += "?" + parsed.query
+    reader, writer = await asyncio.open_connection(
+        host, port, ssl=parsed.scheme == "https"
+    )
+    request = (
+        f"GET {path} HTTP/1.1\r\n"
+        f"Host: {host}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    )
+    writer.write(request.encode())
+    await writer.drain()
+
+    status_line = await reader.readline()
+    parts = status_line.decode().split()
+    status = int(parts[1]) if len(parts) > 1 else 502
+    headers: List[Tuple[bytes, bytes]] = []
+    hdr_dict = {}
+    while True:
+        line = await reader.readline()
+        if line == b"\r\n":
+            break
+        key, val = line.decode().split(":", 1)
+        val = val.strip()
+        headers.append((key.lower().encode(), val.encode()))
+        hdr_dict[key.lower()] = val
+
+    if hdr_dict.get("transfer-encoding") == "chunked":
+        body = await _read_chunked_body(reader)
+    elif "content-length" in hdr_dict:
+        length = int(hdr_dict["content-length"])
+        body = await reader.readexactly(length)
+    else:
+        body = await reader.read()
+
+    writer.close()
+    await writer.wait_closed()
+    return status, headers, body

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -13,6 +13,7 @@ from typing import Callable, Awaitable, Dict, List, Optional
 
 # Assuming pageql.py is in the same directory or Python path
 from .pageql import PageQL
+from .http_utils import _http_get, _parse_multipart_data, _read_chunked_body
 
 scripts_by_send: defaultdict = defaultdict(list)
 _idle_task: Optional[asyncio.Task] = None
@@ -113,105 +114,6 @@ def reload_ws_script(client_id: str) -> str:
 """
 
 
-async def _read_chunked_body(reader: asyncio.StreamReader) -> bytes:
-    chunks = []
-    while True:
-        size_line = await reader.readline()
-        size = int(size_line.strip(), 16)
-        if size == 0:
-            await reader.readline()
-            break
-        chunk = await reader.readexactly(size)
-        chunks.append(chunk)
-        await reader.readline()
-    return b"".join(chunks)
-
-
-def _parse_multipart_data(body: bytes, boundary: str) -> Dict[str, object]:
-    """Very small multipart/form-data parser.
-
-    Returns a dict mapping field names to either strings or ``{"filename": str, "body": bytes}``.
-    """
-    result: Dict[str, object] = {}
-    if not boundary:
-        return result
-    delim = b"--" + boundary.encode()
-    parts = body.split(delim)
-    for part in parts[1:]:
-        part = part.strip()
-        if not part or part == b"--":
-            continue
-        if part.startswith(b"\r\n"):
-            part = part[2:]
-        if part.endswith(b"\r\n"):
-            part = part[:-2]
-        header_end = part.find(b"\r\n\r\n")
-        if header_end == -1:
-            continue
-        header_bytes = part[:header_end].decode("utf-8", "ignore")
-        content = part[header_end + 4 :]
-        headers = {}
-        for line in header_bytes.split("\r\n"):
-            if ":" not in line:
-                continue
-            k, v = line.split(":", 1)
-            headers[k.strip().lower()] = v.strip()
-        disp = headers.get("content-disposition", "")
-        m = re.findall(r"([a-zA-Z0-9_-]+)=\"([^\"]*)\"", disp)
-        disp_dict = {k: v for k, v in m}
-        name = disp_dict.get("name")
-        filename = disp_dict.get("filename")
-        if not name:
-            continue
-        if filename is not None:
-            result[name] = {"filename": filename, "body": content}
-        else:
-            result[name] = content.decode("utf-8")
-    return result
-
-
-async def _http_get(url: str) -> tuple[int, list[tuple[bytes, bytes]], bytes]:
-    parsed = urlparse(url)
-    host = parsed.hostname or ""
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    path = parsed.path or "/"
-    if parsed.query:
-        path += "?" + parsed.query
-    reader, writer = await asyncio.open_connection(host, port, ssl=parsed.scheme == "https")
-    request = (
-        f"GET {path} HTTP/1.1\r\n"
-        f"Host: {host}\r\n"
-        "Connection: close\r\n"
-        "\r\n"
-    )
-    writer.write(request.encode())
-    await writer.drain()
-
-    status_line = await reader.readline()
-    parts = status_line.decode().split()
-    status = int(parts[1]) if len(parts) > 1 else 502
-    headers: list[tuple[bytes, bytes]] = []
-    hdr_dict = {}
-    while True:
-        line = await reader.readline()
-        if line == b"\r\n":
-            break
-        key, val = line.decode().split(":", 1)
-        val = val.strip()
-        headers.append((key.lower().encode(), val.encode()))
-        hdr_dict[key.lower()] = val
-
-    if hdr_dict.get("transfer-encoding") == "chunked":
-        body = await _read_chunked_body(reader)
-    elif "content-length" in hdr_dict:
-        length = int(hdr_dict["content-length"])
-        body = await reader.readexactly(length)
-    else:
-        body = await reader.read()
-
-    writer.close()
-    await writer.wait_closed()
-    return status, headers, body
 
 
 class PageQLApp:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ import http.client
 import http.server
 import threading
 import pageql.pageqlapp
+from pageql.http_utils import _http_get
 import asyncio
 import base64
 # Ensure the package can be imported without optional dependencies
@@ -101,7 +102,7 @@ def test_fallback_url_handles_unknown_route():
             server.config.app.fallback_url = f"http://127.0.0.1:{fb_port}"
 
             async def make_request():
-                status, _headers, body = await pageql.pageqlapp._http_get(
+                status, _headers, body = await _http_get(
                     f"http://127.0.0.1:{port}/missing"
                 )
                 return status, body.decode()


### PR DESCRIPTION
## Summary
- refactor HTTP helper functions into `http_utils`
- update `pageqlapp` to import helpers from new module
- adjust tests to use `_http_get` from `http_utils`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683aac58d158832f9005ad9781dd4aab