### PR TITLE
Refactor render context

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -3,7 +3,8 @@ PageQL: A template language for embedding SQL inside HTML directly
 """
 
 # Import the main classes from the PageQL modules
-from .pageql import PageQL, RenderResult
+from .pageql import PageQL
+from .render_context import RenderResult
 from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -35,6 +35,7 @@ from pageql.reactive import (
     ReadOnly,
     _convert_dot_sql,
 )
+from pageql.render_context import RenderContext, RenderResult, RenderResultException
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 import sqlglot
 
@@ -188,80 +189,6 @@ def format_unknown_directive(directive: str) -> str:
     return "\n".join(lines) + "</pre>"
 
 
-# Define RenderResult as a simple class
-class RenderResult:
-    """Holds the results of a render operation."""
-
-    def __init__(self, status_code=200, headers=None, cookies=None, body="", context=None):
-        if headers is None:
-            headers = []
-        if cookies is None:
-            cookies = []
-        self.body = body
-        self.status_code = status_code
-        self.headers = headers  # List of (name, value) tuples
-        self.cookies = cookies  # List of (name, value, opts) tuples
-        self.redirect_to = None
-        self.context = context
-
-
-class RenderContext:
-    """Track state for a single render pass."""
-
-    def __init__(self):
-        self.next_id = 0
-        self.listeners = []
-        self.out = []
-        self.scripts: list[str] = []
-        self.send_script = None
-        self.rendering = True
-        self.reactiveelement = None
-        self.headers: list[tuple[str, str]] = []
-        self.cookies: list[tuple[str, str, dict]] = []
-
-    def marker_id(self) -> int:
-        mid = self.next_id
-        self.next_id += 1
-        return mid
-
-    def add_listener(self, signal, listener):
-        signal.listeners.append(listener)
-        self.listeners.append((signal, listener))
-
-    def add_dependency(self, signal):
-        """Track *signal* for cleanup without reacting to updates."""
-        self.add_listener(signal, lambda *_: None)
-
-    def cleanup(self):
-        for signal, listener in self.listeners:
-            signal.remove_listener(listener)
-        self.listeners.clear()
-
-    def clear_output(self):
-        self.out.clear()
-
-    def append_script(self, content, out=None):
-        if out is None:
-            out = self.out
-
-        send_directly = out is self.out and not self.rendering
-
-        if not send_directly:
-            # Avoid prematurely closing the script tag if ``content`` contains
-            # the ``</script>`` sequence by escaping it. This can happen when
-            # reactive HTML snippets include nested ``<script>`` tags that are
-            # inserted via ``pinsert`` or ``pupdate``.
-            # Escape any nested ``</script>`` sequences to avoid prematurely
-            # terminating the surrounding script tag. Using a double backslash
-            # prevents ``SyntaxWarning: invalid escape sequence`` from Python
-            # while producing the desired ``<\/script>`` string in HTML.
-            safe_content = content.replace("</script>", "<\\/script>")
-            out.append(f"<script>{safe_content}</script>")
-        else:
-            if self.send_script is not None:
-                self.send_script(content)
-            else:
-                self.scripts.append(content)
 
 
 def db_execute_dot(db, exp, params):
@@ -397,12 +324,6 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         raise ValueError(f"Error evaluating SQL expression `{exp}` with params `{params}`: {e}")
 
 
-class RenderResultException(Exception):
-    """
-    Exception raised when a render result is returned from a render call.
-    """
-    def __init__(self, render_result):
-        self.render_result = render_result
 
 class PageQL:
     """

--- a/src/pageql/render_context.py
+++ b/src/pageql/render_context.py
@@ -1,0 +1,82 @@
+"""Utilities and classes for managing rendering state."""
+
+class RenderResult:
+    """Holds the results of a render operation."""
+
+    def __init__(self, status_code=200, headers=None, cookies=None, body="", context=None):
+        if headers is None:
+            headers = []
+        if cookies is None:
+            cookies = []
+        self.body = body
+        self.status_code = status_code
+        self.headers = headers  # List of (name, value) tuples
+        self.cookies = cookies  # List of (name, value, opts) tuples
+        self.redirect_to = None
+        self.context = context
+
+
+class RenderContext:
+    """Track state for a single render pass."""
+
+    def __init__(self):
+        self.next_id = 0
+        self.listeners = []
+        self.out = []
+        self.scripts: list[str] = []
+        self.send_script = None
+        self.rendering = True
+        self.reactiveelement = None
+        self.headers: list[tuple[str, str]] = []
+        self.cookies: list[tuple[str, str, dict]] = []
+
+    def marker_id(self) -> int:
+        mid = self.next_id
+        self.next_id += 1
+        return mid
+
+    def add_listener(self, signal, listener):
+        signal.listeners.append(listener)
+        self.listeners.append((signal, listener))
+
+    def add_dependency(self, signal):
+        """Track *signal* for cleanup without reacting to updates."""
+        self.add_listener(signal, lambda *_: None)
+
+    def cleanup(self):
+        for signal, listener in self.listeners:
+            signal.remove_listener(listener)
+        self.listeners.clear()
+
+    def clear_output(self):
+        self.out.clear()
+
+    def append_script(self, content, out=None):
+        if out is None:
+            out = self.out
+
+        send_directly = out is self.out and not self.rendering
+
+        if not send_directly:
+            # Avoid prematurely closing the script tag if ``content`` contains
+            # the ``</script>`` sequence by escaping it. This can happen when
+            # reactive HTML snippets include nested ``<script>`` tags that are
+            # inserted via ``pinsert`` or ``pupdate``.
+            # Escape any nested ``</script>`` sequences to avoid prematurely
+            # terminating the surrounding script tag. Using a double backslash
+            # prevents ``SyntaxWarning: invalid escape sequence`` from Python
+            # while producing the desired ``<\/script>`` string in HTML.
+            safe_content = content.replace("</script>", "<\\/script>")
+            out.append(f"<script>{safe_content}</script>")
+        else:
+            if self.send_script is not None:
+                self.send_script(content)
+            else:
+                self.scripts.append(content)
+
+
+class RenderResultException(Exception):
+    """Exception raised when a render result is returned from a render call."""
+
+    def __init__(self, render_result):
+        self.render_result = render_result


### PR DESCRIPTION
## Summary
- extract `RenderResult`, `RenderContext`, and `RenderResultException` to a new module `render_context.py`
- update imports to reference the new module

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ef9a7d100832fafe44f303f541d4b