### PR TITLE
Add environment vars to params

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -515,6 +515,7 @@ class PageQLApp:
         params['cookies'] = _parse_cookies(headers.get('cookie', ''))
         params['headers'] = headers
         params['method'] = method
+        params['env'] = dict(os.environ)
 
         if (
             path_cleaned == 'index'

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,32 @@
+import asyncio, tempfile
+from pathlib import Path
+from pageql.pageqlapp import PageQLApp
+
+
+def test_environment_map_available(monkeypatch):
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "e.pageql").write_text("{{ env.MY_VAR }}", encoding="utf-8")
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+            sent: list[dict] = []
+
+            async def send(msg):
+                sent.append(msg)
+
+            async def receive():
+                return {"type": "http.request"}
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/e",
+                "headers": [],
+                "query_string": b"",
+            }
+
+            monkeypatch.setenv("MY_VAR", "hello")
+            await app.pageql_handler(scope, receive, send)
+            body = next(m for m in sent if m["type"] == "http.response.body")["body"].decode()
+            assert "hello" in body
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- expose `env` mapping in `PageQLApp` params
- test that environment variables are accessible in templates

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68507bef0cc4832fb7fd8224599b42c7