### PR TITLE
Remove async code from PageQL engine

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -359,7 +359,7 @@ class PageQLApp:
             if path in self.before_hooks:
                 self._log(f"Before hook for {path}")
                 await self.before_hooks[path](params)
-            result = await self.pageql_engine.render_async(
+            result = self.pageql_engine.render(
                 path_cleaned,
                 params,
                 None,


### PR DESCRIPTION
## Summary
- drop async helpers and `_run_sync`
- make `PageQL` synchronous and update call sites

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68435ecbb0cc832fbf00e62114989a09