### PR TITLE
Refactor render context classes

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -3,7 +3,8 @@ PageQL: A template language for embedding SQL inside HTML directly
 """
 
 # Import the main classes from the PageQL modules
-from .pageql import PageQL, RenderResult
+from .pageql import PageQL
+from .render_context import RenderResult, RenderContext, RenderResultException
 from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
@@ -15,6 +16,8 @@ __version__ = "0.1.0"
 __all__ = [
     "PageQL",
     "RenderResult",
+    "RenderContext",
+    "RenderResultException",
     "ReadOnly",
     "PageQLApp",
     "parse_reactive",

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -8,7 +8,8 @@ import os
 import sys
 import uvicorn
 
-from .pageql import PageQL, RenderContext
+from .pageql import PageQL
+from .render_context import RenderContext
 from .pageqlapp import PageQLApp
 
 

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -35,6 +35,7 @@ from pageql.reactive import (
     ReadOnly,
     _convert_dot_sql,
 )
+from .render_context import RenderResult, RenderContext, RenderResultException
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 from pageql.database import (
     connect_database,
@@ -86,90 +87,6 @@ def format_unknown_directive(directive: str) -> str:
     return "\n".join(lines) + "</pre>"
 
 
-# Define RenderResult as a simple class
-class RenderResult:
-    """Holds the results of a render operation."""
-
-    def __init__(self, status_code=200, headers=None, cookies=None, body="", context=None):
-        if headers is None:
-            headers = []
-        if cookies is None:
-            cookies = []
-        self.body = body
-        self.status_code = status_code
-        self.headers = headers  # List of (name, value) tuples
-        self.cookies = cookies  # List of (name, value, opts) tuples
-        self.redirect_to = None
-        self.context = context
-
-
-class RenderContext:
-    """Track state for a single render pass."""
-
-    def __init__(self):
-        self.next_id = 0
-        self.listeners = []
-        self.out = []
-        self.scripts: list[str] = []
-        self.send_script = None
-        self.rendering = True
-        self.reactiveelement = None
-        self.headers: list[tuple[str, str]] = []
-        self.cookies: list[tuple[str, str, dict]] = []
-
-    def marker_id(self) -> int:
-        mid = self.next_id
-        self.next_id += 1
-        return mid
-
-    def add_listener(self, signal, listener):
-        signal.listeners.append(listener)
-        self.listeners.append((signal, listener))
-
-    def add_dependency(self, signal):
-        """Track *signal* for cleanup without reacting to updates."""
-        self.add_listener(signal, lambda *_: None)
-
-    def cleanup(self):
-        for signal, listener in self.listeners:
-            signal.remove_listener(listener)
-        self.listeners.clear()
-
-    def clear_output(self):
-        self.out.clear()
-
-    def append_script(self, content, out=None):
-        if out is None:
-            out = self.out
-
-        send_directly = out is self.out and not self.rendering
-
-        if not send_directly:
-            # Avoid prematurely closing the script tag if ``content`` contains
-            # the ``</script>`` sequence by escaping it. This can happen when
-            # reactive HTML snippets include nested ``<script>`` tags that are
-            # inserted via ``pinsert`` or ``pupdate``.
-            # Escape any nested ``</script>`` sequences to avoid prematurely
-            # terminating the surrounding script tag. Using a double backslash
-            # prevents ``SyntaxWarning: invalid escape sequence`` from Python
-            # while producing the desired ``<\/script>`` string in HTML.
-            safe_content = content.replace("</script>", "<\\/script>")
-            out.append(f"<script>{safe_content}</script>")
-        else:
-            if self.send_script is not None:
-                self.send_script(content)
-            else:
-                self.scripts.append(content)
-
-
-
-
-class RenderResultException(Exception):
-    """
-    Exception raised when a render result is returned from a render call.
-    """
-    def __init__(self, render_result):
-        self.render_result = render_result
 
 class PageQL:
     """

--- a/src/pageql/render_context.py
+++ b/src/pageql/render_context.py
@@ -1,0 +1,84 @@
+"""Utilities for managing render state and results."""
+
+
+class RenderResult:
+    """Holds the results of a render operation."""
+
+    def __init__(self, status_code=200, headers=None, cookies=None, body="", context=None):
+        if headers is None:
+            headers = []
+        if cookies is None:
+            cookies = []
+        self.body = body
+        self.status_code = status_code
+        self.headers = headers  # List of (name, value) tuples
+        self.cookies = cookies  # List of (name, value, opts) tuples
+        self.redirect_to = None
+        self.context = context
+
+
+class RenderContext:
+    """Track state for a single render pass."""
+
+    def __init__(self):
+        self.next_id = 0
+        self.listeners = []
+        self.out = []
+        self.scripts: list[str] = []
+        self.send_script = None
+        self.rendering = True
+        self.reactiveelement = None
+        self.headers: list[tuple[str, str]] = []
+        self.cookies: list[tuple[str, str, dict]] = []
+
+    def marker_id(self) -> int:
+        mid = self.next_id
+        self.next_id += 1
+        return mid
+
+    def add_listener(self, signal, listener):
+        signal.listeners.append(listener)
+        self.listeners.append((signal, listener))
+
+    def add_dependency(self, signal):
+        """Track *signal* for cleanup without reacting to updates."""
+        self.add_listener(signal, lambda *_: None)
+
+    def cleanup(self):
+        for signal, listener in self.listeners:
+            signal.remove_listener(listener)
+        self.listeners.clear()
+
+    def clear_output(self):
+        self.out.clear()
+
+    def append_script(self, content, out=None):
+        if out is None:
+            out = self.out
+
+        send_directly = out is self.out and not self.rendering
+
+        if not send_directly:
+            # Avoid prematurely closing the script tag if ``content`` contains
+            # the ``</script>`` sequence by escaping it. This can happen when
+            # reactive HTML snippets include nested ``<script>`` tags that are
+            # inserted via ``pinsert`` or ``pupdate``.
+            # Escape any nested ``</script>`` sequences to avoid prematurely
+            # terminating the surrounding script tag. Using a double backslash
+            # prevents ``SyntaxWarning: invalid escape sequence`` from Python
+            # while producing the desired ``<\/script>`` string in HTML.
+            safe_content = content.replace("</script>", "<\\/script>")
+            out.append(f"<script>{safe_content}</script>")
+        else:
+            if self.send_script is not None:
+                self.send_script(content)
+            else:
+                self.scripts.append(content)
+
+
+class RenderResultException(Exception):
+    """Exception raised when a render result is returned from a render call."""
+
+    def __init__(self, render_result):
+        self.render_result = render_result
+

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -71,7 +71,8 @@ from pageql.reactive import (
     get_dependencies,
     ReadOnly,
 )
-from pageql.pageql import RenderContext, Tables
+from pageql.render_context import RenderContext
+from pageql.pageql import Tables
 from pageql.database import evalone
 
 
@@ -158,7 +159,7 @@ def test_delete_propagates_renderresultexception():
     conn = _db()
     rt = ReactiveTable(conn, "items")
 
-    from pageql.pageql import RenderResult, RenderResultException
+    from pageql.render_context import RenderResult, RenderResultException
 
     def boom(_):
         raise RenderResultException(RenderResult(status_code=302))

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,7 +7,8 @@ import types
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-from pageql.pageql import PageQL, RenderContext
+from pageql.pageql import PageQL
+from pageql.render_context import RenderContext
 from pageql.reactive import DerivedSignal
 
 


### PR DESCRIPTION
## Summary
- factor out `RenderContext`, `RenderResult`, and `RenderResultException`
- update imports across project and tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_683eff05cc40832fbcdc845ad8711585