### PR TITLE
Add slow fetch benchmark

### DIFF
--- a/benchmarks/benchmark_pageql.py
+++ b/benchmarks/benchmark_pageql.py
@@ -10,10 +10,14 @@ ITERATIONS = 100
 
 # port assigned to the local fetch server
 FETCH_PORT = 0
+# when True the fetch server delays responses
+SLOW_FETCH = False
 
 async def _handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
     await reader.readuntil(b"\r\n\r\n")
     body = b"hi"
+    if SLOW_FETCH:
+        await asyncio.sleep(0.005)
     writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
     await writer.drain()
     writer.close()
@@ -72,6 +76,7 @@ MODULES = {
     'count': "{{count(*) from items}}",
     's12_update': "{{#update items set name='upd' where id=1}}{{#update items set name='upd0' where id=1}}",
     's13_fetch': "{{#fetch d from 'http://127.0.0.1:' || :port}}{{d__body}}",
+    's21_slow_fetch': "{{#fetch d from 'http://127.0.0.1:' || :port}}{{d__body}}",
     's14_render_partial': "{{#partial public greet}}hi {{who}}{{/partial}}{{#render greet who='Bob'}}",
     's15_param': "{{#partial public greet}}{{#param who required}}{{who}}{{/partial}}{{#render greet who='Ann'}}",
     's16_create': "{{#create table if not exists t (id int)}}done",
@@ -94,7 +99,7 @@ PARAMS = {
 def bench_factory(name):
     def bench(pql):
         params = PARAMS.get(name, {}).copy()
-        if name == 's13_fetch':
+        if name in ('s13_fetch', 's21_slow_fetch'):
             params['port'] = FETCH_PORT
         return pql.render('/' + name, params)
     return bench
@@ -103,7 +108,7 @@ SCENARIOS = [(n, bench_factory(n)) for n in MODULES if n != 'other']
 
 
 def run_benchmarks(db_path):
-    global FETCH_PORT
+    global FETCH_PORT, SLOW_FETCH
     loop, server, port, thread = _start_server()
     FETCH_PORT = port
     print(f"Running benchmarks for {db_path} ...")
@@ -116,6 +121,7 @@ def run_benchmarks(db_path):
                 continue
             pql.load_module(m, src)
         bench = bench_factory(name)
+        SLOW_FETCH = name == 's21_slow_fetch'
         start = time.perf_counter()
         for _ in range(ITERATIONS):
             bench(pql)


### PR DESCRIPTION
## Summary
- add ability to delay responses from benchmark fetch server
- include `s21_slow_fetch` scenario in `benchmark_pageql`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842698bfad8832f8f1a843f95dcee11