### PR TITLE
Remove sync fetch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,7 @@ reachable from outside the container.
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
     *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
-*   `#fetch <var> from <url_expression>`: Fetches an external URL using a callback provided to `PageQL` and exposes the result as `<var>.body`, `<var>.status_code` and `<var>.headers`.
-*   `#fetch async <var> from <url_expression>`: Runs the fetch in the background while rendering.  `<var>.status_code`, `<var>.body` and `<var>.headers` start as `NULL` but update reactively when the request finishes.
+*   `#fetch async <var> from <url_expression>`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes.
 
     ```pageql
     {{#fetch async horse from "https://t3.ftcdn.net/jpg/03/26/50/04/360_F_326500445_ZD1zFSz2cMT1qOOjDy7C5xCD4shawQfM.jpg"}}


### PR DESCRIPTION
## Summary
- delete documentation for synchronous `#fetch` directive
- clarify async fetch description wording

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684bebcd630c832f8f766c9b454425bf