### PR TITLE
Rename http_get_map to fetch

### DIFF
--- a/src/pageql/http_utils.py
+++ b/src/pageql/http_utils.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Tuple, Callable, Awaitable
 
 __all__ = [
     "_http_get",
-    "http_get_map",
+    "fetch",
     "_parse_multipart_data",
     "_read_chunked_body",
     "_parse_cookies",
@@ -160,7 +160,7 @@ async def _http_get(url: str) -> Tuple[int, List[Tuple[bytes, bytes]], bytes]:
     return status, headers, body
 
 
-async def http_get_map(url: str) -> Dict[str, object]:
+async def fetch(url: str) -> Dict[str, object]:
     """Return a mapping with ``status``, ``headers`` and decoded ``body``."""
     status, headers, body = await _http_get(url)
     try:

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -45,7 +45,7 @@ from pageql.database import (
     evalone,
 )
 from pageql.params import handle_param
-from pageql.http_utils import http_get_map
+from pageql.http_utils import fetch
 import sqlglot
 
 
@@ -111,9 +111,9 @@ class PageQL:
         Args:
             db_path: Path to the SQLite database file or database URL.
             fetch_cb: Optional HTTP fetch callback. Defaults to an async
-                HTTP GET using :func:`pageql.http_utils.http_get_map`.
+                HTTP GET using :func:`pageql.http_utils.fetch`.
         """
-        self.fetch_cb = fetch_cb or http_get_map
+        self.fetch_cb = fetch_cb or fetch
         self._modules = {} # Store parsed node lists here later
         self._parse_errors = {} # Store errors here
         self.tests = {}


### PR DESCRIPTION
## Summary
- rename the http_utils helper `http_get_map` to `fetch`
- update PageQL to reference `fetch` as the default HTTP helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68426f2a5d0c832f81a1b517cacbfe38