### PR TITLE
Fix numbers pageql syntax

### DIFF
--- a/tests/test_unknown_directive.py
+++ b/tests/test_unknown_directive.py
@@ -16,3 +16,12 @@ def test_unknown_directive_raises():
     with pytest.raises(ValueError) as exc:
         r.render("/bad")
     assert "Unknown directive '#a'" in str(exc.value)
+
+
+def test_from_directive_with_zero_width_space():
+    r = PageQL(":memory:")
+    bad = "{{#from\u200b todos}}{{/from}}"
+    r.load_module("bad_space", bad)
+    with pytest.raises(ValueError) as exc:
+        r.render("/bad_space")
+    assert "Unknown directive '#from\u200b'" in str(exc.value)

--- a/website/numbers.pageql
+++ b/website/numbers.pageql
@@ -1,10 +1,7 @@
-{{#from
-  WITH RECURSIVE numbers(n) AS (
+{{#from WITH RECURSIVE numbers(n) AS (
     VALUES(1)
     UNION ALL
     SELECT n+1 FROM numbers WHERE n < 1000
-  )
-  SELECT n FROM numbers
-}}
+  ) SELECT n FROM numbers}}
   {{n}}<br>
 {{/from}}


### PR DESCRIPTION
## Summary
- fix `numbers.pageql` so `#from` directive is on one line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684c4bb3e0f4832f98b3027293a33ae0