### PR TITLE
Add fetch directive parser

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -77,6 +77,7 @@ DIRECTIVE_HELP: dict[str, str] = {
     "#header <name> <expr>": "add an HTTP response header",
     "#cookie <name> <expr> [opts]": "set an HTTP cookie",
     "#update <table> set <expr> where <cond>": "execute an SQL UPDATE",
+    "#fetch <var> from <url>": "fetch a remote URL into a variable",
 }
 
 def format_unknown_directive(directive: str) -> str:

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -192,6 +192,17 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
             body.append(("#let", (var, sql, expr)))
             continue
 
+        if ntype == "#fetch":
+            var, rest = parsefirstword(ncontent)
+            if rest is None:
+                raise SyntaxError("#fetch requires a variable and expression")
+            first, expr = parsefirstword(rest)
+            if first.lower() != "from" or expr is None:
+                raise SyntaxError("#fetch syntax is '<var> from <expr>'")
+            i += 1
+            body.append(("#fetch", (var, expr)))
+            continue
+
         # -------------------------------------------------------- #partial ...
         if ntype == "#partial":
             part_terms = {"/partial"}
@@ -409,6 +420,8 @@ def ast_param_dependencies(ast):
                 deps.update(get_dependencies(_convert_dot_sql(c[1])))
             elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#redirect", "#statuscode", "#error"}:
                 deps.update(get_dependencies(_convert_dot_sql(c)))
+            elif t == "#fetch":
+                deps.update(get_dependencies(_convert_dot_sql(c[1])))
             elif t == "#header":
                 _, rest = parsefirstword(c)
                 if rest:

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -1,0 +1,20 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast, ast_param_dependencies
+
+
+def test_fetch_directive_parsed():
+    tokens = tokenize("{{#fetch file from 'http://ex'}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert body == [("#fetch", ("file", "'http://ex'"))]
+
+
+def test_fetch_directive_dependencies():
+    tokens = tokenize("{{#fetch dst from :url}}")
+    ast = build_ast(tokens, dialect="sqlite")
+    deps = ast_param_dependencies(ast)
+    assert deps == {"url"}
+


### PR DESCRIPTION
## Summary
- support `#fetch` directive in the parser
- include `#fetch` in directive help
- expose dependencies for `#fetch`
- add unit tests for the new directive

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68411d194828832fa2e44079c066b3ed