### PR TITLE
Fix Content-Type override logic

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -362,11 +362,12 @@ class PageQLApp:
             for name, value in result.headers:
                 if name.lower() == 'content-type':
                     content_type = value
+                    continue
                 headers.append((str(name).encode('utf-8'), str(value).encode('utf-8')))
 
             if content_type is None:
                 content_type = 'text/html; charset=utf-8'
-                headers.insert(0, (b'Content-Type', b'text/html; charset=utf-8'))
+            headers.insert(0, (b'Content-Type', str(content_type).encode('utf-8')))
 
             for name, value, opts in result.cookies:
                 parts = [f"{name}={value}"]

--- a/tests/test_header_override.py
+++ b/tests/test_header_override.py
@@ -1,0 +1,22 @@
+import asyncio, tempfile
+from pageql.pageqlapp import PageQLApp
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_content_type_header_overrides(tmp_path):
+    (tmp_path / "_before.pageql").write_text("{{#header Content-Type 'text/html'}}")
+    (tmp_path / "data.pageql").write_text("{{#header Content-Type 'application/json'}}[1]")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, headers, body = await _http_get(f"http://127.0.0.1:{port}/data")
+        server.should_exit = True
+        await task
+        return status, headers, body.decode()
+
+    status, headers, body = asyncio.run(run_test())
+    ct_headers = [h for h in headers if h[0] == b"content-type"]
+    assert status == 200
+    assert ct_headers == [(b"content-type", b"application/json")]
+    assert body == "[1]"


### PR DESCRIPTION
## Summary
- ensure only one Content-Type header is returned
- test that later Content-Type headers override earlier ones

## Testing
- `pytest tests/test_header_override.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685085b6b144832facf53afb1cc17c01