### PR TITLE
Add GitHub callback fetch example

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -24,3 +24,39 @@ def test_githubauth_page_renders_button():
         assert "github.com/login/oauth/authorize" in body
         assert "Iv23liGYF2X5uR4izdC3" in body
 
+
+def test_githubauth_callback_fetch():
+    src = Path("website/githubauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "githubauth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            from pageql import pageql as pql_mod
+            seen = {}
+
+            def fake_fetch(url: str):
+                seen["url"] = url
+                return {"status_code": 200, "headers": [], "body": "resp"}
+
+            old_fetch = pql_mod.fetch_sync
+            pql_mod.fetch_sync = fake_fetch
+            try:
+                server, task, port = await run_server_in_task(tmpdir)
+                status, _headers, body = await _http_get(
+                    f"http://127.0.0.1:{port}/githubauth/callback?code=abc&state=xyz"
+                )
+                server.should_exit = True
+                await task
+            finally:
+                pql_mod.fetch_sync = old_fetch
+            return status, body.decode(), seen.get("url")
+
+        status, body, url = asyncio.run(run_test())
+
+        assert status == 200
+        assert "resp" in body
+        assert url.startswith("https://github.com/login/oauth/access_token")
+        assert "Iv23liGYF2X5uR4izdC3" in url
+        assert "code=abc" in url
+        assert "state=xyz" in url
+

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -3,3 +3,11 @@
   <button>Login with GitHub</button>
 </a>
 
+
+{{#partial GET callback}}
+  {{#param code required}}
+  {{#param state required}}
+  {{#let client_secret = "YOUR_CLIENT_SECRET"}}
+  {{#fetch token from 'https://github.com/login/oauth/access_token?client_id=Iv23liGYF2X5uR4izdC3&client_secret=' || :client_secret || '&code=' || :code || '&state=' || :state}}
+  {{token__body}}
+{{/partial}}


### PR DESCRIPTION
## Summary
- demo GitHub auth callback with PageQL's `#fetch`
- test for callback partial

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850857e3974832f8c4ffc5685c29813