### PR TITLE
Return ReadOnly(None) for NULL

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -320,7 +320,7 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
     exp = exp.strip()
     if exp.upper() == "NULL":
         if reactive:
-            return DerivedSignal(lambda: None, [])
+            return ReadOnly(None)
         return None
     dialect = getattr(tables, "dialect", "sqlite") if tables is not None else "sqlite"
     if re.match("^:?[a-zA-z._][a-zA-z._0-9]*$", exp):


### PR DESCRIPTION
## Summary
- return `ReadOnly(None)` instead of constructing a DerivedSignal when evaluating `NULL`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cb087dd18832faeefe7fd1bf58cd8