### PR TITLE
Ensure run_tasks executes after render

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -380,6 +380,7 @@ class PageQLApp:
                 method,
                 reactive=self.reactive_default,
             )
+            run_tasks()
 
             if result.status_code == 404:
                 if self.fallback_app is not None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -163,3 +163,25 @@ def test_index_html_served_when_pageql_missing(tmp_path):
     status, body = asyncio.run(run_test())
     assert status == 200
     assert "<h1>Home</h1>" in body
+
+
+def test_run_tasks_called(monkeypatch, tmp_path):
+    (tmp_path / "index.pageql").write_text("hello")
+
+    called = []
+
+    def fake_run_tasks():
+        called.append(True)
+
+    monkeypatch.setattr(pageql.pageqlapp, "run_tasks", fake_run_tasks)
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, _body = await _http_get(f"http://127.0.0.1:{port}/index")
+        server.should_exit = True
+        await task
+        return status
+
+    status = asyncio.run(run_test())
+    assert status == 200
+    assert called


### PR DESCRIPTION
## Summary
- run any queued pageql tasks after rendering
- test that run_tasks is invoked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845f2465d40832fb4f0cfb5c80f18d7