### PR TITLE
Add no-csrf documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ pageql -path/to/your/database.sqlite ./templates
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   `--fallback-url <url>`: (Optional) Forward unknown routes to this base URL.
+*   `--no-csrf`: (Optional) Disable CSRF protection. Useful for local testing but not recommended in production.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
 *   When a PostgreSQL or MySQL URL is provided, `--create` is ignored and the

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -117,6 +117,30 @@ def reload_ws_script(client_id: str) -> str:
 
 
 class PageQLApp:
+    """ASGI application for serving PageQL templates.
+
+    Parameters
+    ----------
+    db_path : str
+        Path to the SQLite database file or a database URL.
+    template_dir : str
+        Directory containing ``.pageql`` template files.
+    create_db : bool, optional
+        Create the database file if it doesn't exist.
+    should_reload : bool, optional
+        Reload templates automatically when files change.
+    reactive : bool, optional
+        Enable reactive rendering by default.
+    quiet : bool, optional
+        Suppress logging output.
+    fallback_app : Optional[Callable]
+        ASGI application to use when no template matches.
+    fallback_url : Optional[str]
+        Forward unmatched routes to this base URL.
+    csrf_protect : bool, optional
+        Enable CSRF protection on state-changing requests.
+        Pass ``--no-csrf`` on the command line to disable.
+    """
     def __init__(
         self,
         db_path,


### PR DESCRIPTION
## Summary
- mention `--no-csrf` option in the README
- document `csrf_protect` parameter in `PageQLApp`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c24aca19c832f988ad03ee7e56db6