### PR TITLE
Add session management

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -14,6 +14,13 @@ from .tokens import (
     store_token,
     get_and_delete_token,
 )
+from .sessions import (
+    create_session,
+    validate_session,
+    extend_session,
+    delete_session,
+    invalidate_user_sessions,
+)
 # Define the version
 __version__ = "0.1.0"
 
@@ -29,4 +36,9 @@ __all__ = [
     "create_tokens_table",
     "store_token",
     "get_and_delete_token",
+    "create_session",
+    "validate_session",
+    "extend_session",
+    "delete_session",
+    "invalidate_user_sessions",
 ]

--- a/src/pageql/sessions.py
+++ b/src/pageql/sessions.py
@@ -1,0 +1,81 @@
+"""Session helpers using the token table."""
+import sqlite3
+import time
+from typing import Optional
+
+from .tokens import generate_token, hash_token, store_token
+
+__all__ = [
+    "create_session",
+    "validate_session",
+    "extend_session",
+    "delete_session",
+    "invalidate_user_sessions",
+]
+
+
+def create_session(
+    conn: sqlite3.Connection,
+    user_id: int,
+    expires_in: int,
+    *,
+    hashed: bool = True,
+) -> str:
+    """Create a new session returning the session token."""
+    token = generate_token()
+    expires_at = int(time.time()) + expires_in
+    store_token(conn, token, user_id, expires_at, hashed=hashed)
+    return token
+
+
+def validate_session(
+    conn: sqlite3.Connection,
+    token: str,
+    *,
+    hashed: bool = True,
+) -> Optional[tuple[int, int]]:
+    """Return ``(user_id, expires_at)`` if the token is valid and not expired."""
+    tval = hash_token(token) if hashed else token
+    row = conn.execute(
+        "SELECT expires_at, user_id FROM token WHERE token=?",
+        (tval,),
+    ).fetchone()
+    if row is None:
+        return None
+    expires_at, user_id = row
+    if int(time.time()) > expires_at:
+        conn.execute("DELETE FROM token WHERE token=?", (tval,))
+        conn.commit()
+        return None
+    return user_id, expires_at
+
+
+def extend_session(
+    conn: sqlite3.Connection,
+    token: str,
+    expires_in: int,
+    *,
+    hashed: bool = True,
+) -> None:
+    """Update ``expires_at`` for ``token`` if it exists."""
+    tval = hash_token(token) if hashed else token
+    new_exp = int(time.time()) + expires_in
+    conn.execute(
+        "UPDATE token SET expires_at=? WHERE token=?",
+        (new_exp, tval),
+    )
+    conn.commit()
+
+
+def delete_session(conn: sqlite3.Connection, token: str, *, hashed: bool = True) -> None:
+    """Remove ``token`` from the table."""
+    tval = hash_token(token) if hashed else token
+    conn.execute("DELETE FROM token WHERE token=?", (tval,))
+    conn.commit()
+
+
+def invalidate_user_sessions(conn: sqlite3.Connection, user_id: int) -> None:
+    """Delete all sessions for ``user_id``."""
+    conn.execute("DELETE FROM token WHERE user_id=?", (user_id,))
+    conn.commit()
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,33 @@
+import sqlite3
+
+from pageql.sessions import (
+    create_session,
+    validate_session,
+    extend_session,
+    delete_session,
+    invalidate_user_sessions,
+)
+from pageql.tokens import create_tokens_table
+
+
+def test_session_lifecycle():
+    conn = sqlite3.connect(":memory:")
+    create_tokens_table(conn)
+    token = create_session(conn, 1, 10)
+    user_id, exp = validate_session(conn, token)
+    assert user_id == 1
+    extend_session(conn, token, 20)
+    _uid, exp2 = validate_session(conn, token)
+    assert exp2 >= exp
+    delete_session(conn, token)
+    assert validate_session(conn, token) is None
+
+
+def test_invalidate_user_sessions():
+    conn = sqlite3.connect(":memory:")
+    create_tokens_table(conn)
+    t1 = create_session(conn, 2, 10)
+    t2 = create_session(conn, 2, 10)
+    invalidate_user_sessions(conn, 2)
+    assert validate_session(conn, t1) is None
+    assert validate_session(conn, t2) is None


### PR DESCRIPTION
## Summary
- implement simple session helpers using token table
- export session APIs
- test session lifecycle utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683aadeb6f08832faafb42b8c617d404