### PR TITLE
Switch to render_async in async handler

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -359,7 +359,7 @@ class PageQLApp:
             if path in self.before_hooks:
                 self._log(f"Before hook for {path}")
                 await self.before_hooks[path](params)
-            result = self.pageql_engine.render(
+            result = await self.pageql_engine.render_async(
                 path_cleaned,
                 params,
                 None,


### PR DESCRIPTION
## Summary
- use `await render_async` in the async request handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6843145a5898832fab6644930d4b9607