### PR TITLE
Support optional async keyword in #fetch

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -81,7 +81,7 @@ DIRECTIVE_HELP: dict[str, str] = {
     "#header <name> <expr>": "add an HTTP response header",
     "#cookie <name> <expr> [opts]": "set an HTTP cookie",
     "#update <table> set <expr> where <cond>": "execute an SQL UPDATE",
-    "#fetch <var> from <url>": "fetch a remote URL into a variable",
+    "#fetch [async] <var> from <url>": "fetch a remote URL into a variable",
 }
 
 def format_unknown_directive(directive: str) -> str:

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -193,12 +193,18 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
             continue
 
         if ntype == "#fetch":
-            var, rest = parsefirstword(ncontent)
+            first, rest = parsefirstword(ncontent)
+            if first.lower() == "async":
+                if rest is None:
+                    raise SyntaxError("#fetch requires a variable and expression")
+                var, rest = parsefirstword(rest)
+            else:
+                var = first
             if rest is None:
                 raise SyntaxError("#fetch requires a variable and expression")
-            first, expr = parsefirstword(rest)
-            if first.lower() != "from" or expr is None:
-                raise SyntaxError("#fetch syntax is '<var> from <expr>'")
+            kw, expr = parsefirstword(rest)
+            if kw.lower() != "from" or expr is None:
+                raise SyntaxError("#fetch syntax is '[async] <var> from <expr>'")
             i += 1
             body.append(("#fetch", (var, expr)))
             continue

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -15,8 +15,21 @@ def test_fetch_directive_parsed():
     assert body == [("#fetch", ("file", "'http://ex'"))]
 
 
+def test_fetch_async_directive_parsed():
+    tokens = tokenize("{{#fetch async file from 'http://ex'}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert body == [("#fetch", ("file", "'http://ex'"))]
+
+
 def test_fetch_directive_dependencies():
     tokens = tokenize("{{#fetch dst from :url}}")
+    ast = build_ast(tokens, dialect="sqlite")
+    deps = ast_param_dependencies(ast)
+    assert deps == {"url"}
+
+
+def test_fetch_async_directive_dependencies():
+    tokens = tokenize("{{#fetch async dst from :url}}")
     ast = build_ast(tokens, dialect="sqlite")
     deps = ast_param_dependencies(ast)
     assert deps == {"url"}


### PR DESCRIPTION
## Summary
- extend parser to handle `#fetch async`
- document optional keyword in directive help
- test parsing of `#fetch async` syntax

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_684598ce0dd0832fae8978835f895571