### PR TITLE
Add /healthz endpoint

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -593,6 +593,16 @@ class PageQLApp:
         if scope['type'] == 'lifespan':
             return await self.lifespan(scope, receive, send)
         path = scope.get('path', '/')
+        if scope['type'] == 'http' and path == '/healthz':
+            await send(
+                {
+                    'type': 'http.response.start',
+                    'status': 200,
+                    'headers': [(b'content-type', b'text/plain')],
+                }
+            )
+            await send({'type': 'http.response.body', 'body': b'OK'})
+            return
         self._log(f"path: {path}")
         if scope["type"] == "websocket" and scope["path"] == "/reload-request-ws":
             await self._handle_reload_websocket(scope, receive, send)

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,22 @@
+import asyncio
+import tempfile
+
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_healthz_endpoint():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            status, _headers, body = await _http_get(
+                f"http://127.0.0.1:{port}/healthz"
+            )
+            server.should_exit = True
+            await task
+            return status, body.decode()
+
+        status, body = asyncio.run(run_test())
+        assert status == 200
+        assert body == "OK"
+


### PR DESCRIPTION
## Summary
- add HTTP handler for `/healthz` that returns `OK`
- test new health check endpoint

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845aa7ed96c832fa996d44d9e8e349f