### PR TITLE
Improve missing parameter error handling

### DIFF
--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -22,3 +22,13 @@ def test_param_float_validation():
     with pytest.raises(ValueError) as exc:
         r.render("/m", {"val": "abc"}, reactive=False)
     assert "failed type/validation 'float'" in str(exc.value)
+
+
+def test_missing_param_error():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#let session :non_existent}}")
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", reactive=False)
+    msg = str(exc.value).lower()
+    assert "missing parameter 'non_existent'" in msg
+    assert "available parameters" in msg


### PR DESCRIPTION
## Summary
- check for missing parameters before executing SQL
- raise informative errors listing available parameters
- add regression test for missing parameter in `#let`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c3a9a7e74832fb7556aa1f73071b2