### PR TITLE
Add jwt load/render round-trip test

### DIFF
--- a/tests/test_jwt_token.py
+++ b/tests/test_jwt_token.py
@@ -1,0 +1,35 @@
+import sys
+import types
+import json
+
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL
+from pageql import jws_serialize_compact, jws_deserialize_compact
+
+
+def test_jwt_round_trip_load_render(tmp_path):
+    key_path = tmp_path / "key.pem"
+    r = PageQL(":memory:")
+    r.db.create_function(
+        "jws_serialize_compact",
+        1,
+        lambda payload: jws_serialize_compact(payload, key_path=str(key_path)),
+    )
+    r.db.create_function(
+        "jws_deserialize_compact",
+        1,
+        lambda token: json.dumps(
+            jws_deserialize_compact(token, key_path=str(key_path))
+        ),
+    )
+    src = """
+{{#let payload json_set('{}', '$.uid', 42)}}
+{{#let token jws_serialize_compact(:payload)}}
+{{ cast(json_extract(jws_deserialize_compact(:token), '$.uid') as integer) }}
+"""
+    r.load_module("jwt", src)
+    result = r.render("/jwt", reactive=False)
+    assert result.body.strip() == "42"


### PR DESCRIPTION
## Summary
- test jwt round-trip using PageQL load/render

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src pytest -k jwt -vv`

------
https://chatgpt.com/codex/tasks/task_e_683ca36db460832fa1ca645b4932dc27