### PR TITLE
Add #test directive parsing

### DIFF
--- a/tests/test_test_directive.py
+++ b/tests/test_test_directive.py
@@ -1,0 +1,24 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast
+from pageql.pageql import PageQL
+
+
+def test_build_ast_collects_tests():
+    tokens = tokenize("{{#test t1}}hi {{#render x}}{{/test}}")
+    tests = {}
+    body, partials = build_ast(tokens, dialect="sqlite", tests=tests)
+    assert body == []
+    assert partials == {}
+    assert tests == {"t1": [("text", "hi "), ("#render", "x")]} 
+
+
+def test_load_module_stores_tests():
+    r = PageQL(":memory:")
+    src = "{{#test t2}}ok{{/test}}"
+    r.load_module("m", src)
+    assert "m" in r.tests
+    assert r.tests["m"] == {"t2": [("text", "ok")]}


### PR DESCRIPTION
## Summary
- parse `{{#test}}` directives in the parser
- store collected tests on `PageQL.tests`
- expose `#test` in directive help
- test basic parsing and module loading for tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683c80d5eff4832fb70bd3a10a7967ce