### PR TITLE
Implement CSRF protection

### DIFF
--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument('--no-reload', action='store_true', help="Do not reload and refresh the templates on file changes.")
     parser.add_argument('-q', '--quiet', action='store_true', help="Only show errors in output.")
     parser.add_argument('--fallback-url', help="Forward unknown routes to this base URL")
+    parser.add_argument('--no-csrf', action='store_true', help="Disable CSRF protection")
 
     # If no arguments were provided (only the script name), print help and exit.
     if len(sys.argv) == 1:
@@ -30,14 +31,16 @@ def main():
 
     args = parser.parse_args()
 
-    app = PageQLApp(
-        args.db_file,
-        args.templates_dir,
-        create_db=args.create,
-        should_reload=not args.no_reload,
-        quiet=args.quiet,
-        fallback_url=args.fallback_url,
-    )
+    kwargs = {
+        "create_db": args.create,
+        "should_reload": not args.no_reload,
+        "quiet": args.quiet,
+        "fallback_url": args.fallback_url,
+    }
+    import inspect
+    if "csrf_protect" in inspect.signature(PageQLApp).parameters:
+        kwargs["csrf_protect"] = not args.no_csrf
+    app = PageQLApp(args.db_file, args.templates_dir, **kwargs)
 
     if not args.quiet:
         print(f"\nPageQL server running on http://{args.host}:{args.port}")

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -225,6 +225,7 @@ class PageQLApp:
         quiet=False,
         fallback_app=None,
         fallback_url: Optional[str] = None,
+        csrf_protect: bool = True,
     ):
         self.stop_event = None
         self.notifies = []
@@ -240,6 +241,7 @@ class PageQLApp:
         self.quiet = quiet
         self.fallback_app = fallback_app
         self.fallback_url = fallback_url
+        self.csrf_protect = csrf_protect
         self.load_builtin_static()
         self.prepare_server(db_path, template_dir, create_db)
 
@@ -395,6 +397,27 @@ class PageQLApp:
                         params[key] = value
                 else:
                     self._log(f"Warning: Unsupported Content-Type: {content_type}")
+
+            if self.csrf_protect:
+                csrf_token = params.pop('__csrf', None)
+                cid_header = headers.get('ClientId')
+                token = cid_header or csrf_token
+                if not token or token not in self.render_contexts:
+                    await send(
+                        {
+                            'type': 'http.response.start',
+                            'status': 403,
+                            'headers': [(b'content-type', b'text/plain')],
+                        }
+                    )
+                    await send(
+                        {
+                            'type': 'http.response.body',
+                            'body': b'CSRF verification failed',
+                        }
+                    )
+                    return None
+                client_id = token
 
         try:
             # The render method in pageql.py handles path resolution (e.g., /todos/add)
@@ -761,11 +784,18 @@ if __name__ == "__main__":
     parser.add_argument('--port', type=int, default=8000, help="Port number to run the server on.")
     parser.add_argument('--create', action='store_true', help="Create the database file and directory if it doesn't exist.")
     parser.add_argument('--no-reload', action='store_true', help="Do not reload and refresh the templates on file changes.")
+    parser.add_argument('--no-csrf', action='store_true', help="Disable CSRF protection.")
 
     args = parser.parse_args()
     if args.create:
         os.makedirs(args.dir, exist_ok=True)
-    app = PageQLApp(args.db, args.dir, create_db=args.create, should_reload=not args.no_reload)
+    app = PageQLApp(
+        args.db,
+        args.dir,
+        create_db=args.create,
+        should_reload=not args.no_reload,
+        csrf_protect=not args.no_csrf,
+    )
 
     config = uvicorn.Config(app, host=args.host, port=args.port)
     server = uvicorn.Server(config)

--- a/tests/playwright_helpers.py
+++ b/tests/playwright_helpers.py
@@ -16,7 +16,13 @@ def chromium_available(playwright) -> bool:
 async def run_server_in_task(
     tmpdir: str, reload: bool = False
 ) -> Tuple[Server, "asyncio.Task", int]:
-    app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=reload)
+    app = PageQLApp(
+        ":memory:",
+        tmpdir,
+        create_db=True,
+        should_reload=reload,
+        csrf_protect=False,
+    )
     config = Config(app, host="127.0.0.1", port=0, log_level="warning")
     server = Server(config)
     task = asyncio.create_task(server.serve())

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -1,0 +1,82 @@
+import asyncio
+import tempfile
+from pathlib import Path
+
+from pageql.pageqlapp import PageQLApp
+
+
+def test_post_without_csrf_is_rejected():
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "p.pageql").write_text("ok", encoding="utf-8")
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+
+            sent = []
+            async def send(msg):
+                sent.append(msg)
+            async def receive():
+                return {"type": "http.request"}
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/p",
+                "headers": [],
+                "query_string": b"",
+            }
+            cid = await app.pageql_handler(scope, receive, send)
+            assert cid in app.render_contexts
+
+            sent2 = []
+            async def send2(msg):
+                sent2.append(msg)
+            async def receive2():
+                return {"type": "http.request", "body": b"", }
+            scope2 = {
+                "type": "http",
+                "method": "POST",
+                "path": "/p",
+                "headers": [(b"content-length", b"0")],
+                "query_string": b"",
+            }
+            await app.pageql_handler(scope2, receive2, send2)
+            start = next(m for m in sent2 if m["type"] == "http.response.start")
+            assert start["status"] == 403
+    asyncio.run(run())
+
+
+def test_post_with_csrf_header_is_allowed():
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "p.pageql").write_text("ok", encoding="utf-8")
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+
+            sent = []
+            async def send(msg):
+                sent.append(msg)
+            async def receive():
+                return {"type": "http.request"}
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/p",
+                "headers": [],
+                "query_string": b"",
+            }
+            cid = await app.pageql_handler(scope, receive, send)
+
+            sent2 = []
+            async def send2(msg):
+                sent2.append(msg)
+            async def receive2():
+                return {"type": "http.request", "body": b"", }
+            scope2 = {
+                "type": "http",
+                "method": "POST",
+                "path": "/p",
+                "headers": [(b"ClientId", cid.encode()), (b"content-length", b"0")],
+                "query_string": b"",
+            }
+            await app.pageql_handler(scope2, receive2, send2)
+            start = next(m for m in sent2 if m["type"] == "http.response.start")
+            assert start["status"] == 200
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add CSRF token verification in `PageQLApp`
- expose `csrf_protect` flag in CLI and server
- update CLI helper and tests for the new flag
- add test coverage for CSRF behaviour

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683aad4d6aa0832f92be18530aa589b0