### PR TITLE
Update TODO with default reactive note

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 - "Reactive" Aspect:
 UI updates are now implemented. The reactive query model updates the browser automatically whenever the underlying data changes.
+- PageQL defaults to `#reactive on`. Use `#reactive off` to disable live updates.
 
 Later:
 - Code completion (language server) / VS code pluigin


### PR DESCRIPTION
## Summary
- mention that `#reactive on` is the default in TODO

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6843131d66d8832fad0b2e85649a0c26