### PR TITLE
Remove unneeded waits in browser tests

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -132,7 +132,6 @@ async def test_reactive_count_insert_via_execute(browser):
         )
 
         async def after(page, port, app: PageQLApp):
-            await page.wait_for_timeout(30)
             app.pageql_engine.tables.executeone(
                 "INSERT INTO nums(value) VALUES (1)", {}
             )
@@ -158,7 +157,6 @@ async def test_reactive_count_delete_via_execute(browser):
         )
 
         async def after(page, port, app: PageQLApp):
-            await page.wait_for_timeout(30)
             app.pageql_engine.tables.executeone(
                 "DELETE FROM nums WHERE value = 1",
                 {},
@@ -182,11 +180,9 @@ async def test_insert_via_execute_after_click(browser):
         )
 
         async def after(page, port, app: PageQLApp):
-            await page.wait_for_timeout(30)
             app.pageql_engine.tables.executeone(
                 "INSERT INTO msgs(text) VALUES (:text)", {"text": "hello"}
             )
-            await page.wait_for_timeout(30)
 
         result = await _load_page_async(tmpdir, "msgs", after, reload=True, browser=browser)
         _, body_text = result


### PR DESCRIPTION
## Summary
- remove `page.wait_for_timeout` calls from integration tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683eaba97a48832f9fda8c873a57c630