### PR TITLE
Fix GitHub OAuth token parsing

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -45,7 +45,7 @@ def test_githubauth_callback_fetch(monkeypatch):
                 return {
                     "status_code": 200,
                     "headers": [],
-                    "body": '{"access_token": "t"}',
+                    "body": 'access_token=t&token_type=bearer&scope=',
                 }
 
             old_fetch = pql_mod.fetch_sync

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -10,7 +10,8 @@
   {{#let client_secret = env.GITHUB_CLIENT_SECRET}}
   {{#fetch token from 'https://github.com/login/oauth/access_token?client_id=Iv23liGYF2X5uR4izdC3&client_secret='||:client_secret||'&code='||:code||'&state='||:state}}
   {{token__body}}
-  {{#let access_token = trim(json_extract(:token__body, '$.access_token'), '"')}}
+  {{#let token_json = '{"'||replace(replace(:token__body, '=', '":"'), '&', '","')||'"}'}}
+  {{#let access_token = json_extract(:token_json, '$.access_token')}}
   {{#fetch user from 'https://api.github.com/user?access_token='||:access_token}}
   {{user__body}}
   {{/partial}}


### PR DESCRIPTION
## Summary
- parse GitHub OAuth token query string to JSON before extracting
- update githubauth tests for query string response

## Testing
- `PYTHONPATH=src pytest tests/test_githubauth_page.py::test_githubauth_callback_fetch -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68511537ac18832f8a12e223f0a3c14d