### PR TITLE
Specify sqlite dialect for sqlglot

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -343,7 +343,7 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         def _build():
             nonlocal expr
             if expr is None:
-                expr = sqlglot.parse_one(sql)
+                expr = sqlglot.parse_one(sql, read="sqlite")
             #print("parse_reactive: ", expr.sql())
             comp = parse_reactive(expr, tables, params, one_value=True)
             return comp
@@ -1047,7 +1047,7 @@ class PageQL:
                     }
                     expr_copy = expr.copy()
                     _replace_placeholders(expr_copy, converted_params)
-                    cache_key = expr_copy.sql()
+                    cache_key = expr_copy.sql(dialect="sqlite")
                     comp = self._from_cache.get(cache_key)
                     if comp is None or not comp.listeners:
                         comp = parse_reactive(expr, self.tables, params)

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -112,7 +112,7 @@ def _read_block(node_list, i, stop, partials):
             if_terms = {"#elif", "#else", "/if", "/ifdef", "/ifndef"}  # inline terminators for this IF
             if ntype == "#if":
                 try:
-                    cond_expr = sqlglot.parse_one("SELECT " + ncontent)
+                    cond_expr = sqlglot.parse_one("SELECT " + ncontent, read="sqlite")
                 except Exception as e:  # pragma: no cover - invalid SQL
                     raise SyntaxError(f"bad SQL in #if: {e}")
             i += 1
@@ -127,7 +127,7 @@ def _read_block(node_list, i, stop, partials):
                     i += 1
                     elif_body, i = _read_block(node_list, i, if_terms, partials)
                     try:
-                        expr = sqlglot.parse_one("SELECT " + c)
+                        expr = sqlglot.parse_one("SELECT " + c, read="sqlite")
                     except Exception as e:  # pragma: no cover - invalid SQL
                         raise SyntaxError(f"bad SQL in #elif: {e}")
                     r.append((c, expr))
@@ -151,7 +151,7 @@ def _read_block(node_list, i, stop, partials):
             from_terms = {"/from"}
             query = ncontent
             try:
-                expr = sqlglot.parse_one("SELECT * FROM " + query)
+                expr = sqlglot.parse_one("SELECT * FROM " + query, read="sqlite")
             except Exception as e:  # pragma: no cover - invalid SQL
                 raise SyntaxError(f"bad SQL in #from: {e}")
             i += 1
@@ -172,7 +172,7 @@ def _read_block(node_list, i, stop, partials):
             else:
                 parse_sql = "SELECT " + sql
             try:
-                expr = sqlglot.parse_one(parse_sql)
+                expr = sqlglot.parse_one(parse_sql, read="sqlite")
             except Exception as e:  # pragma: no cover - invalid SQL
                 raise SyntaxError(f"bad SQL in #let: {e}")
             i += 1

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -709,7 +709,7 @@ class Tables:
             self._get(table).delete(sql, params)
         elif lsql.startswith("select"):
             from .reactive_sql import parse_reactive
-            expr = sqlglot.parse_one(sql_strip)
+            expr = sqlglot.parse_one(sql_strip, read="sqlite")
             return parse_reactive(expr, self, params)
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -47,7 +47,7 @@ class FallbackReactive(Signal):
         self.sql = sql
 
         if expr is None:
-            expr = sqlglot.parse_one(sql)
+            expr = sqlglot.parse_one(sql, read="sqlite")
 
         # Determine table dependencies
         self.deps = []
@@ -110,10 +110,10 @@ def build_reactive(expr, tables: Tables):
     if isinstance(expr, exp.Select):
         from_expr = expr.args.get("from")
         if from_expr is None:
-            return FallbackReactive(tables, expr.sql())
+            return FallbackReactive(tables, expr.sql(dialect="sqlite"))
         parent = build_from(from_expr.this, tables)
         if expr.args.get("where"):
-            parent = Where(parent, expr.args["where"].this.sql())
+            parent = Where(parent, expr.args["where"].this.sql(dialect="sqlite"))
         select_list = expr.args.get("expressions") or [exp.Star()]
         if len(select_list) == 1:
             col = select_list[0]
@@ -121,7 +121,7 @@ def build_reactive(expr, tables: Tables):
                 return parent
             if isinstance(col, exp.Count) and isinstance(col.this, exp.Star):
                 return CountAll(parent)
-        select_sql = ", ".join(col.sql() for col in select_list)
+        select_sql = ", ".join(col.sql(dialect="sqlite") for col in select_list)
         return Select(parent, select_sql)
     if isinstance(expr, exp.Table):
         return tables._get(expr.name)
@@ -154,7 +154,7 @@ def parse_reactive(
     """
     expr = expr.copy()
     _replace_placeholders(expr, params)
-    sql = expr.sql()
+    sql = expr.sql(dialect="sqlite")
 
     cache_key = None
     if cache:

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -20,14 +20,14 @@ def test_no_wrap_when_closed_in_same_node():
 def test_wrap_across_directive():
     nodes = [
         ("text", "<div"),
-        ["#if", ("cond", sqlglot.parse_one("SELECT cond")), [("text", "class='x'")], []],
+        ["#if", ("cond", sqlglot.parse_one("SELECT cond", read="sqlite")), [("text", "class='x'")], []],
         ("text", ">x</div>")
     ]
     res = add_reactive_elements(nodes)
     assert res == [
         ["#reactiveelement", [
             ("text", "<div"),
-            ["#if", ("cond", sqlglot.parse_one("SELECT cond")), [("text", "class='x'")], []],
+            ["#if", ("cond", sqlglot.parse_one("SELECT cond", read="sqlite")), [("text", "class='x'")], []],
             ("text", ">")
         ]],
         ("text", "x</div>")
@@ -37,7 +37,7 @@ def test_wrap_across_directive():
 def test_wrap_with_directive_and_surrounding_text():
     nodes = [
         ("text", "hello <input "),
-        ["#if", ("a", sqlglot.parse_one("SELECT a")), [("text", "checked")], []],
+        ["#if", ("a", sqlglot.parse_one("SELECT a", read="sqlite")), [("text", "checked")], []],
         ("text", "type='submit'> world"),
     ]
     res = add_reactive_elements(nodes)
@@ -45,7 +45,7 @@ def test_wrap_with_directive_and_surrounding_text():
         ("text", "hello "),
         ["#reactiveelement", [
             ("text", "<input "),
-            ["#if", ("a", sqlglot.parse_one("SELECT a")), [("text", "checked")], []],
+            ["#if", ("a", sqlglot.parse_one("SELECT a", read="sqlite")), [("text", "checked")], []],
             ("text", "type='submit'>"),
         ]],
         ("text", " world"),
@@ -55,7 +55,7 @@ def test_wrap_with_directive_and_surrounding_text():
 def test_input_if_inside_paragraph():
     nodes = [
         ("text", "<p>Active count is 1: <input type='checkbox' "),
-        ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1")), [("text", "checked")]],
+        ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1", read="sqlite")), [("text", "checked")]],
         ("text", "></p>")
     ]
     res = add_reactive_elements(nodes)
@@ -63,7 +63,7 @@ def test_input_if_inside_paragraph():
         ("text", "<p>Active count is 1: "),
         ["#reactiveelement", [
             ("text", "<input type='checkbox' "),
-            ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1")), [("text", "checked")]],
+            ["#if", (":active_count == 1", sqlglot.parse_one("SELECT :active_count == 1", read="sqlite")), [("text", "checked")]],
             ("text", ">")
         ]],
         ("text", "</p>")
@@ -87,9 +87,9 @@ def test_delete_insert_input_and_text():
     assert res[2][0] == "#let"
     assert res[2][1][0] == "active_count"
     assert res[2][1][1] == "COUNT(*) from todos WHERE completed = 0"
-    assert res[2][1][2].sql() == sqlglot.parse_one(
-        "SELECT COUNT(*) from todos WHERE completed = 0"
-    ).sql()
+    assert res[2][1][2].sql(dialect="sqlite") == sqlglot.parse_one(
+        "SELECT COUNT(*) from todos WHERE completed = 0", read="sqlite"
+    ).sql(dialect="sqlite")
     assert res[3:] == [
         ("text", "<p>"),
         [
@@ -98,7 +98,7 @@ def test_delete_insert_input_and_text():
                 ("text", "<input class=\"toggle"),
                 ("render_expression", "3"),
                 ("text", "\" type=\"checkbox\" "),
-                ["#if", ("1", sqlglot.parse_one("SELECT 1")), [("text", "checked")]],
+                ["#if", ("1", sqlglot.parse_one("SELECT 1", read="sqlite")), [("text", "checked")]],
                 ("text", ">"),
             ],
         ],
@@ -126,7 +126,7 @@ def test_wrap_inside_else_branch():
         ("text", "<div>"),
         [
             "#if",
-            ("1", sqlglot.parse_one("SELECT 1")),
+            ("1", sqlglot.parse_one("SELECT 1", read="sqlite")),
             [("text", "<span>hi</span>")],
             [
                 [

--- a/tests/test_evalone.py
+++ b/tests/test_evalone.py
@@ -71,14 +71,14 @@ def test_evalone_reactive_uses_expr(monkeypatch):
     conn = _db()
     conn.execute("INSERT INTO items(name) VALUES ('z')")
     tables = Tables(conn)
-    expr = sqlglot.parse_one("SELECT name FROM items WHERE id = 1")
+    expr = sqlglot.parse_one("SELECT name FROM items WHERE id = 1", read="sqlite")
 
     called = False
 
     def fake_parse_one(sql):
         nonlocal called
         called = True
-        return sqlglot.parse_one(sql)
+        return sqlglot.parse_one(sql, read="sqlite")
 
     monkeypatch.setattr(sqlglot, "parse_one", fake_parse_one)
 

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -33,7 +33,7 @@ def test_parse_select_basic():
     conn = _db()
     tables = Tables(conn)
     sql = "SELECT * FROM items"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     assert isinstance(comp, ReactiveTable)
     assert_sql_equivalent(conn, sql, comp.sql)
@@ -43,7 +43,7 @@ def test_parse_select_where():
     conn = _db()
     tables = Tables(conn)
     sql = "SELECT name FROM items WHERE name='x'"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     assert isinstance(comp, Select)
     assert isinstance(comp.parent, Where)
@@ -54,7 +54,7 @@ def test_parse_count():
     conn = _db()
     tables = Tables(conn)
     sql = "SELECT COUNT(*) FROM items"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     assert isinstance(comp, CountAll)
     assert_sql_equivalent(conn, sql, comp.sql)
@@ -69,7 +69,7 @@ def test_parse_union_all():
     # Add sample rows so result comparison is non-trivial
     conn.execute("INSERT INTO a(name) VALUES ('a1')")
     conn.execute("INSERT INTO b(name) VALUES ('b1')")
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     assert isinstance(comp, UnionAll)
     assert_sql_equivalent(conn, sql, comp.sql)
@@ -81,7 +81,7 @@ def test_parse_reactive_fallback_join():
     conn.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, a_id INTEGER, title TEXT)")
     tables = Tables(conn)
     sql = "SELECT a.name, b.title FROM a JOIN b ON a.id=b.a_id"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     events = []
     comp.listeners.append(events.append)
@@ -101,7 +101,7 @@ def test_parse_select_with_params():
     conn = _db()
     tables = Tables(conn)
     sql = "SELECT name FROM items WHERE id = :id"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {"id": 1})
     assert isinstance(comp, Select)
     assert isinstance(comp.parent, Where)
@@ -112,7 +112,7 @@ def test_parse_select_constant():
     conn = _db()
     tables = Tables(conn)
     sql = "SELECT 42 AS answer"
-    expr = sqlglot.parse_one(sql)
+    expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
     assert isinstance(comp, ReadOnly)
     assert comp.value == [(42,)]

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -103,7 +103,7 @@ def test_from_reactive_uses_parse(monkeypatch):
     original = rsql.parse_reactive
 
     def wrapper(expr, tables, params=None, **kwargs):
-        seen.append(expr.sql())
+        seen.append(expr.sql(dialect="sqlite"))
         return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
@@ -136,7 +136,7 @@ def test_from_reactive_caches_queries(monkeypatch):
     original = rsql.parse_reactive
 
     def wrapper(expr, tables, params=None, **kwargs):
-        seen.append(expr.sql())
+        seen.append(expr.sql(dialect="sqlite"))
         return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)
@@ -164,7 +164,7 @@ def test_from_reactive_reparses_after_cleanup(monkeypatch):
     original = rsql.parse_reactive
 
     def wrapper(expr, tables, params=None, **kwargs):
-        seen.append(expr.sql())
+        seen.append(expr.sql(dialect="sqlite"))
         return original(expr, tables, params, **kwargs)
 
     monkeypatch.setattr(rsql, "parse_reactive", wrapper)


### PR DESCRIPTION
## Summary
- ensure all sqlglot.parse_one calls use the sqlite dialect
- generate SQL using sqlite dialect when calling `expr.sql`
- update tests to expect the sqlite dialect

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c1e690624832f9ae213cee0b5e89d