### PR TITLE
Use jws helpers for JWT login example

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -5,6 +5,7 @@ import sqlite3
 import mimetypes
 import re
 import base64
+import json
 from urllib.parse import urlparse, parse_qs
 from watchfiles import awatch
 import uuid
@@ -19,6 +20,7 @@ from .http_utils import (
     _read_chunked_body,
     _parse_cookies,
 )
+from .jws_utils import jws_serialize_compact, jws_deserialize_compact
 
 scripts_by_send: defaultdict = defaultdict(list)
 _idle_task: Optional[asyncio.Task] = None
@@ -616,6 +618,14 @@ class PageQLApp:
                 self.conn.create_function(
                     "base64_decode", 1,
                     lambda txt: base64.b64decode(txt).decode("utf-8") if txt is not None else None,
+                )
+                self.conn.create_function(
+                    "jws_serialize_compact", 1,
+                    lambda payload: jws_serialize_compact(payload),
+                )
+                self.conn.create_function(
+                    "jws_deserialize_compact", 1,
+                    lambda token: json.dumps(jws_deserialize_compact(token)),
                 )
             except Exception as e:
                 self._log(f"Warning: could not register base64_encode: {e}")

--- a/website/basic_auth_sessionless.pageql
+++ b/website/basic_auth_sessionless.pageql
@@ -8,10 +8,8 @@
 {{#insert or ignore into users(id, username, password) values (2, 'bob', 'pass')}}
 
 {{!-- Load JWT from session cookie --}}
-{{#param session optional}}
-{{#let jwt_part substr(:session, instr(:session, '.') + 1)}}
-{{#let jwt_part substr(:jwt_part, 1, instr(:jwt_part, '.') - 1)}}
-{{#let payload base64_decode(:jwt_part)}}
+{{#param cookies.session optional}}
+{{#let payload jws_deserialize_compact(:cookies.session)}}
 {{#let uid cast(json_extract(:payload, '$.uid') as integer)}}
 {{#let expiry cast(json_extract(:payload, '$.exp') as integer)}}
 {{#let jwt_valid (:expiry > cast(strftime('%s','now') as integer))}}
@@ -30,7 +28,7 @@
   {{#if uid}}
     {{#let expiry (cast(strftime('%s','now') as integer) + 3600)}}
     {{#let payload json_set('{"role":"member"}', '$.exp', :expiry, '$.uid', :uid)}}
-    {{#let token (base64_encode('{"alg":"none","typ":"JWT"}') || '.' || base64_encode(:payload) || '.')}}
+    {{#let token jws_serialize_compact(:payload)}}
     {{#cookie session :token path='/' httponly}}
     {{#redirect '/basic_auth_sessionless'}}
   {{#else}}
@@ -48,10 +46,8 @@
 {{/partial}}
 
 {{#partial GET profile}}
-  {{#param session optional}}
-  {{#let jwt_part substr(:session, instr(:session, '.') + 1)}}
-  {{#let jwt_part substr(:jwt_part, 1, instr(:jwt_part, '.') - 1)}}
-  {{#let payload base64_decode(:jwt_part)}}
+  {{#param cookies.session optional}}
+  {{#let payload jws_deserialize_compact(:cookies.session)}}
   {{#let uid cast(json_extract(:payload, '$.uid') as integer)}}
   {{#let expiry cast(json_extract(:payload, '$.exp') as integer)}}
   {{#let jwt_valid (:expiry > cast(strftime('%s','now') as integer))}}


### PR DESCRIPTION
## Summary
- register JWS helpers in `PageQLApp`
- use `cookies.session` and JWS helpers in the sessionless auth example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c81656494832fbe85c87566a40646