### PR TITLE
Add cross-tab update note in tutorial pages

### DIFF
--- a/website/02_adding_data.html
+++ b/website/02_adding_data.html
@@ -479,6 +479,8 @@
     <li>Add a blank item—notice how validation blocks it with an error page.</li>
   </ol>
 
+  <p><em>Tip: Try with two tabs open. After you submit a form or toggle items, the other tab updates automatically without refresh. This works with no additional code because the queries in <code>todos.pageql</code> are reactive.</em></p>
+
   <p><em>(Validation errors return a plain‑text stack trace in dev mode; there's no production mode yet.)</em></p>
 
   <h2>5 Recap</h2>

--- a/website/03_updating_state.html
+++ b/website/03_updating_state.html
@@ -597,6 +597,8 @@
     <li>Use the header checkbox to toggle all items on/off.</li>
   </ol>
 
+  <p><em>Tip: Try with two tabs open. After you submit a form or toggle items, the other tab updates automatically without refresh. This works with no additional code because the queries in <code>todos.pageql</code> are reactive.</em></p>
+
   <!-- 5 -->
   <h2>5 Recap</h2>
   <ul>

--- a/website/04_deleting_and_bulk.html
+++ b/website/04_deleting_and_bulk.html
@@ -493,6 +493,8 @@
     <li>Deliberately break the SQL inside <code>clear_completed</code> (e.g., change the table name to <code>todoz</code>) and test again ➜ all rows survive; the error page shows the failed query, proving rollback.</li>
   </ol>
 
+  <p><em>Tip: Try with two tabs open. After you submit a form or toggle items, the other tab updates automatically without refresh. This works with no additional code because the queries in <code>todos.pageql</code> are reactive.</em></p>
+
   <!-- 5 -->
   <h2>5 Under the hood: request transaction timeline</h2>
 

--- a/website/05_adding_filters.html
+++ b/website/05_adding_filters.html
@@ -469,6 +469,8 @@
     <li>Manually tamper with the URL (e.g. <code>?filter=hack</code>) → PageQL blocks the request because it fails the regex pattern.</li>
   </ol>
 
+  <p><em>Tip: Try with two tabs open. After you submit a form or toggle items, the other tab updates automatically without refresh. This works with no additional code because the queries in <code>todos.pageql</code> are reactive.</em></p>
+
   <!-- 6 -->
   <h2>6 How it works</h2>
 


### PR DESCRIPTION
## Summary
- encourage opening a second tab in the "Try it out" sections
- explain that other tabs update automatically thanks to reactive queries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684314a3ba6c832f8f9a02e88e5d91e3