### PR TITLE
Switch to wss on HTTPS hosts

### DIFF
--- a/src/pageql/client_script.py
+++ b/src/pageql/client_script.py
@@ -23,7 +23,8 @@ _CLIENT_SCRIPT_TEMPLATE = """
       document.body.addEventListener('htmx:configRequest', (evt) => {
         evt.detail.headers['ClientId'] = clientId;
       });
-      const ws_url = `ws://${host}:${port}/reload-request-ws?clientId=${clientId}`;
+      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+      const ws_url = `${proto}://${host}:${port}/reload-request-ws?clientId=${clientId}`;
 
       function forceReload() {
         const socket = new WebSocket(ws_url);


### PR DESCRIPTION
## Summary
- update client script to use `wss` when the page is served over HTTPS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684692c2b9a4832f83e3297d9f32d0d0