### PR TITLE
Fix benchmark error and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ Basic performance tests can be executed using the standalone script in
 rendering features of PageQL with both an in-memory SQLite database and
 a temporary file based database.
 
+Run it with the repository's `src` directory on the Python path so that the
+`pageql` package can be imported:
+
 ```bash
-python benchmarks/benchmark_pageql.py
+PYTHONPATH=src python benchmarks/benchmark_pageql.py
 ```
 
 ## Core Philosophy


### PR DESCRIPTION
## Summary
- fix server shutdown in benchmark_pageql.py
- update README instructions for running benchmarks

## Testing
- `pytest`
- `PYTHONPATH=src python benchmarks/benchmark_pageql.py`

------
https://chatgpt.com/codex/tasks/task_e_684267823c68832fa3f6bee0d337ae50