### PR TITLE
Use pageql.dialect instead of hardcoded sqlite

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -677,8 +677,9 @@ class Select(Signal):
             self.listeners = None
 
 class Tables:
-    def __init__(self, conn):
+    def __init__(self, conn, dialect="sqlite"):
         self.conn = conn
+        self.dialect = dialect
         self.tables = {}
 
     def _get(self, name):
@@ -709,7 +710,7 @@ class Tables:
             self._get(table).delete(sql, params)
         elif lsql.startswith("select"):
             from .reactive_sql import parse_reactive
-            expr = sqlglot.parse_one(sql_strip, read="sqlite")
+            expr = sqlglot.parse_one(sql_strip, read=self.dialect)
             return parse_reactive(expr, self, params)
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -80,7 +80,7 @@ def test_delete_insert_input_and_text():
         "{{#insert into todos(text, completed) values ('test', 0)}}"
     )
     tokens = tokenize(snippet)
-    body, _ = build_ast(tokens)
+    body, _ = build_ast(tokens, dialect="sqlite")
     res = add_reactive_elements(body)
     assert res[0] == ("#reactive", "on")
     assert res[1] == ("#delete", "from todos where completed = 0")
@@ -120,7 +120,7 @@ def test_wrap_inside_else_branch():
         "<div>{{#if 1}}<span>hi</span>{{#else}}<input value='{{x}}'>{{/if}}</div>"
     )
     tokens = tokenize(snippet)
-    body, _ = build_ast(tokens)
+    body, _ = build_ast(tokens, dialect="sqlite")
     res = add_reactive_elements(body)
     assert res == [
         ("text", "<div>"),

--- a/tests/test_ast_dependencies.py
+++ b/tests/test_ast_dependencies.py
@@ -13,7 +13,7 @@ def test_basic_ast_dependencies():
         "{{#from items where id=:item_id}}{{/from}}"
     )
     tokens = tokenize(snippet)
-    ast = build_ast(tokens)
+    ast = build_ast(tokens, dialect="sqlite")
     deps = ast_param_dependencies(ast)
     assert deps == {"limit", "flag", "item_id"}
 
@@ -21,6 +21,6 @@ def test_basic_ast_dependencies():
 def test_partial_ast_dependencies():
     snippet = "{{#partial sub}} {{count(*) from nums where id=:pid}} {{/partial}}"
     tokens = tokenize(snippet)
-    ast = build_ast(tokens)
+    ast = build_ast(tokens, dialect="sqlite")
     deps = ast_param_dependencies(ast)
     assert deps == {"pid"}

--- a/tests/test_error_directive.py
+++ b/tests/test_error_directive.py
@@ -18,6 +18,6 @@ def test_error_directive_raises():
 
 def test_error_directive_dependencies():
     tokens = tokenize("{{#error :msg}}")
-    ast = build_ast(tokens)
+    ast = build_ast(tokens, dialect="sqlite")
     deps = ast_param_dependencies(ast)
     assert deps == {"msg"}

--- a/tests/test_from_dependencies.py
+++ b/tests/test_from_dependencies.py
@@ -8,7 +8,7 @@ from pageql.parser import tokenize, build_ast
 
 def test_from_node_has_dependencies():
     tokens = tokenize("{{#from items where id=:x}}{{#if :y}}ok{{/if}}{{/from}}")
-    body, _ = build_ast(tokens)
+    body, _ = build_ast(tokens, dialect="sqlite")
     from_node = body[0]
     assert from_node[0] == "#from"
     assert from_node[2] == {"y"}


### PR DESCRIPTION
## Summary
- plumb SQL dialect through parser and reactive execution
- use `tables.dialect` when parsing or generating SQL
- update tests for new `build_ast` API

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c2072c578832f985d3aaea139b8cb