### PR TITLE
Add parsing for #header directive

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -519,9 +519,12 @@ class PageQL:
 
     def _process_header_directive(self, node_content, params, path, includes,
                                   http_verb, reactive, ctx, out):
-        name, value_expr = parsefirstword(node_content)
-        if value_expr is None:
-            raise ValueError("#header requires a name and expression")
+        if isinstance(node_content, tuple):
+            name, value_expr = node_content
+        else:
+            name, value_expr = parsefirstword(node_content)
+            if value_expr is None:
+                raise ValueError("#header requires a name and expression")
         value = evalone(self.db, value_expr, params, reactive, self.tables)
         if isinstance(value, Signal):
             value = value.value

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -232,6 +232,14 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
             body.append(("#respond", (status_expr, body_expr)))
             continue
 
+        if ntype == "#header":
+            name, value_expr = parsefirstword(ncontent)
+            if value_expr is None:
+                raise SyntaxError("#header requires a name and expression")
+            i += 1
+            body.append(("#header", (name, value_expr)))
+            continue
+
         # -------------------------------------------------------- #partial ...
         if ntype == "#partial":
             part_terms = {"/partial"}
@@ -458,9 +466,13 @@ def ast_param_dependencies(ast):
             elif t == "#fetch":
                 deps.update(get_dependencies(_convert_dot_sql(c[1])))
             elif t == "#header":
-                _, rest = parsefirstword(c)
-                if rest:
-                    deps.update(get_dependencies(_convert_dot_sql(rest)))
+                if isinstance(c, tuple):
+                    _, expr = c
+                    deps.update(get_dependencies(_convert_dot_sql(expr)))
+                else:
+                    _, rest = parsefirstword(c)
+                    if rest:
+                        deps.update(get_dependencies(_convert_dot_sql(rest)))
             elif t == "#cookie":
                 _, rest = parsefirstword(c)
                 if rest:

--- a/tests/test_header_directive.py
+++ b/tests/test_header_directive.py
@@ -1,0 +1,19 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast, ast_param_dependencies
+
+
+def test_header_directive_parses():
+    tokens = tokenize("{{#header X-Test 'v'}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert body == [("#header", ("X-Test", "'v'"))]
+
+
+def test_header_directive_dependencies():
+    tokens = tokenize("{{#header X-Test :val}}")
+    ast = build_ast(tokens, dialect="sqlite")
+    deps = ast_param_dependencies(ast)
+    assert deps == {"val"}


### PR DESCRIPTION
## Summary
- parse `#header` directive into (name, value) pairs
- update dependency analysis for new header form
- allow render phase to handle tuple node format
- test parsing and dependencies for `#header`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685062e8cb60832fafea644b405ea483