### PR TITLE
Add JWS helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "uvicorn",
     "watchfiles",
     "sqlglot",
+    "joserfc",
 ]
 
 [project.optional-dependencies]

--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -7,6 +7,7 @@ from .pageql import PageQL, RenderResult
 from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
+from .jws_utils import jws_serialize_compact, jws_deserialize_compact
 # Define the version
 __version__ = "0.1.0"
 
@@ -17,4 +18,6 @@ __all__ = [
     "ReadOnly",
     "PageQLApp",
     "parse_reactive",
+    "jws_serialize_compact",
+    "jws_deserialize_compact",
 ]

--- a/src/pageql/jws_utils.py
+++ b/src/pageql/jws_utils.py
@@ -1,0 +1,44 @@
+import os
+import json
+from pathlib import Path
+from joserfc import jws
+from joserfc.jwk import RSAKey
+
+DEFAULT_KEY_PATH = os.path.join(Path.home(), ".pageql_jws_key.pem")
+DEFAULT_ALGORITHM = "RS256"
+
+
+def _load_or_create_key(path: str = DEFAULT_KEY_PATH) -> RSAKey:
+    """Load an RSA key from *path* or create one if missing."""
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            data = f.read()
+        key = RSAKey.import_key(data)
+    else:
+        key = RSAKey.generate_key(auto_kid=True)
+        with open(path, "wb") as f:
+            f.write(key.as_pem())
+    return key
+
+
+def jws_serialize_compact(payload, protected=None, *, key_path=DEFAULT_KEY_PATH):
+    """Return a JWS Compact string for *payload* using ``joserfc``."""
+    if protected is None:
+        protected = {"alg": DEFAULT_ALGORITHM}
+    key = _load_or_create_key(key_path)
+    if isinstance(payload, (dict, list)):
+        payload = json.dumps(payload)
+    if isinstance(payload, str):
+        payload = payload.encode()
+    return jws.serialize_compact(protected, payload, key)
+
+
+def jws_deserialize_compact(value, *, key_path=DEFAULT_KEY_PATH):
+    """Deserialize a JWS Compact string and return the payload."""
+    key = _load_or_create_key(key_path)
+    obj = jws.deserialize_compact(value, key)
+    data = obj.payload
+    try:
+        return json.loads(data)
+    except Exception:
+        return data.decode() if isinstance(data, (bytes, bytearray)) else data

--- a/tests/test_jws_utils.py
+++ b/tests/test_jws_utils.py
@@ -1,0 +1,16 @@
+import sys
+import types
+from pathlib import Path
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql import jws_serialize_compact, jws_deserialize_compact
+
+
+def test_jws_round_trip(tmp_path):
+    key_path = tmp_path / "key.pem"
+    token = jws_serialize_compact("hello", key_path=str(key_path))
+    assert key_path.exists()
+    assert jws_deserialize_compact(token, key_path=str(key_path)) == "hello"
+


### PR DESCRIPTION
## Summary
- add `jws_serialize_compact` and `jws_deserialize_compact` helpers
- expose them from `pageql`
- include `joserfc` in dependencies
- test the roundtrip behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c7dd739e0832fb2dc57c51864e687