### PR TITLE
Remove in-memory benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Install: pip install pageql  # uvicorn[standard] is installed automatically
 
 Basic performance tests can be executed using the standalone script in
 `benchmarks/benchmark_pageql.py`.  The script exercises 20 different
-rendering features of PageQL with both an in-memory SQLite database and
-a temporary file based database.
+rendering features of PageQL using a temporary file based SQLite database.
 
 Run it with the repository's `src` directory on the Python path so that the
 `pageql` package can be imported:

--- a/benchmarks/benchmark_pageql.py
+++ b/benchmarks/benchmark_pageql.py
@@ -157,7 +157,6 @@ async def run_benchmarks_parallel(db_path: str) -> None:
         print(f"{k:20s}: {(v/ITERATIONS)*1000:.4f}ms")
 
 if __name__ == '__main__':
-    asyncio.run(run_benchmarks(':memory:'))
     with tempfile.TemporaryDirectory() as tmp:
         path = os.path.join(tmp, 'bench.db')
         asyncio.run(run_benchmarks(path))


### PR DESCRIPTION
## Summary
- remove the in-memory PageQL benchmark run
- update benchmark docs

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68429befb294832f9052b64e6e083a2a