### PR TITLE
Default fetch directive uses async http

### DIFF
--- a/src/pageql/http_utils.py
+++ b/src/pageql/http_utils.py
@@ -5,7 +5,14 @@ import re
 from urllib.parse import urlparse, parse_qs
 from typing import Dict, List, Tuple, Callable, Awaitable
 
-__all__ = ["_http_get", "_parse_multipart_data", "_read_chunked_body", "_parse_cookies", "_parse_form_data"]
+__all__ = [
+    "_http_get",
+    "http_get_map",
+    "_parse_multipart_data",
+    "_read_chunked_body",
+    "_parse_cookies",
+    "_parse_form_data",
+]
 
 
 async def _read_chunked_body(reader: asyncio.StreamReader) -> bytes:
@@ -151,6 +158,16 @@ async def _http_get(url: str) -> Tuple[int, List[Tuple[bytes, bytes]], bytes]:
     writer.close()
     await writer.wait_closed()
     return status, headers, body
+
+
+async def http_get_map(url: str) -> Dict[str, object]:
+    """Return a mapping with ``status``, ``headers`` and decoded ``body``."""
+    status, headers, body = await _http_get(url)
+    try:
+        body = body.decode("utf-8")
+    except Exception:
+        pass
+    return {"status": status, "headers": headers, "body": body}
 
 
 def _parse_cookies(cookie_header: str) -> Dict[str, str]:

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -45,6 +45,7 @@ from pageql.database import (
     evalone,
 )
 from pageql.params import handle_param
+from pageql.http_utils import http_get_map
 import sqlglot
 
 
@@ -109,9 +110,10 @@ class PageQL:
 
         Args:
             db_path: Path to the SQLite database file or database URL.
-            fetch_cb: Optional HTTP fetch callback.
+            fetch_cb: Optional HTTP fetch callback. Defaults to an async
+                HTTP GET using :func:`pageql.http_utils.http_get_map`.
         """
-        self.fetch_cb = fetch_cb
+        self.fetch_cb = fetch_cb or http_get_map
         self._modules = {} # Store parsed node lists here later
         self._parse_errors = {} # Store errors here
         self.tests = {}

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -35,9 +35,33 @@ def test_fetch_directive_render():
     assert seen == ["http://x"]
 
 
-def test_fetch_directive_missing_cb_errors():
-    r = PageQL(":memory:")
-    r.load_module("m", "{{#fetch f from 'u'}}")
-    with pytest.raises(ValueError):
-        r.render("/m", reactive=False)
+def test_fetch_directive_defaults_to_http_get():
+    import http.server, threading
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"hi"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever)
+    t.start()
+    try:
+        r = PageQL(":memory:")
+        r.load_module(
+            "m",
+            "{{#fetch d from 'http://127.0.0.1:' || :port}}{{d__status}} {{d__body}}",
+        )
+        out = r.render("/m", {"port": port}, reactive=False).body.strip()
+        assert out == "200 hi"
+    finally:
+        server.shutdown()
+        t.join()
 


### PR DESCRIPTION
## Summary
- add `http_get_map` wrapper for `_http_get`
- default `PageQL.fetch_cb` to use `http_get_map`
- test fetch directive with default callback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841fbd73650832fb841a3de90994c7f