### PR TITLE
Fix profiling with websockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pageql -path/to/your/database.sqlite ./templates
 *   `--no-csrf`: (Optional) Disable CSRF protection. Useful for local testing but not recommended in production.
 *   `--test`: (Optional) Run template tests and exit instead of serving.
 *   `--http-disconnect-cleanup-timeout <seconds>`: (Optional) Delay before cleaning up HTTP disconnect contexts.
-*   `--profile`: (Optional) Profile the server and print statistics when it stops.
+*   `--profile`: (Optional) Profile the server using `cProfile` and print statistics when it stops.
 *   PageQL automatically configures new SQLite databases with write-ahead logging
     and an increased cache for better concurrency.
 *   When a PostgreSQL or MySQL URL is provided, `--create` is ignored and the

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -110,10 +110,10 @@ def main():
         print("Press Ctrl+C to stop.")
 
     if args.profile:
-        import profile
+        import cProfile
         import pstats
 
-        profiler = profile.Profile()
+        profiler = cProfile.Profile()
         try:
             profiler.runcall(
                 uvicorn.run,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ def test_cli_profile(monkeypatch, tmp_path):
     monkeypatch.setattr(cli.uvicorn, "run", dummy_run)
 
     import types
-    monkeypatch.setitem(sys.modules, "profile", types.SimpleNamespace(Profile=lambda: DummyProfile()))
+    monkeypatch.setitem(sys.modules, "cProfile", types.SimpleNamespace(Profile=lambda: DummyProfile()))
     monkeypatch.setitem(sys.modules, "pstats", types.SimpleNamespace(Stats=lambda prof: DummyStats(prof)))
 
     argv = ["pageql", "db", str(tmp_path), "--profile"]


### PR DESCRIPTION
## Summary
- use `cProfile` instead of `profile` in CLI
- adjust docs for new profiler
- update CLI test to patch `cProfile`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842b6eb8c34832f815a3e808e8a09da