### PR TITLE
Add fetch directive using fetch_cb

### DIFF
--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -4,6 +4,8 @@ sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies
+from pageql.pageql import PageQL
+import pytest
 
 
 def test_fetch_directive_parsed():
@@ -17,4 +19,25 @@ def test_fetch_directive_dependencies():
     ast = build_ast(tokens, dialect="sqlite")
     deps = ast_param_dependencies(ast)
     assert deps == {"url"}
+
+
+def test_fetch_directive_render():
+    seen = []
+
+    def fetch(url: str):
+        seen.append(url)
+        return {"a": "1", "b": "2"}
+
+    r = PageQL(":memory:", fetch_cb=fetch)
+    r.load_module("m", "{{#fetch data from 'http://x'}}{{data__a}} {{data__b}}")
+    out = r.render("/m", reactive=False).body
+    assert out.strip() == "1 2"
+    assert seen == ["http://x"]
+
+
+def test_fetch_directive_missing_cb_errors():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#fetch f from 'u'}}")
+    with pytest.raises(ValueError):
+        r.render("/m", reactive=False)
 


### PR DESCRIPTION
## Summary
- implement `#fetch` directive in PageQL
- call provided `fetch_cb` to retrieve data and merge into params
- expose `fetch_cb` results during rendering
- test parsing, dependency extraction and rendering of `#fetch`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841a21f8dec832fadaed64f48e3efa6