### PR TITLE
Switch #let syntax to use '='

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pageql -path/to/your/database.sqlite ./templates
 
 **Variable Manipulation:**
 
-*   `#let :<variable> <expression> [from <table> [WHERE ...]]`: Sets a variable. The value can be a literal (string, integer, float, `NULL`), or the result of a SQL expression, optionally evaluated against a table with a `WHERE` clause.
+*   `#let :<variable> = <expression> [from <table> [WHERE ...]]`: Sets a variable. The value can be a literal (string, integer, float, `NULL`), or the result of a SQL expression, optionally evaluated against a table with a `WHERE` clause.
 *   `#param <name> [type=<type>] [optional | required] [default=<simple_expression>] [min=<num>] [max=<num>] [minlength=<num>] [maxlength=<num>] [pattern="<regex>"]`: Declares and optionally validates an expected request parameter (URL query string or POST form variable) named `<name>`.
     *   **Behavior:** Choose `optional` or `required`. **If neither is specified, the default is `required`.**
         *   `required` (or default): Processing stops with an error if the parameter is missing and no `default` is provided.
@@ -190,7 +190,7 @@ PageQL does not define its own expression language. Instead, it leverages the ex
 Expressions are primarily used in:
 
 *   **`#if <expression>` / `#elif <expression>`:** To conditionally render blocks of content. The expression should evaluate to a boolean-like value (in SQLite, 0 is false, non-zero is true). If the expression is more complex than a single variable name, it **must** use the colon prefix for variables (e.g., `#if :count > 10`).
-*   **`#let :<variable> <expression> [from ...]`:** To compute a value to assign to a variable. Variables used within the `<expression>` **must** use the colon prefix (e.g., `#let :total_price :quantity * :unit_price`).
+*   **`#let :<variable> = <expression> [from ...]`:** To compute a value to assign to a variable. Variables used within the `<expression>` **must** use the colon prefix (e.g., `#let :total_price = :quantity * :unit_price`).
 *   **`WHERE <expression>` clauses:** Within database query tags (`#from`, `#update`, `#delete`, `#view`, `#let ... from`) to filter data. Variables **must** use the colon prefix (e.g., `WHERE user_id = :id`).
 *   **Value clauses:** In `#insert` (`values (...)`), `#update` (`set col = ...`), `#cookie`, `#header`, `#redirect`. Variables **must** use the colon prefix.
 
@@ -254,10 +254,10 @@ Generally, you can use standard SQL expressions supported by your database, such
 {{#partial POST toggle_all}}
   {{#param filter default='all'}} {{!-- Preserve filter for redirect --}}
   {{!-- Check if all are currently complete to decide toggle direction --}}
-  {{#let :active_count COUNT(*) from todos WHERE completed = 0}}
-  {{#let :new_status 1}} {{!-- Default to marking all complete --}}
+  {{#let :active_count = COUNT(*) from todos WHERE completed = 0}}
+  {{#let :new_status = 1}} {{!-- Default to marking all complete --}}
   {{#if :active_count == 0}} {{!-- If none active, mark all incomplete --}}
-    {{#let :new_status 0}}
+    {{#let :new_status = 0}}
   {{/if}}
   {{#update todos set completed = :new_status}}
   {{#redirect '/todos?filter=' || :filter}} {{!-- Redirect to base path --}}
@@ -282,10 +282,10 @@ Generally, you can use standard SQL expressions supported by your database, such
 
 
 {{!-- Get counts for footer and toggle-all logic --}}
-{{#let active_count COUNT(*) from todos WHERE completed = 0}}
-{{#let completed_count COUNT(*) from todos WHERE completed = 1}}
-{{#let total_count  COUNT(*) from todos}}
-{{#let all_complete (:active_count == 0 AND :total_count > 0)}}
+{{#let active_count = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count  = COUNT(*) from todos}}
+{{#let all_complete = (:active_count == 0 AND :total_count > 0)}}
 
 <!doctype html>
 <html lang="en">

--- a/benchmarks/benchmark_pageql.py
+++ b/benchmarks/benchmark_pageql.py
@@ -18,8 +18,8 @@ MODULES = {
     's1_static': "Hello",
     's2_expr': "{{1+1}}",
     's3_param': "{{name}}",
-    's4_set': "{{#let a 5}}{{a}}",
-    's5_set_expr': "{{#let a 2}}{{:a + :a}}",
+    's4_set': "{{#let a = 5}}{{a}}",
+    's5_set_expr': "{{#let a = 2}}{{:a + :a}}",
     's6_if': "{{#if 1==1}}yes{{#else}}no{{/if}}",
     's7_ifdef': "{{#ifdef name}}hi{{#else}}bye{{/ifdef}}",
     's8_ifndef': "{{#ifndef name}}hi{{#else}}bye{{/ifndef}}",
@@ -34,9 +34,9 @@ MODULES = {
     's17_status': "{{#statuscode 201}}created",
     's18_redirect': "{{#redirect '/target'}}",
     's19_import': "{{#import other as o}}{{#render o}}",
-    's20_reactive': "{{#reactive on}}{{#let foo 1}}{{foo}}",
+    's20_reactive': "{{#reactive on}}{{#let foo = 1}}{{foo}}",
     'other': "import works",
-    'qtest': '''{{#delete from items}}{{#reactive on}}{{#let active_count_reactive COUNT(*) from items WHERE name = 'x'}}
+    'qtest': '''{{#delete from items}}{{#reactive on}}{{#let active_count_reactive = COUNT(*) from items WHERE name = 'x'}}
             {{#insert into items(name) values ('x')}}'''
 }
 

--- a/examples/templates/basic_auth.pageql
+++ b/examples/templates/basic_auth.pageql
@@ -14,8 +14,8 @@
 
 {{!-- Helper to load the logged in user from session cookie --}}
 {{#param session optional}}
-{{#let user_id user_id from sessions where token=:session}}
-{{#let username username from users where id=:user_id}}
+{{#let user_id = user_id from sessions where token=:session}}
+{{#let username = username from users where id=:user_id}}
 
 {{#if username}}
 <p>Logged in as {{username}}. <a href="/basic_auth/profile">Profile</a> <a href="/basic_auth/logout">Logout</a></p>
@@ -28,9 +28,9 @@
   {{#param password required}}
   {{#param session optional}}
   {{#delete from sessions where token=:session}}
-  {{#let uid id from users where username=:username and password=:password}}
+  {{#let uid = id from users where username=:username and password=:password}}
   {{#if uid}}
-    {{#let token lower(hex(randomblob(16)))}}
+    {{#let token = lower(hex(randomblob(16)))}}
     {{#insert into sessions(token, user_id) values(:token, :uid)}}
     {{#cookie session :token path='/' httponly}}
     {{#redirect '/basic_auth'}}
@@ -41,8 +41,8 @@
 
 {{#partial GET login}}
   {{#param session optional}}
-  {{#let user_id user_id from sessions where token=:session}}
-  {{#let username username from users where id=:user_id}}
+  {{#let user_id = user_id from sessions where token=:session}}
+  {{#let username = username from users where id=:user_id}}
 
   <h1>Login</h1>
   <form method="POST" action="/basic_auth/login">
@@ -54,8 +54,8 @@
 
 {{#partial GET profile}}
   {{#param session optional}}
-  {{#let user_id user_id from sessions where token=:session}}
-  {{#let username username from users where id=:user_id}}
+  {{#let user_id = user_id from sessions where token=:session}}
+  {{#let username = username from users where id=:user_id}}
 
   {{#if username}}
     <h1>Hello {{username}}</h1>

--- a/examples/templates/todos2.pageql
+++ b/examples/templates/todos2.pageql
@@ -51,8 +51,8 @@ Cool, this is a test for creating a todos app from nothing
 </td><td onclick="document.location.href='/todos2/edit?id={{:id}}'">  {{text}}</td></tr>
 {{/from}}
 </table>
-{{#let total count(*) from todos}}
-{{#let active count(*) from todos where completed>0}}
+{{#let total = count(*) from todos}}
+{{#let active = count(*) from todos where completed>0}}
 
 Active: {{active}}/{{total}}
 

--- a/examples/templates/todos_noreactive.pageql
+++ b/examples/templates/todos_noreactive.pageql
@@ -46,10 +46,10 @@
 {{#partial public toggle_all}}
   {{#param filter default='all'}} {{!-- Preserve filter for redirect --}}
   {{!-- Check if all are currently complete to decide toggle direction --}}
-  {{#let :active_count COUNT(*) from todos WHERE completed = 0}}
-  {{#let :new_status 1}} {{!-- Default to marking all complete --}}
+  {{#let :active_count = COUNT(*) from todos WHERE completed = 0}}
+  {{#let :new_status = 1}} {{!-- Default to marking all complete --}}
   {{#if :active_count == 0}} {{!-- If none active, mark all incomplete --}}
-    {{#let :new_status 0}}
+    {{#let :new_status = 0}}
   {{/if}}
   {{#update todos set completed = :new_status}}
   {{#redirect '/todos?filter=' || :filter}} {{!-- Redirect to base path --}}
@@ -74,10 +74,10 @@
 
 
 {{!-- Get counts for footer and toggle-all logic --}}
-{{#let active_count COUNT(*) from todos WHERE completed = 0}}
-{{#let completed_count COUNT(*) from todos WHERE completed = 1}}
-{{#let total_count  COUNT(*) from todos}}
-{{#let all_complete (:active_count == 0 AND :total_count > 0)}}
+{{#let active_count = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count  = COUNT(*) from todos}}
+{{#let all_complete = (:active_count == 0 AND :total_count > 0)}}
 
 <!doctype html>
 <html lang="en">

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -172,7 +172,7 @@ DIRECTIVE_HELP: dict[str, str] = {
     "#redirect <url>": "issue an HTTP redirect",
     "#error <expr>": "raise an error with the evaluated expression",
     "#render <name>": "render a named partial",
-    "#let <name> <expr>": "assign a variable from an expression",
+    "#let <name> = <expr>": "assign a variable from an expression",
     "#statuscode <code>": "set the HTTP status code",
     "#header <name> <expr>": "add an HTTP response header",
     "#cookie <name> <expr> [opts]": "set an HTTP cookie",

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -177,6 +177,8 @@ def _read_block(node_list, i, stop, partials, dialect):
         if ntype == "#let":
             var, rest = parsefirstword(ncontent)
             sql = rest or ""
+            if sql.lstrip().startswith("="):
+                sql = sql.lstrip()[1:].lstrip()
             sql_strip = sql.lstrip().lower()
             if sql_strip.startswith("select") or sql_strip.startswith("(select"):
                 parse_sql = sql
@@ -187,7 +189,7 @@ def _read_block(node_list, i, stop, partials, dialect):
             except Exception as e:  # pragma: no cover - invalid SQL
                 raise SyntaxError(f"bad SQL in #let: {e}")
             i += 1
-            body.append(("#let", (var, rest, expr)))
+            body.append(("#let", (var, sql, expr)))
             continue
 
         # -------------------------------------------------------- #partial ...

--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -74,7 +74,7 @@ def test_delete_insert_input_and_text():
     snippet = (
         "{{#reactive on}}"
         "{{#delete from todos where completed = 0}}"
-        "{{#let active_count COUNT(*) from todos WHERE completed = 0}}"
+        "{{#let active_count = COUNT(*) from todos WHERE completed = 0}}"
         '<p><input class="toggle{{3}}" type="checkbox" {{#if 1}}checked{{/if}}>'
         '<input type="text" value="{{active_count}}"></p>'
         "{{#insert into todos(text, completed) values ('test', 0)}}"

--- a/tests/test_ast_dependencies.py
+++ b/tests/test_ast_dependencies.py
@@ -8,7 +8,7 @@ from pageql.parser import tokenize, build_ast, ast_param_dependencies
 
 def test_basic_ast_dependencies():
     snippet = (
-        "{{#let cnt count(*) from nums where value > :limit}}"
+        "{{#let cnt = count(*) from nums where value > :limit}}"
         "{{#if :flag}}ok{{#else}}no{{/if}}"
         "{{#from items where id=:item_id}}{{/from}}"
     )

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -51,7 +51,7 @@ async def test_set_variable_in_browser(browser):
     pytest.importorskip("playwright.async_api")
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        Path(tmpdir, "greet.pageql").write_text("{{#let :a 'world'}}Hello {{a}}", encoding="utf-8")
+        Path(tmpdir, "greet.pageql").write_text("{{#let :a = 'world'}}Hello {{a}}", encoding="utf-8")
 
         result = await _load_page_async(tmpdir, "greet", browser=browser)
         status, body_text = result
@@ -75,7 +75,7 @@ async def test_reactive_set_variable_in_browser(browser):
             "{{#create table vars(val TEXT)}}"
             "{{#insert into vars(val) values ('ww')}}"
             "{{#reactive on}}"
-            "{{#let a (select val from vars)}}"
+            "{{#let a = (select val from vars)}}"
             "hello {{a}}"
             "{{#update vars set val = 'world'}}",
             encoding="utf-8",
@@ -101,7 +101,7 @@ async def test_reactive_count_insert_in_browser(browser):
         Path(tmpdir, "count.pageql").write_text(
             "{{#create table nums(value INTEGER)}}"
             "{{#reactive on}}"
-            "{{#let a count(*) from nums}}"
+            "{{#let a = count(*) from nums}}"
             "{{a}}"
             "{{#insert into nums(value) values (1)}}",
             encoding="utf-8",
@@ -129,7 +129,7 @@ async def test_reactive_count_insert_via_execute(browser):
         Path(tmpdir, "count_after.pageql").write_text(
             "{{#create table if not exists nums(value INTEGER)}}"
             "{{#reactive on}}"
-            "{{#let a count(*) from nums}}"
+            "{{#let a = count(*) from nums}}"
             "{{a}}",
             encoding="utf-8",
         )
@@ -156,7 +156,7 @@ async def test_reactive_count_delete_via_execute(browser):
             "{{#create table if not exists nums(value INTEGER)}}"
             "{{#insert into nums(value) values (1)}}"
             "{{#reactive on}}"
-            "{{#let a count(*) from nums}}"
+            "{{#let a = count(*) from nums}}"
             "{{a}}",
             encoding="utf-8",
         )

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -26,7 +26,7 @@ def test_param_float_validation():
 
 def test_missing_param_error():
     r = PageQL(":memory:")
-    r.load_module("m", "{{#let session :non_existent}}")
+    r.load_module("m", "{{#let session = :non_existent}}")
     with pytest.raises(ValueError) as exc:
         r.render("/m", reactive=False)
     msg = str(exc.value).lower()

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -6,6 +6,6 @@ def test_from_row_columns_readonly():
     r = PageQL(":memory:")
     r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
     r.db.execute("INSERT INTO items(name) VALUES ('x')")
-    r.load_module("m", "{{#from items}}{{#let id 2}}{{/from}}")
+    r.load_module("m", "{{#from items}}{{#let id = 2}}{{/from}}")
     with pytest.raises(ValueError):
         r.render("/m")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -71,8 +71,8 @@ def test_reactive_count_with_param_dependency():
         "{{#create table vars(val INTEGER)}}"
         "{{#insert into vars(val) values (1)}}"
         "{{#reactive on}}"
-        "{{#let a (select val from vars)}}"
-        "{{#let cnt count(*) from nums where value > :a}}"
+        "{{#let a = (select val from vars)}}"
+        "{{#let cnt = count(*) from nums where value > :a}}"
         "{{cnt}}"
         "{{#update vars set val = 2}}"
         "{{#delete from nums where value = 3}}"
@@ -148,7 +148,7 @@ def test_from_reactive_caches_queries(monkeypatch):
     r.db.executemany("INSERT INTO items(name) VALUES (?)", [("a",), ("b",)])
     snippet = (
         "{{#reactive on}}"
-        "{{#let v 1}}"
+        "{{#let v = 1}}"
         "{{#from items where id=:v}}[{{id}}]{{/from}}"
         "{{#from items where id=:v}}[{{id}}]{{/from}}"
     )
@@ -174,8 +174,8 @@ def test_randomblob_expression_not_cached(monkeypatch):
     r = PageQL(":memory:")
     snippet = (
         "{{#reactive on}}"
-        "{{#let t1 lower(hex(randomblob(4)))}}"
-        "{{#let t2 lower(hex(randomblob(4)))}}"
+        "{{#let t1 = lower(hex(randomblob(4)))}}"
+        "{{#let t2 = lower(hex(randomblob(4)))}}"
     )
     r.load_module("m", snippet)
     r.render("/m")
@@ -219,12 +219,12 @@ def test_reactive_set_comments():
 {{#create table vals(name TEXT, value INTEGER)}}
 {{#insert into vals(name, value) values ('a', 1)}}
 {{#insert into vals(name, value) values ('b', 3)}}
-{{#let a (select value from vals where name = 'a')}}
+{{#let a = (select value from vals where name = 'a')}}
 {{a}}
 {{:a + :a}}
-{{#let b (select value from vals where name = 'b')}}
+{{#let b = (select value from vals where name = 'b')}}
 <p>{{:a + :b}} = 4</p>
-{{#let c :a+:b}}
+{{#let c = :a+:b}}
 <p>{{:c}} = c = 4</p>
 {{#update vals set value = 2 where name = 'a'}}
 <p>{{:a + :b}} = 5</p>
@@ -407,7 +407,7 @@ def test_reactive_if_update():
     snippet = (
         "{{#create table vals(name TEXT, value INTEGER)}}"
         "{{#insert into vals(name, value) values ('a', 1)}}"
-        "{{#reactive on}}{{#let a value from vals where name = 'a'}}{{#if :a}}T{{#else}}F{{/if}}{{#update vals set value = 0 where name = 'a'}}{{#update vals set value = 1 where name = 'a'}}"
+        "{{#reactive on}}{{#let a = value from vals where name = 'a'}}{{#if :a}}T{{#else}}F{{/if}}{{#update vals set value = 0 where name = 'a'}}{{#update vals set value = 1 where name = 'a'}}"
     )
     r.load_module("m", snippet)
     result = r.render("/m")
@@ -425,7 +425,7 @@ def test_reactive_if_elif_chain():
     r.db.executemany("INSERT INTO vals(name, value) VALUES (?, ?)", [("a", 1)])
     snippet = (
         "{{#reactive on}}"
-        "{{#let a value from vals where name = 'a'}}"
+        "{{#let a = value from vals where name = 'a'}}"
         "{{#if :a == 1}}A{{#elif :a == 2}}B{{#else}}C{{/if}}"
         "{{#update vals set value = 2 where name = 'a'}}"
         "{{#update vals set value = 3 where name = 'a'}}"
@@ -472,7 +472,7 @@ def test_reactive_if_variable_and_table_dependency():
         "{{#create table vals(name TEXT, value INTEGER)}}"
         "{{#insert into vals(name, value) values ('threshold', 1)}}"
         "{{#reactive on}}"
-        "{{#let threshold value from vals where name = 'threshold'}}"
+        "{{#let threshold = value from vals where name = 'threshold'}}"
         "{{#insert into items(value) values (1)}}"
         "{{#if (select count(*) from items) > :threshold}}MORE{{#else}}LESS{{/if}}"
         "{{#update vals set value = 0 where name = 'threshold'}}"
@@ -496,7 +496,7 @@ def test_reactiveelement_adds_pprevioustag_script():
     r.db.executemany("INSERT INTO vals(name, value) VALUES (?, ?)", [("c", 1)])
     snippet = (
         "{{#reactive on}}"
-        "{{#let c value from vals where name = 'c'}}"
+        "{{#let c = value from vals where name = 'c'}}"
         "<div {{#if :c}}class='x'{{/if}}></div>"
     )
     r.load_module("m", snippet)
@@ -523,7 +523,7 @@ def test_reactiveelement_updates_node():
     r.db.executemany("INSERT INTO vals(name, value) VALUES (?, ?)", [("c", 1)])
     snippet = (
         "{{#reactive on}}"
-        "{{#let c value from vals where name = 'c'}}"
+        "{{#let c = value from vals where name = 'c'}}"
         "<div {{#if :c}}class='x'{{#else}}class='y'{{/if}}></div>"
         "{{#update vals set value = 0 where name = 'c'}}"
         "{{#update vals set value = 1 where name = 'c'}}"
@@ -543,7 +543,7 @@ def test_reactiveelement_input_value():
     r.db.executemany("INSERT INTO vals(name, value) VALUES (?, ?)", [("c", 1)])
     snippet = (
         "{{#reactive on}}"
-        "{{#let c value from vals where name = 'c'}}"
+        "{{#let c = value from vals where name = 'c'}}"
         "<input type='text' value='{{c}}'>"
         "{{#update vals set value = 2 where name = 'c'}}"
     )
@@ -562,7 +562,7 @@ def test_reactiveelement_self_closing_input():
         "{{#create table vals(name TEXT, value INTEGER)}}"
         "{{#insert into vals(name, value) values ('c', 1)}}"
         "{{#reactive on}}"
-        "{{#let c value from vals where name = 'c'}}"
+        "{{#let c = value from vals where name = 'c'}}"
         "<input type='text' value='{{c}}' />"
         "{{#update vals set value = 2 where name = 'c'}}"
     )
@@ -581,7 +581,7 @@ def test_reactiveelement_if_with_table_insert_updates_input():
     )
     snippet = (
         "{{#reactive on}}"
-        "{{#let active_count count(*) from todos}}"
+        "{{#let active_count = count(*) from todos}}"
         "<p>Active count is 1: <input type='checkbox' {{#if :active_count == 1}}checked{{/if}}></p>"
         "{{#insert into todos(text, completed) values ('test', 0)}}"
     )
@@ -600,7 +600,7 @@ def test_reactiveelement_if_variable_updates_checked():
         "{{#create table vals(name TEXT, value INTEGER)}}"
         "{{#insert into vals(name, value) values ('flag', 1)}}"
         "{{#reactive on}}"
-        "{{#let flag value from vals where name = 'flag'}}"
+        "{{#let flag = value from vals where name = 'flag'}}"
         "<input type='checkbox' {{#if :flag}}checked{{/if}}>"
         "{{#update vals set value = 0 where name = 'flag'}}"
         "{{#update vals set value = 1 where name = 'flag'}}"
@@ -623,7 +623,7 @@ def test_reactiveelement_delete_and_insert_updates_input_and_text():
     snippet = (
         "{{#reactive on}}"
         "{{#delete from todos where completed = 0}}"
-        "{{#let active_count COUNT(*) from todos WHERE completed = 0}}"
+        "{{#let active_count = COUNT(*) from todos WHERE completed = 0}}"
         '<p><input class="toggle{{3}}" type="checkbox" {{#if 1}}checked{{/if}}><input type="text" value="{{active_count}}"></p>'
         "{{#insert into todos(text, completed) values ('test', 0)}}"
     )
@@ -690,7 +690,7 @@ def test_pinsert_does_not_send_marker_scripts():
     r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, value INTEGER)")
     snippet = (
         "{{#reactive on}}"
-        "{{#from items}}<li>{{#let a 1}}{{#if :a}}X{{/if}}</li>{{/from}}"
+        "{{#from items}}<li>{{#let a = 1}}{{#if :a}}X{{/if}}</li>{{/from}}"
     )
     r.load_module("m", snippet)
     result = r.render("/m")

--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -21,7 +21,7 @@ __doc__ = """
 ... ''')
 
 >>> source_with_comment = '''
-... {{#let :ww 3+3}}
+... {{#let :ww = 3+3}}
 ... Start Text.
 ... {{!-- This is a comment --}}
 ... {{ :hello }}
@@ -55,7 +55,7 @@ __doc__ = """
 ... {{#else}}
 ... He.lo isn't defined!
 ... {{/ifdef}}
-... {{#let a.b he.lo}}
+... {{#let a.b = he.lo}}
 ... {{#ifdef a.b}}
 ... a.b is defined
 ... {{/ifdef}}
@@ -165,7 +165,7 @@ cool
 >>> r.load_module("delete_test", "{{#partial delete :id}}deleted[{{id}}]{{/partial}}")
 >>> print(r.render("/delete_test/1", http_verb="DELETE").body)
 deleted[1]
->>> r.load_module("varnum", "{{#let idd0 3}}{{idd0}}")
+>>> r.load_module("varnum", "{{#let idd0 = 3}}{{idd0}}")
 >>> print(r.render("/varnum").body)
 3
 >>> r.load_module("fromtest", "{{#from (select 1 as id)}}[{{id}}]{{/from}}")

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -9,6 +9,6 @@ from pageql.parser import tokenize
 def test_unmatched_braces():
     with pytest.raises(SyntaxError) as exc:
         tokenize(
-            "something like {{#a\n{{#let active_count    COUNT(*) from todos WHERE completed = 0}}"
+            "something like {{#a\n{{#let active_count =    COUNT(*) from todos WHERE completed = 0}}"
         )
     assert "mismatched {{ in token" in str(exc.value)

--- a/website/03_updating_state.html
+++ b/website/03_updating_state.html
@@ -404,16 +404,16 @@
   <h3>2.1 Computed counts &amp; flags</h3>
 
   <pre class="code-block"><code class="language-diff">
-&#123;&#123;<span class="keyword">#let</span> <span class="variable">active_count</span>    COUNT(*) from todos WHERE completed = 0&#125;&#125;
-&#123;&#123;<span class="keyword">#let</span> <span class="variable">completed_count</span> COUNT(*) from todos WHERE completed = 1&#125;&#125;
-&#123;&#123;<span class="keyword">#let</span> <span class="variable">total_count</span>     COUNT(*) from todos&#125;&#125;
-&#123;&#123;<span class="keyword">#let</span> <span class="variable">all_complete</span>    (:<span class="variable">active_count</span> == 0 AND :<span class="variable">total_count</span> &gt; 0)&#125;&#125;
+&#123;&#123;<span class="keyword">#let</span> <span class="variable">active_count</span>    = COUNT(*) from todos WHERE completed = 0&#125;&#125;
+&#123;&#123;<span class="keyword">#let</span> <span class="variable">completed_count</span> = COUNT(*) from todos WHERE completed = 1&#125;&#125;
+&#123;&#123;<span class="keyword">#let</span> <span class="variable">total_count</span>     = COUNT(*) from todos&#125;&#125;
+&#123;&#123;<span class="keyword">#let</span> <span class="variable">all_complete</span>    = (:<span class="variable">active_count</span> == 0 AND :<span class="variable">total_count</span> &gt; 0)&#125;&#125;
 
 &#123;&#123;<span class="keyword">#param</span> <span class="variable">edit_id</span> <span class="attribute">type</span>=<span class="string">integer</span> <span class="attribute">optional</span>&#125;&#125;
-</code><div class="clean-code">&#123;&#123;#let active_count    COUNT(*) from todos WHERE completed = 0&#125;&#125;
-&#123;&#123;#let completed_count COUNT(*) from todos WHERE completed = 1&#125;&#125;
-&#123;&#123;#let total_count     COUNT(*) from todos&#125;&#125;
-&#123;&#123;#let all_complete    (:active_count == 0 AND :total_count &gt; 0)&#125;&#125;
+</code><div class="clean-code">&#123;&#123;#let active_count    = COUNT(*) from todos WHERE completed = 0&#125;&#125;
+&#123;&#123;#let completed_count = COUNT(*) from todos WHERE completed = 1&#125;&#125;
+&#123;&#123;#let total_count     = COUNT(*) from todos&#125;&#125;
+&#123;&#123;#let all_complete    = (:active_count == 0 AND :total_count &gt; 0)&#125;&#125;
 
 &#123;&#123;#param edit_id type=integer optional&#125;&#125;</div></pre>
 
@@ -547,7 +547,7 @@
 {{/partial}}
 
 {{#partial public toggle_all}}
-  {{#let active_count COUNT(*) from todos WHERE completed = 0}}
+  {{#let active_count = COUNT(*) from todos WHERE completed = 0}}
   {{#update todos set completed = IIF(:active_count = 0, 0, 1)}}
   {{#redirect '/todos'}}
 {{/partial}}</div></pre>

--- a/website/basic_auth.pageql
+++ b/website/basic_auth.pageql
@@ -14,8 +14,8 @@
 
 {{!-- Helper to load the logged in user from session cookie --}}
 {{#param session optional}}
-{{#let user_id user_id from sessions where token=:session}}
-{{#let username username from users where id=:user_id}}
+{{#let user_id = user_id from sessions where token=:session}}
+{{#let username = username from users where id=:user_id}}
 
 {{#if username}}
 <p>Logged in as {{username}}. <a href="/basic_auth/profile">Profile</a> <a href="/basic_auth/logout">Logout</a></p>
@@ -28,9 +28,9 @@
   {{#param password required}}
   {{#param session optional}}
   {{#delete from sessions where token=:session}}
-  {{#let uid id from users where username=:username and password=:password}}
+  {{#let uid = id from users where username=:username and password=:password}}
   {{#if uid}}
-    {{#let token lower(hex(randomblob(16)))}}
+    {{#let token = lower(hex(randomblob(16)))}}
     {{#insert into sessions(token, user_id) values(:token, :uid)}}
     {{#cookie session :token path='/' httponly}}
     {{#redirect '/basic_auth'}}
@@ -41,8 +41,8 @@
 
 {{#partial GET login}}
   {{#param session optional}}
-  {{#let user_id user_id from sessions where token=:session}}
-  {{#let username username from users where id=:user_id}}
+  {{#let user_id = user_id from sessions where token=:session}}
+  {{#let username = username from users where id=:user_id}}
 
   <h1>Login</h1>
   <form method="POST" action="/basic_auth/login">
@@ -54,8 +54,8 @@
 
 {{#partial GET profile}}
   {{#param session optional}}
-  {{#let user_id user_id from sessions where token=:session}}
-  {{#let username username from users where id=:user_id}}
+  {{#let user_id = user_id from sessions where token=:session}}
+  {{#let username = username from users where id=:user_id}}
 
   {{#if username}}
     <h1>Hello {{username}}</h1>

--- a/website/index.html
+++ b/website/index.html
@@ -365,7 +365,7 @@ pageql data.db templates --create</code></pre>
 {{/partial}}
 
 {{#partial post toggle_all}}
-  {{#let active_count COUNT(*) from todos WHERE completed = 0}}
+  {{#let active_count = COUNT(*) from todos WHERE completed = 0}}
   {{#update todos set completed =  IIF(:active_count = 0, 0, 1)}}
 {{/partial}}
 
@@ -387,10 +387,10 @@ pageql data.db templates --create</code></pre>
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )}}
 
-{{#let active_count    COUNT(*) from todos WHERE completed = 0}}
-{{#let completed_count COUNT(*) from todos WHERE completed = 1}}
-{{#let total_count     COUNT(*) from todos}}
-{{#let all_complete    (:active_count == 0 AND :total_count &gt; 0)}}
+{{#let active_count    = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count     = COUNT(*) from todos}}
+{{#let all_complete    = (:active_count == 0 AND :total_count &gt; 0)}}
 
 
 &lt;!doctype html&gt;

--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -11,7 +11,7 @@
 {{/partial}}
 
 {{#partial post toggle_all}}
-  {{#let active_count COUNT(*) from todos WHERE completed = 0}}
+  {{#let active_count = COUNT(*) from todos WHERE completed = 0}}
   {{#update todos set completed =  IIF(:active_count = 0, 0, 1)}}
 {{/partial}}
 
@@ -33,10 +33,10 @@
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )}}
 
-{{#let active_count    COUNT(*) from todos WHERE completed = 0}}
-{{#let completed_count COUNT(*) from todos WHERE completed = 1}}
-{{#let total_count     COUNT(*) from todos}}
-{{#let all_complete    (:active_count == 0 AND :total_count > 0)}}
+{{#let active_count    = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count     = COUNT(*) from todos}}
+{{#let all_complete    = (:active_count == 0 AND :total_count > 0)}}
 
 
 <!doctype html>

--- a/website/todos_without_edit_id.pageql
+++ b/website/todos_without_edit_id.pageql
@@ -12,7 +12,7 @@
 {{/partial}}
 
 {{#partial post toggle_all}}
-  {{#let active_count COUNT(*) from todos WHERE completed = 0}}
+  {{#let active_count = COUNT(*) from todos WHERE completed = 0}}
   {{#update todos set completed =  IIF(:active_count = 0, 0, 1)}}
 {{/partial}}
 
@@ -34,10 +34,10 @@
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )}}
 
-{{#let active_count    COUNT(*) from todos WHERE completed = 0}}
-{{#let completed_count COUNT(*) from todos WHERE completed = 1}}
-{{#let total_count     COUNT(*) from todos}}
-{{#let all_complete    (:active_count == 0 AND :total_count > 0)}}
+{{#let active_count    = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count     = COUNT(*) from todos}}
+{{#let all_complete    = (:active_count == 0 AND :total_count > 0)}}
 
 
 <!doctype html>


### PR DESCRIPTION
## Summary
- update parser and docs to parse `#let a = expr`
- revise directive help
- update examples, website docs, benchmarks and tests for new `=` syntax

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c7a999ae4832fbcdefe5aac88f21f