### PR TITLE
Fix missing param detection in reactive mode

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -347,6 +347,15 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         if tables is None:
             tables = Tables(db, dialect)
         dep_names = [name.replace('.', '__') for name in get_dependencies(sql)]
+
+        missing = [n for n in dep_names if n not in params]
+        if missing:
+            avail = ', '.join(sorted(params.keys()))
+            raise ValueError(
+                f"Missing parameter(s) {', '.join(m.replace('__', '.') for m in missing)} "
+                f"for SQL expression `{exp}`. Available parameters: {avail}"
+            )
+
         for name in dep_names:
             val = params.get(name)
             if val is not None and not isinstance(val, Signal):

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -32,3 +32,13 @@ def test_missing_param_error():
     msg = str(exc.value).lower()
     assert "missing parameter 'non_existent'" in msg
     assert "available parameters" in msg
+
+
+def test_missing_param_error_reactive():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{:c + 0}}")
+    with pytest.raises(ValueError) as exc:
+        r.render("/m", reactive=True)
+    msg = str(exc.value).lower()
+    assert "missing parameter(s) c" in msg
+    assert "available parameters" in msg


### PR DESCRIPTION
## Summary
- detect missing parameters before creating a reactive expression
- test missing parameter errors in reactive mode

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c3e49dc10832fa1ee22c0c90a4d06