### PR TITLE
Fix session reuse in basic_auth example

### DIFF
--- a/examples/templates/basic_auth.pageql
+++ b/examples/templates/basic_auth.pageql
@@ -26,6 +26,8 @@
 {{#partial POST login}}
   {{#param username required}}
   {{#param password required}}
+  {{#param session optional}}
+  {{#delete from sessions where token=:session}}
   {{#let uid id from users where username=:username and password=:password}}
   {{#if uid}}
     {{#let token lower(hex(randomblob(16)))}}

--- a/website/basic_auth.pageql
+++ b/website/basic_auth.pageql
@@ -26,6 +26,8 @@
 {{#partial POST login}}
   {{#param username required}}
   {{#param password required}}
+  {{#param session optional}}
+  {{#delete from sessions where token=:session}}
   {{#let uid id from users where username=:username and password=:password}}
   {{#if uid}}
     {{#let token lower(hex(randomblob(16)))}}


### PR DESCRIPTION
## Summary
- delete any existing session record when logging in to the basic auth example
- update both example copies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c301411a4832f8ac8a981c88688a4