### PR TITLE
Add sqlglot sqlite hex literal test

### DIFF
--- a/tests/test_sqlglot_sqlite.py
+++ b/tests/test_sqlglot_sqlite.py
@@ -1,0 +1,14 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+import sqlglot
+from sqlglot import expressions as exp
+
+
+def test_sqlite_hex_literal_parsing():
+    expr = sqlglot.parse_one("SELECT X'33'", read="sqlite")
+    assert isinstance(expr, exp.Select)
+    assert isinstance(expr.expressions[0], exp.HexString)
+    assert expr.sql(dialect="sqlite") == "SELECT x'33'"


### PR DESCRIPTION
## Summary
- ensure sqlglot can parse SQLite hex literals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c18c6dd60832f8981f540a92eed23