### PR TITLE
Add Dockerfile and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy required files and install PageQL
+COPY pyproject.toml README.md ./
+COPY src ./src
+RUN pip install .
+
+EXPOSE 8000
+
+# Mount database and templates at runtime
+VOLUME ["/data", "/templates"]
+
+ENTRYPOINT ["pageql"]
+CMD ["/data/data.db", "/templates", "--create"]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ pageql path/to/your/database.sqlite ./templates
 *   Although `postgres://` and `mysql://` URLs work, remote connections add read
     latency that can degrade performance of reactive queries.
 
+## Docker
+
+A simple `Dockerfile` is included for running PageQL in a containerized
+environment.  The image installs the package and by default serves templates
+from the `/templates` volume using a SQLite database stored under `/data`.
+
+```bash
+docker build -t pageql .
+docker run -p 8000:8000 \
+    -v $(pwd)/templates:/templates \
+    -v $(pwd)/data:/data \
+    pageql
+```
+
+The container runs `pageql /data/data.db /templates --create` so a new database
+is created automatically on first use.
+
 *(Note: Actual command name and argument flags are subject to change.)*
 
 ## Proposed Tag Syntax


### PR DESCRIPTION
## Summary
- add a Dockerfile for containerized PageQL deployments
- document Docker usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68459d739428832fa6fbcb205563cefc