### PR TITLE
Add GitHub OAuth helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "watchfiles",
     "sqlglot",
     "joserfc",
+    "httpx",
+    "authlib",
 ]
 
 [project.optional-dependencies]

--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -10,6 +10,7 @@ from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
 from .jws_utils import jws_serialize_compact, jws_deserialize_compact
+from .github_auth import build_authorization_url, fetch_github_user
 # Define the version
 __version__ = "0.1.0"
 
@@ -21,6 +22,8 @@ __all__ = [
     "ReadOnly",
     "PageQLApp",
     "parse_reactive",
+    "build_authorization_url",
+    "fetch_github_user",
     "jws_serialize_compact",
     "jws_deserialize_compact",
 ]

--- a/src/pageql/github_auth.py
+++ b/src/pageql/github_auth.py
@@ -1,0 +1,43 @@
+from typing import Dict, Optional
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL = "https://api.github.com/user"
+
+
+def build_authorization_url(
+    client_id: str,
+    redirect_uri: str,
+    *,
+    state: Optional[str] = None,
+    scope: str = "read:user",
+) -> str:
+    """Return the GitHub authorization URL."""
+    client = AsyncOAuth2Client(client_id=client_id, redirect_uri=redirect_uri)
+    url, _state = client.create_authorization_url(
+        GITHUB_AUTHORIZE_URL, state=state, scope=scope
+    )
+    return url
+
+
+async def fetch_github_user(
+    client_id: str,
+    client_secret: str,
+    code: str,
+    redirect_uri: str,
+) -> Dict[str, object]:
+    """Exchange *code* for a token and return the user's profile."""
+    async with AsyncOAuth2Client(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    ) as client:
+        await client.fetch_token(
+            GITHUB_ACCESS_TOKEN_URL,
+            code=code,
+            client_secret=client_secret,
+        )
+        resp = await client.get(GITHUB_USER_URL, headers={"Accept": "application/json"})
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/test_github_auth.py
+++ b/tests/test_github_auth.py
@@ -1,0 +1,70 @@
+import sys
+import types
+import pytest
+
+# Ensure watchfiles awatch stub to avoid dependency
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *a, **k: None
+sys.path.insert(0, "src")
+
+from pageql.github_auth import build_authorization_url, fetch_github_user
+
+
+def test_build_authorization_url():
+    url = build_authorization_url(
+        "cid",
+        "http://localhost/cb",
+        state="s123",
+        scope="read:user",
+    )
+    assert url.startswith("https://github.com/login/oauth/authorize")
+    assert "client_id=cid" in url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%2Fcb" in url
+    assert "state=s123" in url
+
+
+@pytest.mark.anyio
+async def test_fetch_github_user(monkeypatch):
+    calls = {}
+
+    class DummyResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    async def fetch_token(self, url, code=None, client_secret=None):
+        calls["token_url"] = url
+        calls["code"] = code
+        return {"access_token": "t"}
+
+    async def get(self, url, headers=None):
+        calls["user_url"] = url
+        return DummyResponse({"login": "octocat"})
+
+    monkeypatch.setattr(
+        fetch_github_user.__globals__["AsyncOAuth2Client"],
+        "fetch_token",
+        fetch_token,
+    )
+    monkeypatch.setattr(
+        fetch_github_user.__globals__["AsyncOAuth2Client"],
+        "get",
+        get,
+    )
+
+    user = await fetch_github_user(
+        client_id="cid",
+        client_secret="secret",
+        code="code",
+        redirect_uri="http://localhost/cb",
+    )
+
+    assert calls["token_url"].endswith("access_token")
+    assert calls["code"] == "code"
+    assert calls["user_url"].endswith("/user")
+    assert user == {"login": "octocat"}


### PR DESCRIPTION
## Summary
- add httpx & authlib deps
- export new GitHub OAuth utilities
- implement GitHub authorization & profile fetch
- test GitHub OAuth helpers

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68489f59007c832f8c2c5e784f857be4