### PR TITLE
Fix websocket disconnect logging

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -273,7 +273,9 @@ class PageQLApp:
                     if client_id:
                         self.websockets.pop(client_id, None)
                         contexts = self.render_contexts.pop(client_id, [])
-                        print(f"websocket.disconnect: {client_id} render_contexts: {self.render_contexts.keys()}")
+                        self._debug(
+                            f"websocket.disconnect: {client_id} render_contexts: {self.render_contexts.keys()}"
+                        )
                         for ctx in contexts:
                             ctx.send_script = None
                             ctx.cleanup()


### PR DESCRIPTION
## Summary
- use `_debug` helper when logging websocket disconnects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841aa3b1a20832fb28c04ab2dc36970