### PR TITLE
Fix newline handling after # directives

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -22,9 +22,12 @@ def quote_state(text: str, start_state: str | None = None) -> str | None:
 
 def parsefirstword(s):
     s = s.strip()
-    if s.find(' ') < 0:
-        return s, None
-    return s[:s.find(' ')], s[s.find(' '):].strip()
+    if not s:
+        return "", None
+    parts = s.split(None, 1)
+    if len(parts) == 1:
+        return parts[0], None
+    return parts[0], parts[1].strip()
 
 
 def _shorten_error_token(value: str) -> str:


### PR DESCRIPTION
## Summary
- improve how directives parse their first word
- allow whitespace including newlines between directive name and expression

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c4097a5e0832fa7e56d5213d84b88