### PR TITLE
Fix case sensitivity for verb-specific partials

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -183,10 +183,11 @@ def _read_block(node_list, i, stop, partials, dialect):
         if ntype == "#partial":
             part_terms = {"/partial"}
             first, rest = parsefirstword(ncontent)
-            
-            # Check if first token is a verb or 'public'
-            if first in ["public", "get", "post", "put", "delete", "patch"]:
-                partial_type = first.upper() if first != "public" else "PUBLIC"
+
+            # Check if first token is a verb or 'public' (case-insensitive)
+            first_lower = first.lower()
+            if first_lower in ["public", "get", "post", "put", "delete", "patch"]:
+                partial_type = first_lower.upper() if first_lower != "public" else "PUBLIC"
                 name = rest
             else:
                 partial_type = None


### PR DESCRIPTION
## Summary
- make the parser accept HTTP verbs in any case
- tests still pass

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c2e468f74832fa5c71a3b7772ed68