### PR TITLE
Add doctype at start of client script

### DIFF
--- a/src/pageql/client_script.py
+++ b/src/pageql/client_script.py
@@ -1,4 +1,4 @@
-_CLIENT_SCRIPT_TEMPLATE = """
+_CLIENT_SCRIPT_TEMPLATE = """<!doctype html>
 <script src="/htmx.min.js"></script>
 <script>
   htmx.config.defaultSwapStyle = 'none';


### PR DESCRIPTION
## Summary
- add `<!doctype html>` to the beginning of the client script template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846adaf2434832fb07e2a88986dcbc9