### PR TITLE
Fix reactive delete redirect error

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -198,7 +198,12 @@ class ReactiveTable(Signal):
             cursor = self.conn.execute(query, params)
             row = cursor.fetchone()
         except Exception as e:
-            raise Exception(f"Insert into table {self.table_name} failed for query: {query} with params: {params} with error: {e}")
+            from .pageql import RenderResultException
+            if isinstance(e, RenderResultException):
+                raise
+            raise Exception(
+                f"Insert into table {self.table_name} failed for query: {query} with params: {params} with error: {e}"
+            )
         if row is None:
             # insert .. or ignore may not return a row when it affects nothing
             # In this case the statement had no effect so we don't emit events
@@ -221,7 +226,12 @@ class ReactiveTable(Signal):
                 for listener in self.listeners:
                     listener([2, row])
         except Exception as e:
-            raise Exception(f"Delete from table {self.table_name} failed for query: {query} with params: {params} with error: {e}")
+            from .pageql import RenderResultException
+            if isinstance(e, RenderResultException):
+                raise
+            raise Exception(
+                f"Delete from table {self.table_name} failed for query: {query} with params: {params} with error: {e}"
+            )
 
     def update(self, sql, params):
         """


### PR DESCRIPTION
## Summary
- allow `ReactiveTable.delete` to propagate RenderResultException
- make `insert` also propagate RenderResultException
- test that delete propagates redirects

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c4194ea0c832f88d2e3e14ce94113