### PR TITLE
Implement #each directive for param loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ reachable from outside the container.
 *   `#elif <expression>`: Else-if condition within an `#if` block.
 *   `#ifdef <variable>`: Checks if a variable is defined
 *   `#ifndef <variable>`: Checks if a variable is not defined
-*  [NOT IMPLEMENTED]  `#each collection`: (Potential loop/iteration construct over a collection, likely passed in params. Probably it should introduce :this param like in Handlebars)
+*   `#each <param>`: Iterate over sequential parameters `<param>__0` .. `<param>__(<param>__count-1)` setting `<param>` for each value.
 *   `#reactive on|off`: Toggle reactive rendering. PageQL starts in reactive mode, automatically wrapping dynamic output so changes can be pushed to the browser. Use `#reactive off` to disable live updates and `#reactive on` to re-enable them.
 
 **Debugging:**

--- a/tests/test_each.py
+++ b/tests/test_each.py
@@ -1,0 +1,28 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL
+from pageql.parser import tokenize, build_ast, ast_param_dependencies
+
+
+def test_each_basic():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#each items}}[{{items}}]{{/each}}")
+    params = {
+        "items__count": 3,
+        "items__0": "a",
+        "items__1": "b",
+        "items__2": "c",
+    }
+    result = r.render("/m", params, reactive=False)
+    assert result.body == "[a]\n[b]\n[c]\n"
+
+
+def test_each_ast_dependencies():
+    snippet = "{{#each nums}}{{/each}}"
+    tokens = tokenize(snippet)
+    ast = build_ast(tokens)
+    deps = ast_param_dependencies(ast)
+    assert deps == {"nums__count"}


### PR DESCRIPTION
## Summary
- add `#each` control flow directive
- support `#each` in parsing and reactive processing
- update AST dependency analysis
- document `#each` usage in README
- cover new functionality with unit tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850775b72a4832fbe974d00713769b5