### PR TITLE
Add manual JSON example

### DIFF
--- a/tests/test_json_page.py
+++ b/tests/test_json_page.py
@@ -13,9 +13,18 @@ SNIPPET = (
     "    text TEXT NOT NULL,"
     "    completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))"
     ")}}"
+    "["
     "{{{COALESCE(json_group_array("
     "    json_object('id', id, 'text', text, 'completed', completed)"
     "), '[]') from todos}}}"
+    ","
+    "["
+    "{{#let max_id = MAX(id) from todos}}"
+    "{{#from todos order by id}}"
+    "{\"id\":{{id}},\"text\":\"{{text}}\",\"completed\":{{completed}} }{{#if :id != :max_id}},{{/if}}"
+    "{{/from}}"
+    "]"
+    "]"
 )
 
 def test_json_page_outputs_array():
@@ -27,5 +36,4 @@ def test_json_page_outputs_array():
     r.db.execute("INSERT INTO todos(text) VALUES ('task')")
     result = r.render("/json", reactive=False)
     assert ("Content-Type", "application/json") in result.headers
-    assert result.body.strip() == '[{"id":1,"text":"task","completed":0}]'
-
+    assert result.body.strip() == '[[{"id":1,"text":"task","completed":0}],[{"id":1,"text":"task","completed":0 }\n]]'

--- a/website/json.pageql
+++ b/website/json.pageql
@@ -6,7 +6,15 @@
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )}}
 
+[
 {{{COALESCE(json_group_array(
     json_object('id', id, 'text', text, 'completed', completed)
-), '[]') from todos}}}
+), '[]') from todos}}},
+[
+{{#let max_id = MAX(id) from todos}}
+{{#from todos order by id}}
+{"id":{{id}},"text":"{{text}}","completed":{{completed}}{{{'}}'}}{{#if :id != :max_id}},{{/if}}
+{{/from}}
+]
+]
 


### PR DESCRIPTION
## Summary
- demonstrate manual JSON generation using a `#from` loop
- update JSON example test accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68507f295390832fb155c068dad586b0