### PR TITLE
Update GitHub auth demo to use Authorization header

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -35,7 +35,7 @@ def test_githubauth_callback_fetch(monkeypatch):
             seen = []
 
             def fake_fetch(url: str, headers=None):
-                seen.append(url)
+                seen.append((url, headers))
                 if "api.github.com/user" in url:
                     return {
                         "status_code": 200,
@@ -67,11 +67,12 @@ def test_githubauth_callback_fetch(monkeypatch):
         assert status == 200
         assert "access_token" in body
         assert "octocat" in body
-        token_url, user_url = urls
+        (token_url, token_headers), (user_url, user_headers) = urls
         assert token_url.startswith("https://github.com/login/oauth/access_token")
         assert "Iv23liGYF2X5uR4izdC3" in token_url
         assert "client_secret=secret" in token_url
         assert "code=abc" in token_url
         assert "state=xyz" in token_url
-        assert user_url.startswith("https://api.github.com/user?access_token=")
+        assert user_url == "https://api.github.com/user"
+        assert user_headers == {"Authorization": "token \"t\""}
 

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -12,6 +12,7 @@
   {{token__body}}
   {{#let token_json = '{"'||replace(replace(:token__body, '=', '":"'), '&', '","')||'"}'}}
   {{#let access_token = json_extract(:token_json, '$.access_token')}}
-  {{#fetch user from 'https://api.github.com/user?access_token='||:access_token}}
+  {{#fetch user from 'https://api.github.com/user' header='Authorization: token '||:access_token}}
+  {{access_token}}
   {{user__body}}
   {{/partial}}


### PR DESCRIPTION
## Summary
- update `githubauth.pageql` to pass the access token via `Authorization` header
- display extracted access token
- adjust GitHub auth tests to check header value

## Testing
- `PYTHONPATH=src pytest tests/test_githubauth_page.py::test_githubauth_callback_fetch -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68513181d494832fa28cf7602121913f