### PR TITLE
Add Todos demo link to homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -183,6 +183,12 @@
     a:hover {
       border-bottom: 1px solid var(--primary);
     }
+    .tutorial-links {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      margin: 2rem 0;
+    }
     .tutorial-link {
       display: block;
       background: var(--primary);
@@ -191,7 +197,6 @@
       text-align: center;
       padding: 1rem 2rem;
       border-radius: 6px;
-      margin: 2rem auto;
       max-width: 300px;
       text-decoration: none;
       border: none;
@@ -287,7 +292,10 @@
 pageql data.db templates --create</code></pre>
         </div>
         
-        <a href="01_hello_database.html" class="tutorial-link">Start Tutorial</a>
+        <div class="tutorial-links">
+          <a href="01_hello_database.html" class="tutorial-link">Start Tutorial</a>
+          <a href="/todos" class="tutorial-link">Todos Demo</a>
+        </div>
       </div>
 
       <div class="two-columns">


### PR DESCRIPTION
## Summary
- tweak homepage layout to support multiple tutorial links
- add Todos demo link next to Start Tutorial

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68483e5e80a0832fb2027470beb9fc35