### PR TITLE
Improve async benchmark stability

### DIFF
--- a/benchmarks/async_uvicorn_benchmark.py
+++ b/benchmarks/async_uvicorn_benchmark.py
@@ -37,6 +37,15 @@ async def run_benchmark() -> None:
     assert server.servers and server.servers[0].sockets
     port = server.servers[0].sockets[0].getsockname()[1]
 
+    # Wait until the server is responsive. Occasionally ``server.started`` is
+    # ``True`` before the socket is fully accepting connections.
+    while True:
+        try:
+            await _http_get(f"http://127.0.0.1:{port}/todos")
+            break
+        except ConnectionRefusedError:
+            await asyncio.sleep(0.05)
+
 
     # warmup and extract client id
     websocket_connections = []


### PR DESCRIPTION
## Summary
- wait until the uvicorn server responds before starting benchmark requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842f5d01ebc832fab11109f2a43f6d0