### PR TITLE
Update fetch to return status_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pageql -path/to/your/database.sqlite ./templates
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
     *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
-*   `#fetch <var> from <url_expression>`: Fetches an external URL using a callback provided to `PageQL` and exposes the result as `<var>.body` and `<var>.status_code`.
+*   `#fetch <var> from <url_expression>`: Fetches an external URL using a callback provided to `PageQL` and exposes the result as `<var>.body`, `<var>.status_code` and `<var>.headers`.
 
 **Flow Control:**
 

--- a/src/pageql/http_utils.py
+++ b/src/pageql/http_utils.py
@@ -169,13 +169,13 @@ async def _http_get(
 
 
 async def fetch(url: str) -> Dict[str, object]:
-    """Return a mapping with ``status``, ``headers`` and decoded ``body``."""
+    """Return a mapping with ``status_code``, ``headers`` and decoded ``body``."""
     status, headers, body = await _http_get(url)
     try:
         body = body.decode("utf-8")
     except Exception:
         pass
-    return {"status": status, "headers": headers, "body": body}
+    return {"status_code": status, "headers": headers, "body": body}
 
 
 def fetch_sync(url: str) -> Dict[str, object]:
@@ -190,7 +190,7 @@ def fetch_sync(url: str) -> Dict[str, object]:
         body = body_bytes.decode("utf-8")
     except Exception:
         body = body_bytes
-    return {"status": status, "headers": headers, "body": body}
+    return {"status_code": status, "headers": headers, "body": body}
 
 
 def _parse_cookies(cookie_header: str) -> Dict[str, str]:

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -64,7 +64,7 @@ def test_fetch_directive_defaults_to_http_get():
         r = PageQL(":memory:")
         r.load_module(
             "m",
-            "{{#fetch d from 'http://127.0.0.1:' || :port}}{{d__status}} {{d__body}}",
+            "{{#fetch d from 'http://127.0.0.1:' || :port}}{{d__status_code}} {{d__body}}",
         )
         out = r.render("/m", {"port": port}, reactive=False).body.strip()
         assert out == "200 hi"


### PR DESCRIPTION
## Summary
- expose headers in #fetch directive
- return `status_code` from `http_utils.fetch` and `fetch_sync`
- adjust docs and tests for new name

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68428f9cc364832fae7b56616d09a23f