### PR TITLE
Improve CLI test flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It was inspired by ColdFusion language that allows embedding SQL and Handlebars 
 
 PageQL is **reactive-first**: rendered HTML automatically updates when the underlying database data changes.
 
-Usage: ```pageql <database> templates [--create]```
+Usage: ```pageql <database> templates [--create] [--test]```
 
 Install: pip install pageql
 
@@ -72,6 +72,7 @@ pageql -path/to/your/database.sqlite ./templates
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   `--fallback-url <url>`: (Optional) Forward unknown routes to this base URL.
 *   `--no-csrf`: (Optional) Disable CSRF protection. Useful for local testing but not recommended in production.
+*   `--test`: (Optional) Run template tests and exit instead of serving.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
 *   When a PostgreSQL or MySQL URL is provided, `--create` is ignored and the

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -48,15 +48,6 @@ def run_pageql_tests(templates_dir: str) -> bool:
 
 def main():
     """Entry point for the pageql command-line tool."""
-    if '--test' in sys.argv:
-        idx = sys.argv.index('--test')
-        if len(sys.argv) <= idx + 1:
-            print('Usage: pageql --test <templates_dir>')
-            sys.exit(1)
-        templates_dir = sys.argv[idx + 1]
-        success = run_pageql_tests(templates_dir)
-        sys.exit(0 if success else 1)
-
     parser = argparse.ArgumentParser(description="Run the PageQL development server.")
 
     # Add positional arguments - these will be the primary way to use the command
@@ -69,6 +60,7 @@ def main():
     parser.add_argument('-q', '--quiet', action='store_true', help="Only show errors in output.")
     parser.add_argument('--fallback-url', help="Forward unknown routes to this base URL")
     parser.add_argument('--no-csrf', action='store_true', help="Disable CSRF protection")
+    parser.add_argument('--test', action='store_true', help="Run tests instead of serving")
 
     # If no arguments were provided (only the script name), print help and exit.
     if len(sys.argv) == 1:
@@ -76,6 +68,10 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
+
+    if args.test:
+        success = run_pageql_tests(args.templates_dir)
+        sys.exit(0 if success else 1)
 
     if args.db_file is None or args.templates_dir is None:
         parser.error("db_file and templates_dir are required")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ def test_cli_test_command(monkeypatch, tmp_path, capsys):
     (tmp_path / "t.pageql").write_text(
         "{{#test a}}{{#create table t(x int)}}{{#insert into t values (1)}}{{count(*) from t}}{{/test}}"
     )
-    argv = ["pageql", "--test", str(tmp_path)]
+    argv = ["pageql", "db.sqlite", str(tmp_path), "--test"]
     monkeypatch.setattr(sys, "argv", argv)
     with pytest.raises(SystemExit) as exc:
         cli.main()


### PR DESCRIPTION
## Summary
- add `--test` flag to CLI argparser
- update README for `--test` usage
- fix CLI test to use new flag

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cab951ad8832faac02823af04a477