### PR TITLE
Serve index.html for empty root request

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -460,6 +460,14 @@ class PageQLApp:
         params['headers'] = headers
         params['method'] = method
 
+        if (
+            path_cleaned == 'index'
+            and 'index' not in self.pageql_engine._modules
+            and 'index.html' in self.static_files
+        ):
+            await self._serve_static_file('index.html', include_scripts, client_id, send)
+            return
+
         if await self._serve_static_file(path_cleaned, include_scripts, client_id, send):
             return
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -148,3 +148,18 @@ def test_before_hook_handles_bytes(tmp_path):
     assert status == 200
     assert base64.b64encode(b"abcd").decode() in body.decode()
 
+
+def test_index_html_served_when_pageql_missing(tmp_path):
+    index_html = Path(tmp_path) / "index.html"
+    index_html.write_text("<h1>Home</h1>", encoding="utf-8")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, body_bytes = await _http_get(f"http://127.0.0.1:{port}/")
+        server.should_exit = True
+        await task
+        return status, body_bytes.decode()
+
+    status, body = asyncio.run(run_test())
+    assert status == 200
+    assert "<h1>Home</h1>" in body


### PR DESCRIPTION
## Summary
- check for `index.html` when root request doesn't match templates
- test that empty root URL uses `index.html` if available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68459cc3e6b8832f813cd0681208dcf9