### PR TITLE
Remove parallel benchmark run

### DIFF
--- a/benchmarks/benchmark_pageql.py
+++ b/benchmarks/benchmark_pageql.py
@@ -161,5 +161,4 @@ if __name__ == '__main__':
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, 'bench.db')
         asyncio.run(run_benchmarks(path))
-    print("\nParallel version:\n")
-    asyncio.run(run_benchmarks_parallel(':memory:'))
+


### PR DESCRIPTION
## Summary
- avoid running parallel benchmarks in `benchmark_pageql`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684298f5f348832f943e6bc55be4b562