### PR TITLE
Clarify __first_row behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ PageQL uses a unified namespace for variables originating from different sources
 
 *   Request parameters declared and validated via `#param`.
 *   Variables explicitly set using `#let`.
-*   Columns selected within a `#from` loop (each column becomes a variable within the loop's scope). A special `__first_row` parameter is also set to `1` for the first row and `0` thereafter.
+*   Columns selected within a `#from` loop (each column becomes a variable within the loop's scope). A special `__first_row` parameter is also set to `1` for the first row and `0` thereafter. `__first_row` is not reactive and was created mainly to assist with static JSON output.
 *   Parameters passed to a partial via `#render <partial> param_name=value`.
 *   (Potentially cookie values, details TBD).
 


### PR DESCRIPTION
## Summary
- update parameter binding section in README
- note that `__first_row` is non-reactive and intended for static JSON output

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685085294de0832f84535b37f5240530