### PR TITLE
Simplify JSON page

### DIFF
--- a/tests/test_json_page.py
+++ b/tests/test_json_page.py
@@ -13,11 +13,9 @@ SNIPPET = (
     "    text TEXT NOT NULL,"
     "    completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))"
     ")}}"
-    "{{#from (SELECT COALESCE(json_group_array("
+    "{{{COALESCE(json_group_array("
     "    json_object('id', id, 'text', text, 'completed', completed)"
-    "), '[]') AS js FROM todos)}}"
-    "{{{js}}}"
-    "{{/from}}"
+    "), '[]') from todos}}}"
 )
 
 def test_json_page_outputs_array():

--- a/website/json.pageql
+++ b/website/json.pageql
@@ -6,9 +6,7 @@
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )}}
 
-{{#from (SELECT COALESCE(json_group_array(
+{{{COALESCE(json_group_array(
     json_object('id', id, 'text', text, 'completed', completed)
-), '[]') AS js FROM todos)}}
-{{{js}}}
-{{/from}}
+), '[]') from todos}}}
 


### PR DESCRIPTION
## Summary
- output the JSON array expression directly in `website/json.pageql`
- adjust unit test for JSON page

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685078052a9c832f8e0ce4bfba97572b