### PR TITLE
Skip scripts on HTMX requests

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -469,7 +469,8 @@ class PageQLApp:
         path_cleaned = parsed_path.path.strip('/') or 'index'
 
         headers = {k.decode('utf-8').replace('-', '_'): v.decode('utf-8') for k, v in scope['headers']}
-        include_scripts = headers.get('hx_mode', '').lower() != 'none'
+        htmx_request = headers.get('hx_request', '').lower() == 'true'
+        include_scripts = (not htmx_request) and headers.get('hx_mode', '').lower() != 'none'
         query = scope['query_string']
         query_params = parse_qs(query, keep_blank_values=True)
 

--- a/tests/test_htmx_headers.py
+++ b/tests/test_htmx_headers.py
@@ -33,3 +33,32 @@ def test_htmx_none_mode_omits_js_headers():
             assert "reload-request-ws" not in body
 
     asyncio.run(run())
+
+
+def test_htmx_request_omits_js_headers():
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "hello.pageql").write_text("hello", encoding="utf-8")
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+
+            sent = []
+            async def send(msg):
+                sent.append(msg)
+            async def receive():
+                return {"type": "http.request"}
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/hello",
+                "headers": [(b"hx-request", b"true")],
+                "query_string": b"",
+            }
+            await app.pageql_handler(scope, receive, send)
+
+            body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body").decode()
+            assert "hello" in body
+            assert "/htmx.min.js" not in body
+            assert "reload-request-ws" not in body
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- avoid sending the client script on HTMX requests
- test HTMX behaviour with `hx-request` header

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684bed4ed200832fbf634b511d55e14c