### PR TITLE
Fix failing GitHub auth test

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -74,5 +74,5 @@ def test_githubauth_callback_fetch(monkeypatch):
         assert "code=abc" in token_url
         assert "state=xyz" in token_url
         assert user_url == "https://api.github.com/user"
-        assert user_headers == {"Authorization": "token \"t\""}
+        assert user_headers == {"Authorization": "Bearer t"}
 


### PR DESCRIPTION
## Summary
- adjust expected Authorization header in GitHub auth test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685135d95768832fb71776e5160cb87a