### PR TITLE
Use secret key for SSH deploy

### DIFF
--- a/.github/workflows/deploy_to_server.yml
+++ b/.github/workflows/deploy_to_server.yml
@@ -8,5 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare SSH key
+        run: |
+          echo "${{ secrets.RESTRICTED_SCRIPT_KEY }}" > restricted_key
+          chmod 600 restricted_key
       - name: SSH to server
-        run: ssh root@pageql.cloud true
+        run: ssh -i restricted_key -o StrictHostKeyChecking=no root@pageql.cloud true


### PR DESCRIPTION
## Summary
- use the `RESTRICTED_SCRIPT_KEY` repo secret when connecting to `root@pageql.cloud` in the deploy workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68483d0b8838832f9c1bc22c1ea66b9a