### PR TITLE
Limit todos and text length

### DIFF
--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -1,7 +1,7 @@
 {{#partial post add}}
-  {{#param text maxlength=200}}
+  {{#param text maxlength=100}}
   {{#let current_total = COUNT(*) from todos}}
-  {{#if :current_total < 200}}
+  {{#if :current_total < 20}}
     {{#insert into todos(text) values (:text)}}
   {{/if}}
 {{/partial}}
@@ -11,7 +11,7 @@
 {{/partial}}
 
 {{#partial patch :id}}
-  {{#param text maxlength=200}}
+  {{#param text maxlength=100}}
   {{#update todos set text = :text WHERE id = :id}}
 {{/partial}}
 
@@ -73,8 +73,8 @@
 <body>
   <div class="back-link"><a href="/">&larr; PageQL</a></div>
   <h1>Todos</h1>
-  {{#if :total_count < 200}}
-  <input name="text" placeholder="What needs to be done?" maxlength="200" autofocus autocomplete="off"
+  {{#if :total_count < 20}}
+  <input name="text" placeholder="What needs to be done?" maxlength="100" autofocus autocomplete="off"
     hx-post="/todos/add" hx-trigger="keyup[key=='Enter']" hx-on:htmx:after-on-load="this.value=''">
   {{/if}}
   <ul>
@@ -90,10 +90,10 @@
           onclick="this.contentEditable=true;this.focus();"
           onblur="this.contentEditable=false;"
           onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}"
-          oninput="if(this.innerText.length>200){this.innerText=this.innerText.slice(0,200);}"
+          oninput="if(this.innerText.length>100){this.innerText=this.innerText.slice(0,100);}"
           hx-patch="/todos/{{id}}"
           hx-trigger="blur"
-          hx-vals='js:{text: event.target.innerText.slice(0, 200)}'
+          hx-vals='js:{text: event.target.innerText.slice(0, 100)}'
           hx-swap="none"
         >{{text}}</label>
         <button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;">✕</button>


### PR DESCRIPTION
## Summary
- decrease max todos from 200 to 20
- restrict todo text length from 200 to 100

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684844dd8cc0832f932de0732fe324ae