### PR TITLE
Handle None in jws_deserialize_compact

### DIFF
--- a/src/pageql/jws_utils.py
+++ b/src/pageql/jws_utils.py
@@ -34,7 +34,15 @@ def jws_serialize_compact(payload, protected=None, *, key_path=DEFAULT_KEY_PATH)
 
 
 def jws_deserialize_compact(value, *, key_path=DEFAULT_KEY_PATH):
-    """Deserialize a JWS Compact string and return the payload."""
+    """Deserialize a JWS Compact string and return the payload.
+
+    If *value* is ``None`` return ``None`` instead of attempting to
+    deserialize it. This mirrors SQLite's ``NULL`` behaviour when the
+    function is exposed as a database function.
+    """
+    if value is None:
+        return None
+
     key = _load_or_create_key(key_path)
     obj = jws.deserialize_compact(value, key)
     return obj.payload

--- a/tests/test_jws_utils.py
+++ b/tests/test_jws_utils.py
@@ -14,3 +14,9 @@ def test_jws_round_trip(tmp_path):
     assert key_path.exists()
     assert jws_deserialize_compact(token, key_path=str(key_path)) == b"hello"
 
+
+def test_jws_deserialize_null_returns_none(tmp_path):
+    key_path = tmp_path / "key.pem"
+    assert jws_deserialize_compact(None, key_path=str(key_path)) is None
+    assert not key_path.exists()
+


### PR DESCRIPTION
## Summary
- prevent key creation when input value is `None`
- return `None` from `jws_deserialize_compact(None)`
- add test verifying `None` handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cab339e9c832f8b2105b4278701ff