### PR TITLE
Fix reactive query parentheses

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -785,7 +785,7 @@ class PageQL:
             body = node[2]
 
         if reactive:
-            sql = "SELECT * FROM " + query
+            sql = "SELECT * FROM (" + query + ")"
             sql = re.sub(r':([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)',
                          lambda m: ':' + m.group(1).replace('.', '__'),
                          sql)

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -450,7 +450,7 @@ class PageQLAsync(PageQL):
             body = node[2]
 
         if reactive:
-            sql = "SELECT * FROM " + query
+            sql = "SELECT * FROM (" + query + ")"
             sql = re.sub(r":([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+)", lambda m: ":" + m.group(1).replace(".", "__"), sql)
             converted_params = {
                 k: (v.value if isinstance(v, Signal) else v)


### PR DESCRIPTION
## Summary
- adjust reactive query composition to wrap in parentheses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c70c8a384832f891f644a2ba53521