### PR TITLE
Update HTTP cleanup default

### DIFF
--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -69,7 +69,7 @@ def main():
     parser.add_argument(
         '--http-disconnect-cleanup-timeout',
         type=float,
-        default=0.1,
+        default=10.0,
         metavar='SECONDS',
         help='Delay before cleaning up HTTP disconnects.',
     )

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -97,7 +97,7 @@ class PageQLApp:
         fallback_app=None,
         fallback_url: Optional[str] = None,
         csrf_protect: bool = True,
-        http_disconnect_cleanup_timeout: float = 0.1,
+        http_disconnect_cleanup_timeout: float = 10.0,
     ):
         self.stop_event = None
         self.notifies = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_cli_fallback_url(monkeypatch, tmp_path):
             fallback_app=None,
             fallback_url=None,
             csrf_protect=True,
-            http_disconnect_cleanup_timeout=0.1,
+            http_disconnect_cleanup_timeout=10.0,
         ):
             created["db"] = db_file
             created["tpl"] = templates_dir
@@ -71,7 +71,7 @@ def test_cli_http_disconnect_timeout(monkeypatch, tmp_path):
             fallback_app=None,
             fallback_url=None,
             csrf_protect=True,
-            http_disconnect_cleanup_timeout=0.1,
+            http_disconnect_cleanup_timeout=10.0,
         ):
             created["timeout"] = http_disconnect_cleanup_timeout
 


### PR DESCRIPTION
## Summary
- increase HTTP disconnect cleanup timeout default to `10.0`
- update CLI and tests accordingly

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842bd524e2c832f9825337264bc6398