### PR TITLE
Fix NULL literal handling in PageQL expressions

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -318,6 +318,10 @@ def db_execute_dot(db, exp, params):
 
 def evalone(db, exp, params, reactive=False, tables=None, expr=None):
     exp = exp.strip()
+    if exp.upper() == "NULL":
+        if reactive:
+            return DerivedSignal(lambda: None, [])
+        return None
     dialect = getattr(tables, "dialect", "sqlite") if tables is not None else "sqlite"
     if re.match("^:?[a-zA-z._][a-zA-z._0-9]*$", exp):
         original = exp[1:] if exp.startswith(":") else exp

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -35,7 +35,9 @@ def _replace_placeholders(
         val = params[name]
         if isinstance(val, (DerivedSignal, DerivedSignal2, OneValue, ReadOnly)):
             val = val.value
-        if isinstance(val, (int, float)):
+        if val is None:
+            lit = exp.Null()
+        elif isinstance(val, (int, float)):
             lit = exp.Literal.number(val)
         elif isinstance(val, (bytes, bytearray)):
             if dialect == "mysql":

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -703,3 +703,14 @@ def test_pinsert_does_not_send_marker_scripts():
     sc = ctx.scripts[0]
     assert sc.startswith("pinsert(")
     assert "pstart" not in sc and "pend" not in sc
+
+
+def test_let_null_literal():
+    r = PageQL(":memory:")
+    snippet = (
+        "{{#let v = NULL}}"
+        "{{#if :v IS NULL}}null{{#else}}not null{{/if}}"
+    )
+    r.load_module("m", snippet)
+    result = r.render("/m")
+    assert "null" in result.body


### PR DESCRIPTION
## Summary
- support `NULL` literal in `evalone`
- render SQL expressions involving `None` correctly in reactive mode
- test `#let` with `NULL`

## Testing
- `pytest -k test_let_null_literal -vv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cad385530832f9658c6113bec67c7