### PR TITLE
Add JSON todos example page

### DIFF
--- a/tests/test_json_page.py
+++ b/tests/test_json_page.py
@@ -1,0 +1,33 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL
+
+SNIPPET = (
+    "{{#reactive off}}"
+    "{{#header Content-Type 'application/json'}}"
+    "{{#create table if not exists todos ("
+    "    id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "    text TEXT NOT NULL,"
+    "    completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))"
+    ")}}"
+    "{{#from (SELECT COALESCE(json_group_array("
+    "    json_object('id', id, 'text', text, 'completed', completed)"
+    "), '[]') AS js FROM todos)}}"
+    "{{{js}}}"
+    "{{/from}}"
+)
+
+def test_json_page_outputs_array():
+    r = PageQL(":memory:")
+    r.load_module("json", SNIPPET)
+    r.db.execute(
+        "CREATE TABLE IF NOT EXISTS todos(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT NOT NULL, completed INTEGER DEFAULT 0 CHECK(completed IN (0,1)))"
+    )
+    r.db.execute("INSERT INTO todos(text) VALUES ('task')")
+    result = r.render("/json", reactive=False)
+    assert ("Content-Type", "application/json") in result.headers
+    assert result.body.strip() == '[{"id":1,"text":"task","completed":0}]'
+

--- a/website/json.pageql
+++ b/website/json.pageql
@@ -1,0 +1,14 @@
+{{#reactive off}}
+{{#header Content-Type 'application/json'}}
+{{#create table if not exists todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT NOT NULL,
+    completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
+)}}
+
+{{#from (SELECT COALESCE(json_group_array(
+    json_object('id', id, 'text', text, 'completed', completed)
+), '[]') AS js FROM todos)}}
+{{{js}}}
+{{/from}}
+


### PR DESCRIPTION
## Summary
- add a json.pageql example page that outputs todos as JSON
- test JSON output and header handling

## Testing
- `PYTHONPATH=src pytest tests/test_json_page.py -q`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850760e3f7c832f82fcd4092440c2ac