### PR TITLE
Fix reactive dotted param handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -33,6 +33,7 @@ from pageql.reactive import (
     get_dependencies,
     Tables,
     ReadOnly,
+    _convert_dot_sql,
 )
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 import sqlglot
@@ -325,11 +326,7 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         exp = "select " + exp
 
     if reactive:
-        sql = re.sub(
-            r':([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)',
-            lambda m: ':' + m.group(1).replace('.', '__'),
-            exp,
-        )
+        sql = _convert_dot_sql(exp)
         if tables is None:
             tables = Tables(db, dialect)
         dep_names = [name.replace('.', '__') for name in get_dependencies(sql)]

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -714,7 +714,7 @@ class Tables:
             self._get(table).delete(sql, params)
         elif lsql.startswith("select"):
             from .reactive_sql import parse_reactive
-            expr = sqlglot.parse_one(sql_strip, read=self.dialect)
+            expr = sqlglot.parse_one(_convert_dot_sql(sql_strip), read=self.dialect)
             return parse_reactive(expr, self, params)
         else:
             raise ValueError(f"Unsupported SQL statement {sql}")


### PR DESCRIPTION
## Summary
- fix `evalone` to parse dotted parameters once using `_convert_dot_sql`
- ensure parser and ReactiveTable parse dotted placeholders correctly
- track dotted params when computing AST dependencies

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c38f26bf4832f828cf9243cb49928