### PR TITLE
Add first row flag for `#from`

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ PageQL uses a unified namespace for variables originating from different sources
 
 *   Request parameters declared and validated via `#param`.
 *   Variables explicitly set using `#let`.
-*   Columns selected within a `#from` loop (each column becomes a variable within the loop's scope).
+*   Columns selected within a `#from` loop (each column becomes a variable within the loop's scope). A special `__first_row` parameter is also set to `1` for the first row and `0` thereafter.
 *   Parameters passed to a partial via `#render <partial> param_name=value`.
 *   (Potentially cookie values, details TBD).
 

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -858,8 +858,11 @@ class PageQL:
                         v = v.value
                     extra_cache_values[k] = v
                 extra_cache_key = json.dumps(extra_cache_values, sort_keys=True)
+        first = True
         for row in rows:
             row_params = params.copy()
+            row_params["__first_row"] = ReadOnly(first)
+            first = False
             for i, col_name in enumerate(col_names):
                 row_params[col_name] = ReadOnly(row[i])
 

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -496,8 +496,11 @@ class PageQLAsync(PageQL):
                         v = v.value
                     extra_cache_values[k] = v
                 extra_cache_key = json.dumps(extra_cache_values, sort_keys=True)
+        first = True
         for row in rows:
             row_params = params.copy()
+            row_params["__first_row"] = ReadOnly(first)
+            first = False
             for i, col_name in enumerate(col_names):
                 row_params[col_name] = ReadOnly(row[i])
 

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -174,6 +174,7 @@ def _read_block(node_list, i, stop, partials, dialect, tests=None):
                 raise SyntaxError("missing {{/from}}")
             i += 1
             deps = ast_param_dependencies(loop_body)
+            deps.discard("__first_row")
             body.append(["#from", (query, expr), deps, loop_body])
             continue
 

--- a/tests/test_from_first_row.py
+++ b/tests/test_from_first_row.py
@@ -1,0 +1,16 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL
+
+
+def test_from_sets_first_row_param():
+    r = PageQL(":memory:")
+    r.db.execute("CREATE TABLE items(id INTEGER)")
+    r.db.executemany("INSERT INTO items(id) VALUES (?)", [(1,), (2,)])
+    r.load_module("m", "{{#from items ORDER BY id}}{{:__first_row}} {{id}}{{/from}}")
+    result = r.render("/m", reactive=False)
+    assert result.body == "True 1\nFalse 2\n"
+


### PR DESCRIPTION
## Summary
- add `__first_row` parameter to `#from` directive
- ensure parser ignores the new parameter when tracking dependencies
- document the `__first_row` flag
- test `__first_row` functionality

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68508344bc44832f9ff1203fe5c08013