### PR TITLE
Add numbers query example

### DIFF
--- a/website/numbers.pageql
+++ b/website/numbers.pageql
@@ -1,0 +1,10 @@
+{{#from
+  WITH RECURSIVE numbers(n) AS (
+    VALUES(1)
+    UNION ALL
+    SELECT n+1 FROM numbers WHERE n < 1000
+  )
+  SELECT n FROM numbers
+}}
+  {{n}}<br>
+{{/from}}


### PR DESCRIPTION
## Summary
- add `website/numbers.pageql` to demonstrate generating numbers 1..1000 with a recursive query

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c06913048832fa0937a61e6b8a2bd