### PR TITLE
Fix header encoding crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 data.db
 templates/todos2.pageql
 /llm
+copenhagen/

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -368,9 +368,9 @@ class PageQLApp:
 
             # --- Handle Redirect ---
             if result.redirect_to:
-                headers = [(b'Location', result.redirect_to)]
+                headers = [(b'Location', str(result.redirect_to).encode('utf-8'))]
                 for name, value in result.headers:
-                    headers.append((name.encode('utf-8'), value.encode('utf-8')))
+                    headers.append((str(name).encode('utf-8'), str(value).encode('utf-8')))
                 for name, value, opts in result.cookies:
                     parts = [f"{name}={value}"]
                     for k, v in opts.items():
@@ -390,7 +390,7 @@ class PageQLApp:
             else:
                 headers = [(b'Content-Type', b'text/html; charset=utf-8')]
                 for name, value in result.headers:
-                    headers.append((name.encode('utf-8'), value.encode('utf-8')))
+                    headers.append((str(name).encode('utf-8'), str(value).encode('utf-8')))
                 for name, value, opts in result.cookies:
                     parts = [f"{name}={value}"]
                     for k, v in opts.items():


### PR DESCRIPTION
## Summary
- ensure headers with non-string objects are converted to strings before encoding
- ignore the cloned `copenhagen` directory

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683bfb7f7c5c832f913ca9c00c823867