### PR TITLE
Remove inspect dependency in CLI

### DIFF
--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -36,10 +36,8 @@ def main():
         "should_reload": not args.no_reload,
         "quiet": args.quiet,
         "fallback_url": args.fallback_url,
+        "csrf_protect": not args.no_csrf,
     }
-    import inspect
-    if "csrf_protect" in inspect.signature(PageQLApp).parameters:
-        kwargs["csrf_protect"] = not args.no_csrf
     app = PageQLApp(args.db_file, args.templates_dir, **kwargs)
 
     if not args.quiet:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,17 @@ def test_cli_fallback_url(monkeypatch, tmp_path):
     created = {}
 
     class DummyApp:
-        def __init__(self, db_file, templates_dir, create_db=False, should_reload=True, quiet=False, fallback_app=None, fallback_url=None):
+        def __init__(
+            self,
+            db_file,
+            templates_dir,
+            create_db=False,
+            should_reload=True,
+            quiet=False,
+            fallback_app=None,
+            fallback_url=None,
+            csrf_protect=True,
+        ):
             created["db"] = db_file
             created["tpl"] = templates_dir
             created["fallback_url"] = fallback_url


### PR DESCRIPTION
## Summary
- drop unused inspect import in cli
- always pass `csrf_protect` in CLI
- update CLI test dummy app for new argument

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683b29afd7f8832f89f2e698f59adc68