### PR TITLE
Add failing test for sqlglot CTE column alias

### DIFF
--- a/tests/test_sqlglot_cte_alias_bug.py
+++ b/tests/test_sqlglot_cte_alias_bug.py
@@ -1,0 +1,16 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+import sqlglot
+
+
+def test_cte_alias_with_column_list_preserved():
+    sql = (
+        "WITH RECURSIVE numbers(n) AS (VALUES(1) UNION ALL SELECT n+1 FROM numbers WHERE n < 3) "
+        "SELECT n FROM numbers"
+    )
+    expr = sqlglot.parse_one(sql, read="sqlite")
+    assert "numbers(n)" in expr.sql(dialect="sqlite")
+

--- a/tests/test_sqlglot_cte_alias_bug.py
+++ b/tests/test_sqlglot_cte_alias_bug.py
@@ -3,9 +3,11 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
+import pytest
 import sqlglot
 
 
+@pytest.mark.xfail(reason="sqlglot drops column list from CTE alias")
 def test_cte_alias_with_column_list_preserved():
     sql = (
         "WITH RECURSIVE numbers(n) AS (VALUES(1) UNION ALL SELECT n+1 FROM numbers WHERE n < 3) "


### PR DESCRIPTION
## Summary
- add regression test showing sqlglot dropping the column list in a CTE alias

## Testing
- `PYTHONPATH=src pytest tests/test_sqlglot_cte_alias_bug.py` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f0e6808832fa3bdb6952b6ceebb