### PR TITLE
Fix ReadOnly param handling

### DIFF
--- a/src/pageql/params.py
+++ b/src/pageql/params.py
@@ -1,6 +1,7 @@
 import re
 from pageql.parser import parsefirstword
 from pageql.database import parse_param_attrs
+from pageql.reactive import ReadOnly
 
 
 def handle_param(node_content: str, params: dict) -> tuple[str, object | None]:
@@ -11,6 +12,8 @@ def handle_param(node_content: str, params: dict) -> tuple[str, object | None]:
 
     is_required = attrs.get('required', not attrs.__contains__('optional'))
     param_value = params.get(param_name)
+    if isinstance(param_value, ReadOnly):
+        param_value = param_value.value
 
     if param_value is None:
         if 'default' in attrs:

--- a/tests/test_readonly.py
+++ b/tests/test_readonly.py
@@ -9,3 +9,14 @@ def test_from_row_columns_readonly():
     r.load_module("m", "{{#from items}}{{#let id = 2}}{{/from}}")
     with pytest.raises(ValueError):
         r.render("/m")
+
+
+def test_param_allows_readonly_value():
+    r = PageQL(":memory:")
+    r.db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    r.db.execute("INSERT INTO items(name) VALUES ('x')")
+    r.load_module(
+        "m",
+        "{{#from items}}{{#param id type=integer}}{{:id}}{{/from}}",
+    )
+    assert r.render("/m", reactive=False).body.strip() == "1"


### PR DESCRIPTION
## Summary
- support ReadOnly values in `handle_param`
- test that readonly values work when validated as integers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c7897f880832f81078ad9e07471ab