### PR TITLE
Add async render wrapper

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -1103,6 +1103,27 @@ class PageQL:
         _ONEVENT_CACHE.clear()
         return result
 
+    async def render_async(
+        self,
+        path,
+        params={},
+        partial=None,
+        http_verb=None,
+        in_render_directive=False,
+        reactive=True,
+        ctx=None,
+    ):
+        """Asynchronous wrapper around :meth:`render`."""
+        return self.render(
+            path,
+            params,
+            partial,
+            http_verb,
+            in_render_directive,
+            reactive,
+            ctx,
+        )
+
 # Example of how to run the examples if this file is executed
 if __name__ == '__main__':
     # add current directory to sys.path


### PR DESCRIPTION
## Summary
- add `render_async` async method to PageQL as a simple wrapper around `render`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6843126c5f9c832fa62adea85027d31d