### PR TITLE
Return dialect from connect_database

### DIFF
--- a/tests/test_connect_database.py
+++ b/tests/test_connect_database.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from pageql.pageql import connect_database, PageQL
+
+
+def test_connect_database_returns_dialect():
+    conn, dialect = connect_database(":memory:")
+    assert dialect == "sqlite"
+    conn.close()
+
+
+def test_pageql_stores_dialect():
+    p = PageQL(":memory:")
+    assert p.dialect == "sqlite"
+    p.db.close()


### PR DESCRIPTION
## Summary
- return `(connection, dialect)` from `connect_database`
- store the dialect on `PageQL`
- test for new behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c1af46e08832f889cdfd45b8f7f11