### PR TITLE
Support async fetch with tasks

### DIFF
--- a/tests/test_pageql_async.py
+++ b/tests/test_pageql_async.py
@@ -20,3 +20,24 @@ async def test_render_async_returns_expected_result():
     res = await r.render_async("/hello", reactive=False)
     assert res.body == "hi"
 
+
+async def test_fetch_async_queues_task(monkeypatch):
+    calls = []
+
+    async def fake_fetch(url: str):
+        calls.append(url)
+        return {"status_code": 200, "headers": [], "body": "ok"}
+
+    import pageql.pageql_async as pqa
+    monkeypatch.setattr(pqa, "fetch", fake_fetch)
+    from pageql import pageql as pql_mod
+
+    r = PageQLAsync(":memory:")
+    r.load_module("m", "{{#fetch async d from 'http://x'}}{{d__body}}")
+    res = await r.render_async("/m", reactive=False)
+    assert res.body.strip() == "None"
+    assert len(pql_mod.tasks) == 1
+    await pql_mod.tasks.pop()  # run the queued task
+    assert calls == ["http://x"]
+    pql_mod.tasks.clear()
+


### PR DESCRIPTION
## Summary
- import `tasks` in `PageQLAsync`
- update async fetch directive executor to create signals and queue an async task
- test that async fetch schedules a task

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845f581b8a8832fad209e4c5e32076c