### PR TITLE
Disable fetch scenarios in benchmark

### DIFF
--- a/benchmarks/benchmark_pageql.py
+++ b/benchmarks/benchmark_pageql.py
@@ -83,7 +83,11 @@ def bench_factory(name):
         return pql.render('/' + name, params)
     return bench
 
-SCENARIOS = [(n, bench_factory(n)) for n in MODULES if n != 'other']
+SCENARIOS = [
+    (n, bench_factory(n))
+    for n in MODULES
+    if n not in ('other', 's13_fetch', 's21_slow_fetch')
+]
 
 
 async def run_benchmarks(db_path):


### PR DESCRIPTION
## Summary
- exclude the two fetch scenarios from `benchmark_pageql.py`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68429798182c832f91834a344dde9dae