### PR TITLE
Add home link to todos page

### DIFF
--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -52,9 +52,12 @@
     .filters { margin-top: 1rem; }
     .filters a { text-decoration: none; margin: 0 0.5rem; }
     .filters a.selected { font-weight: bold; }
+    .back-link { margin-bottom: 1rem; }
+    .back-link a { color: #be5028; text-decoration: none; font-weight: bold; }
   </style>
 </head>
 <body>
+  <div class="back-link"><a href="/">&larr; PageQL</a></div>
   <h1>Todos</h1>
   <input name="text" placeholder="What needs to be done?" autofocus autocomplete="off"
     hx-post="/todos/add" hx-trigger="keyup[key=='Enter']" hx-on:htmx:after-on-load="this.value=''">


### PR DESCRIPTION
## Summary
- add a simple back link to the home page on `website/todos.pageql`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68483fa0a648832f9522b0866cc4fb83