### PR TITLE
Improve SQL error reporting

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -298,7 +298,12 @@ def db_execute_dot(db, exp, params):
             converted_params[k] = v.value
         else:
             converted_params[k] = v
-    return db.execute(converted_exp, converted_params)
+    try:
+        return db.execute(converted_exp, converted_params)
+    except sqlite3.Error as e:
+        raise ValueError(
+            f"Error executing SQL `{converted_exp}` with params {converted_params}: {e}"
+        )
 
 def evalone(db, exp, params, reactive=False, tables=None, expr=None):
     exp = exp.strip()
@@ -1064,7 +1069,12 @@ class PageQL:
                         comp = parse_reactive(expr, self.tables, params)
                         if cache_allowed:
                             self._from_cache[cache_key] = comp
-                    cursor = self.db.execute(comp.sql, converted_params)
+                    try:
+                        cursor = self.db.execute(comp.sql, converted_params)
+                    except sqlite3.Error as e:
+                        raise ValueError(
+                            f"Error executing SQL `{comp.sql}` with params {converted_params}: {e}"
+                        )
                     col_names = comp.columns if not isinstance(comp.columns, str) else [comp.columns]
                 else:
                     cursor = db_execute_dot(self.db, "select * from " + query, params)


### PR DESCRIPTION
## Summary
- add try/except when executing SQL in `db_execute_dot` and reactive `#from` handling
- convert sqlite errors into `ValueError` that include the SQL and params

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c3c59a12c832f885eb18eb6868573