### PR TITLE
Add async wrappers for PageQL rendering

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -4,6 +4,7 @@ PageQL: A template language for embedding SQL inside HTML directly
 
 # Import the main classes from the PageQL modules
 from .pageql import PageQL
+from .pageql_async import PageQLAsync
 from .render_context import RenderResult
 from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
@@ -15,6 +16,7 @@ __version__ = "0.1.0"
 # Make these classes available directly from the package
 __all__ = [
     "PageQL",
+    "PageQLAsync",
     "RenderResult",
     "ReadOnly",
     "PageQLApp",

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -1,0 +1,155 @@
+"""Async wrappers for PageQL rendering methods."""
+
+from .pageql import PageQL
+
+
+class PageQLAsync(PageQL):
+    """Async subclass that exposes async render helpers."""
+
+    async def handle_render_async(
+        self,
+        node_content,
+        path,
+        params,
+        includes,
+        http_verb=None,
+        reactive=False,
+        ctx=None,
+    ):
+        return self.handle_render(
+            node_content,
+            path,
+            params,
+            includes,
+            http_verb,
+            reactive,
+            ctx,
+        )
+
+    async def _process_render_expression_node_async(
+        self,
+        node_content,
+        params,
+        path,
+        includes,
+        http_verb,
+        reactive,
+        ctx,
+        out,
+    ):
+        return self._process_render_expression_node(
+            node_content,
+            params,
+            path,
+            includes,
+            http_verb,
+            reactive,
+            ctx,
+            out,
+        )
+
+    async def _process_render_param_node_async(
+        self,
+        node_content,
+        params,
+        path,
+        includes,
+        http_verb,
+        reactive,
+        ctx,
+        out,
+    ):
+        return self._process_render_param_node(
+            node_content,
+            params,
+            path,
+            includes,
+            http_verb,
+            reactive,
+            ctx,
+            out,
+        )
+
+    async def _process_render_raw_node_async(
+        self,
+        node_content,
+        params,
+        path,
+        includes,
+        http_verb,
+        reactive,
+        ctx,
+        out,
+    ):
+        return self._process_render_raw_node(
+            node_content,
+            params,
+            path,
+            includes,
+            http_verb,
+            reactive,
+            ctx,
+            out,
+        )
+
+    async def _process_render_directive_async(
+        self,
+        node_content,
+        params,
+        path,
+        includes,
+        http_verb,
+        reactive,
+        ctx,
+        out,
+    ):
+        return self._process_render_directive(
+            node_content,
+            params,
+            path,
+            includes,
+            http_verb,
+            reactive,
+            ctx,
+            out,
+        )
+
+    async def render_async(
+        self,
+        path,
+        params={},
+        partial=None,
+        http_verb=None,
+        in_render_directive=False,
+        reactive=True,
+        ctx=None,
+    ):
+        return self.render(
+            path,
+            params,
+            partial,
+            http_verb,
+            in_render_directive,
+            reactive,
+            ctx,
+        )
+
+    async def _render_impl_async(
+        self,
+        path,
+        params={},
+        partial=None,
+        http_verb=None,
+        in_render_directive=False,
+        reactive=True,
+        ctx=None,
+    ):
+        return self._render_impl(
+            path,
+            params,
+            partial,
+            http_verb,
+            in_render_directive,
+            reactive,
+            ctx,
+        )

--- a/tests/test_pageql_async.py
+++ b/tests/test_pageql_async.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+# Provide a stub for watchfiles.awatch used by PageQLApp if imported
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *a, **k: None
+
+from pageql.pageql_async import PageQLAsync
+
+
+async def test_render_async_returns_expected_result():
+    r = PageQLAsync(":memory:")
+    r.load_module("hello", "hi")
+    res = await r.render_async("/hello", reactive=False)
+    assert res.body == "hi"
+


### PR DESCRIPTION
## Summary
- expose PageQLAsync subclass providing async wrappers around render helpers
- export PageQLAsync
- test async rendering works

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684363f4c664832f91c3b6aa7ab51f4e