### PR TITLE
Limit anyio backend to asyncio

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,10 @@ async def _awatch_stub(*args, **kwargs):
         yield None
 
 sys.modules["watchfiles"].awatch = _awatch_stub
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
## Summary
- override `anyio_backend` fixture so that pytest runs only with asyncio

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ea5221678832fb45843fa3c4b4fe6