### PR TITLE
Include async flag in #fetch AST

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -526,7 +526,11 @@ class PageQL:
 
     def _process_fetch_directive(self, node_content, params, path, includes,
                                  http_verb, reactive, ctx, out):
-        var, expr = node_content
+        if len(node_content) == 3:
+            var, expr, is_async = node_content
+        else:
+            var, expr = node_content
+            is_async = False
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")
@@ -536,6 +540,8 @@ class PageQL:
         # Commit any pending database changes so the fetch callback sees
         # a consistent view of the database before performing the HTTP request
         self.db.commit()
+        if is_async:
+            raise ValueError("async fetch requires async render")
         data = fetch_sync(str(url))
         for k, v in flatten_params(data).items():
             params[f"{var}__{k}"] = v

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -704,7 +704,10 @@ class PageQLAsync(PageQL):
         ctx,
         out,
     ):
-        var, expr = node_content
+        if len(node_content) == 3:
+            var, expr, _is_async = node_content
+        else:
+            var, expr = node_content
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -194,7 +194,9 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
 
         if ntype == "#fetch":
             first, rest = parsefirstword(ncontent)
+            is_async = False
             if first.lower() == "async":
+                is_async = True
                 if rest is None:
                     raise SyntaxError("#fetch requires a variable and expression")
                 var, rest = parsefirstword(rest)
@@ -206,7 +208,7 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
             if kw.lower() != "from" or expr is None:
                 raise SyntaxError("#fetch syntax is '[async] <var> from <expr>'")
             i += 1
-            body.append(("#fetch", (var, expr)))
+            body.append(("#fetch", (var, expr, is_async)))
             continue
 
         # -------------------------------------------------------- #partial ...

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -12,13 +12,13 @@ import pytest
 def test_fetch_directive_parsed():
     tokens = tokenize("{{#fetch file from 'http://ex'}}")
     body, _ = build_ast(tokens, dialect="sqlite")
-    assert body == [("#fetch", ("file", "'http://ex'"))]
+    assert body == [("#fetch", ("file", "'http://ex'", False))]
 
 
 def test_fetch_async_directive_parsed():
     tokens = tokenize("{{#fetch async file from 'http://ex'}}")
     body, _ = build_ast(tokens, dialect="sqlite")
-    assert body == [("#fetch", ("file", "'http://ex'"))]
+    assert body == [("#fetch", ("file", "'http://ex'", True))]
 
 
 def test_fetch_directive_dependencies():


### PR DESCRIPTION
## Summary
- track whether `#fetch` uses the `async` keyword in the parser
- adjust PageQL and PageQLAsync to accept the updated AST
- update tests for the new AST structure

## Testing
- `PYTHONPATH=src pytest tests/test_fetch_directive.py::test_fetch_directive_parsed -vv`
- `PYTHONPATH=src pytest tests/test_fetch_directive.py::test_fetch_async_directive_parsed -vv`
- `PYTHONPATH=src pytest tests/test_fetch_directive.py::test_fetch_async_directive_dependencies -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68459d32212c832fa307f21b922c372e