### PR TITLE
Handle MySQL hex blob literals

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -1054,7 +1054,7 @@ class PageQL:
                         for k, v in params.items()
                     }
                     expr_copy = expr.copy()
-                    _replace_placeholders(expr_copy, converted_params)
+                    _replace_placeholders(expr_copy, converted_params, self.dialect)
                     cache_key = expr_copy.sql(dialect=self.dialect)
                     comp = self._from_cache.get(cache_key)
                     if comp is None or not comp.listeners:

--- a/tests/test_mysql_hex_literal.py
+++ b/tests/test_mysql_hex_literal.py
@@ -1,0 +1,13 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+import sqlglot
+from pageql.reactive_sql import _replace_placeholders
+
+
+def test_mysql_hex_literal_placeholder():
+    expr = sqlglot.parse_one("SELECT :b", read="mysql")
+    _replace_placeholders(expr, {"b": b"\x33\xff"}, "mysql")
+    assert expr.sql(dialect="mysql") == "SELECT 0x33ff"


### PR DESCRIPTION
## Summary
- support dialect-specific binary literal formatting
- adjust placeholder replacement to use MySQL `0x` syntax
- keep cache key creation dialect-aware
- add unit test for MySQL hex literals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c284d52d0832fb67624e469ea5770