### PR TITLE
Fix fetch reactive placeholders

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -34,7 +34,7 @@ def _replace_placeholders(
         if name not in params:
             continue
         val = params[name]
-        if isinstance(val, (DerivedSignal, DerivedSignal2, OneValue, ReadOnly)):
+        if isinstance(val, (DerivedSignal, DerivedSignal2, OneValue, ReadOnly, Signal)):
             val = val.value
         if val is None:
             lit = exp.Null()


### PR DESCRIPTION
## Summary
- unwrap generic `Signal` values in `_replace_placeholders`
- ensure expressions referencing `#fetch` async variables return the value instead of signal object

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684be84e1664832f9cb76d5428bb5917