### PR TITLE
Implement dot notation for #param names

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ pageql -path/to/your/database.sqlite ./templates
     *   `default=<simple_expression>`: Provides a default value if the parameter is missing from the request. If present, this prevents the `required` check from failing.
     *   **Validation:** Optional attributes (`type`, `min`/`max`, `minlength`/`maxlength`, `pattern`) enforce rules on the parameter's value (after applying the default, if applicable). If any validation fails, processing stops with an error.
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
+    *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
 **Flow Control:**
 

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -498,6 +498,7 @@ class PageQL:
             Tuple of (param_name, param_value) after validation
         """
         param_name, attrs_str = parsefirstword(node_content)
+        param_name = param_name.replace('.', '__')
         attrs = parse_param_attrs(attrs_str)
 
         is_required = attrs.get('required', not attrs.__contains__('optional')) # Default required

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -82,7 +82,12 @@ def tokenize(source):
             if inner.startswith('!--') and inner.endswith('--'):
                 pass  # Skip comment nodes
             elif inner.startswith('#') or inner.startswith('/'):
-                nodes.append(parsefirstword(inner))
+                first, rest = parsefirstword(inner)
+                if first == '#param' and rest:
+                    pn, attrs = parsefirstword(rest)
+                    pn = pn.replace('.', '__')
+                    rest = pn if not attrs else f"{pn} {attrs}"
+                nodes.append((first, rest))
             else:
                 if re.match(r'^:?[a-zA-Z._$][a-zA-Z0-9._$]*$', inner):
                     if inner[0] == ':':

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -32,3 +32,10 @@ def test_missing_param_error():
     msg = str(exc.value).lower()
     assert "missing parameter 'non_existent'" in msg
     assert "available parameters" in msg
+
+
+def test_param_nested_name():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#param cookies.session optional}}{{cookies__session}}")
+    result = r.render("/m", {"cookies": {"session": "abc"}}, reactive=False)
+    assert result.body == "abc"


### PR DESCRIPTION
## Summary
- support nested parameter names in `#param` directives
- document dot-to-`__` conversion in README
- test nested name handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c3da56a8c832faef565ce58681a62