### PR TITLE
Update benchmark to run fetch twice

### DIFF
--- a/benchmarks/async_uvicorn_benchmark.py
+++ b/benchmarks/async_uvicorn_benchmark.py
@@ -172,6 +172,7 @@ async def run_fetch_only_benchmark(
 
 
 if __name__ == "__main__":
-    asyncio.run(run_fetch_only_benchmark(http_disconnect_cleanup_timeout=None))
+    asyncio.run(run_fetch_only_benchmark(http_disconnect_cleanup_timeout=0.05))
+    asyncio.run(run_fetch_only_benchmark(http_disconnect_cleanup_timeout=5))
     asyncio.run(run_benchmark())
 


### PR DESCRIPTION
## Summary
- run `run_fetch_only_benchmark` twice with 0.05s and 5s timeouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68429afd9220832fa21ade61cec25e33