### PR TITLE
Add header option to fetch directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ reachable from outside the container.
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
     *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
-*   `#fetch async <var> from <url_expression>`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes.
+*   `#fetch async <var> from <url_expression> [header=<expr>]`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes. The optional `header` expression supplies request headers as a mapping.
 
     ```pageql
     {{#fetch async horse from "https://t3.ftcdn.net/jpg/03/26/50/04/360_F_326500445_ZD1zFSz2cMT1qOOjDy7C5xCD4shawQfM.jpg"}}

--- a/src/pageql/http_utils.py
+++ b/src/pageql/http_utils.py
@@ -168,9 +168,9 @@ async def _http_get(
     return status, resp_headers, body
 
 
-async def fetch(url: str) -> Dict[str, object]:
+async def fetch(url: str, headers: Dict[str, str] | None = None) -> Dict[str, object]:
     """Return a mapping with ``status_code``, ``headers`` and decoded ``body``."""
-    status, headers, body = await _http_get(url)
+    status, headers, body = await _http_get(url, headers=headers)
     try:
         body = body.decode("utf-8")
     except Exception:
@@ -178,11 +178,12 @@ async def fetch(url: str) -> Dict[str, object]:
     return {"status_code": status, "headers": headers, "body": body}
 
 
-def fetch_sync(url: str) -> Dict[str, object]:
+def fetch_sync(url: str, headers: Dict[str, str] | None = None) -> Dict[str, object]:
     """Synchronous variant of :func:`fetch` using ``urllib``."""
-    from urllib.request import urlopen
+    from urllib.request import urlopen, Request
 
-    with urlopen(url) as resp:
+    req = Request(url, headers=headers or {})
+    with urlopen(req) as resp:
         status = resp.status
         headers = [(k.lower().encode(), v.encode()) for k, v in resp.getheaders()]
         body_bytes = resp.read()

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -754,17 +754,38 @@ class PageQLAsync(PageQL):
         ctx,
         out,
     ):
-        if len(node_content) == 3:
+        if len(node_content) == 4:
+            var, expr, is_async, header_expr = node_content
+        elif len(node_content) == 3:
             var, expr, is_async = node_content
+            header_expr = None
         else:
             var, expr = node_content
             is_async = False
+            header_expr = None
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")
         url = evalone(self.db, expr, params, reactive, self.tables)
         if isinstance(url, Signal):
             url = url.value
+        req_headers = None
+        if header_expr is not None:
+            req_headers = evalone(self.db, header_expr, params, reactive, self.tables)
+            if isinstance(req_headers, Signal):
+                req_headers = req_headers.value
+            if isinstance(req_headers, dict):
+                req_headers = {str(k): str(v) for k, v in req_headers.items()}
+            elif isinstance(req_headers, str):
+                hdr_lines = req_headers.split("\n")
+                hdr_dict = {}
+                for line in hdr_lines:
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        hdr_dict[k.strip()] = v.strip()
+                req_headers = hdr_dict
+            else:
+                req_headers = {str(req_headers): ""}
         self.db.commit()
         if is_async:
             body_sig = Signal(None)
@@ -774,15 +795,15 @@ class PageQLAsync(PageQL):
             params[f"{var}__status_code"] = status_sig
             params[f"{var}__headers"] = headers_sig
 
-            async def do_fetch(url=url, b=body_sig, s=status_sig, h=headers_sig):
-                data = await fetch(str(url))
+            async def do_fetch(url=url, b=body_sig, s=status_sig, h=headers_sig, headers=req_headers):
+                data = await fetch(str(url), headers=headers)
                 b.set_value(data.get("body"))
                 s.set_value(data.get("status_code"))
                 h.set_value(data.get("headers"))
 
             tasks.append(do_fetch())
         else:
-            data = await fetch(str(url))
+            data = await fetch(str(url), headers=req_headers)
             for k, v in flatten_params(data).items():
                 params[f"{var}__{k}"] = v
         return reactive

--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -34,7 +34,7 @@ def test_githubauth_callback_fetch(monkeypatch):
             from pageql import pageql as pql_mod
             seen = []
 
-            def fake_fetch(url: str):
+            def fake_fetch(url: str, headers=None):
                 seen.append(url)
                 if "api.github.com/user" in url:
                     return {

--- a/tests/test_pageql_async.py
+++ b/tests/test_pageql_async.py
@@ -24,7 +24,7 @@ async def test_render_async_returns_expected_result():
 async def test_fetch_async_queues_task(monkeypatch):
     calls = []
 
-    async def fake_fetch(url: str):
+    async def fake_fetch(url: str, headers=None):
         calls.append(url)
         return {"status_code": 200, "headers": [], "body": "ok"}
 


### PR DESCRIPTION
## Summary
- support optional `header=` expression in `#fetch`
- update fetch utilities to accept request headers
- document and provide help text for new option
- handle parameter dependencies on `header` expressions
- test `#fetch header=` parsing, dependencies, and render behavior

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685114d90938832f873a9c57079fa710