### PR TITLE
Throw error when #fetch lacks asyncio loop

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -542,16 +542,12 @@ class PageQL:
         if asyncio.iscoroutine(data):
             try:
                 loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                try:
-                    asyncio.set_event_loop(loop)
-                    data = loop.run_until_complete(data)
-                finally:
-                    asyncio.set_event_loop(None)
-                    loop.close()
-            else:
-                data = loop.run_until_complete(data)
+            except RuntimeError as e:
+                data.close()
+                raise RuntimeError(
+                    "#fetch requires an active asyncio event loop"
+                ) from e
+            data = loop.run_until_complete(data)
         for k, v in flatten_params(data).items():
             params[f"{var}__{k}"] = v
         return reactive


### PR DESCRIPTION
## Summary
- fail if `#fetch` can't obtain the current asyncio loop
- ensure coroutine is closed when raising
- adapt fetch directive tests for new behavior
- test missing loop case for async fetch callbacks

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_684281e1bcd4832fb4d24b152992dfa4