### PR TITLE
Add deploy_to_server workflow

### DIFF
--- a/.github/workflows/deploy_to_server.yml
+++ b/.github/workflows/deploy_to_server.yml
@@ -1,0 +1,15 @@
+name: deploy_to_server
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH to server
+        run: ssh root@pageql.cloud true


### PR DESCRIPTION
## Summary
- add `deploy_to_server` workflow that runs after the CI workflow completes and only opens an SSH connection to `root@pageql.cloud`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68483a5979c4832f92e2470007ce5e12