### PR TITLE
Add query_param SQLite function

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,3 +461,4 @@ starts:
 * `base64_decode(text)` - decode a Base64 string back into text
 * `jws_serialize_compact(payload)` - sign a payload using JSON Web Signature
 * `jws_deserialize_compact(token)` - extract the payload from a JWS token
+* `query_param(qs, name)` - return the first value of ``name`` from ``qs``

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -70,6 +70,17 @@ def run_tasks() -> None:
         asyncio.create_task(run_task(t))
 
 
+def _query_param(qs: str | bytes | None, name: str | None):
+    """Return the first value of *name* from *qs* query string."""
+    if qs is None or name is None:
+        return None
+    if isinstance(qs, bytes):
+        qs = qs.decode()
+    params = parse_qs(qs, keep_blank_values=True)
+    values = params.get(name)
+    return values[0] if values else None
+
+
 
 
 
@@ -625,6 +636,10 @@ class PageQLApp:
                 self.conn.create_function(
                     "jws_deserialize_compact", 1,
                     lambda token: jws_deserialize_compact(token),
+                )
+                self.conn.create_function(
+                    "query_param", 2,
+                    _query_param,
                 )
             except Exception as e:
                 self._log(f"Warning: could not register base64_encode: {e}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -150,6 +150,14 @@ def test_base64_encode_function_is_registered(tmp_path):
     assert result == base64.b64encode(b'abcd').decode()
 
 
+def test_query_param_function_is_registered(tmp_path):
+    app = pageql.pageqlapp.PageQLApp(":memory:", tmp_path, create_db=True, should_reload=False)
+    result = app.conn.execute("select query_param('a=1&b=two', 'b')").fetchone()[0]
+    assert result == 'two'
+    result_none = app.conn.execute("select query_param('a=1', 'b')").fetchone()[0]
+    assert result_none is None
+
+
 def test_before_hook_handles_bytes(tmp_path):
     template = Path(tmp_path) / "before.pageql"
     template.write_text(


### PR DESCRIPTION
## Summary
- add `query_param` SQLite helper to fetch values from query strings
- document it in README
- test the new function

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685133858aa8832fbdbad595cd1c7473