### PR TITLE
Add GitHub auth example

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -1,0 +1,26 @@
+import asyncio
+from pathlib import Path
+import tempfile
+
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_githubauth_page_renders_button():
+    src = Path("website/githubauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "githubauth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            status, _headers, body = await _http_get(f"http://127.0.0.1:{port}/githubauth")
+            server.should_exit = True
+            await task
+            return status, body.decode()
+
+        status, body = asyncio.run(run_test())
+
+        assert status == 200
+        assert "github.com/login/oauth/authorize" in body
+        assert "Iv23liGYF2X5uR4izdC3" in body
+

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -1,0 +1,5 @@
+{{#let state = lower(hex(randomblob(16)))}}
+<a href="https://github.com/login/oauth/authorize?client_id=Iv23liGYF2X5uR4izdC3&state={{state}}">
+  <button>Login with GitHub</button>
+</a>
+


### PR DESCRIPTION
## Summary
- add `githubauth.pageql` example with redirect button
- test that the new page renders and includes the GitHub auth URL

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68507f90247c832fb8776668f989ffc6