### PR TITLE
Improve GitHub auth state handling

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -84,7 +84,7 @@ def _expand_array_params(params: Dict[str, object]) -> Dict[str, object]:
                     params[f"{key}__{i}"] = item
     return params
 
-  def _query_param(qs: str | bytes | None, name: str | None):
+def _query_param(qs: str | bytes | None, name: str | None):
     """Return the first value of *name* from *qs* query string."""
     if qs is None or name is None:
         return None
@@ -543,6 +543,7 @@ class PageQLApp:
         params['headers'] = headers
         params['method'] = method
         params['env'] = dict(os.environ)
+        params['path'] = scope['path']
 
         if (
             path_cleaned == 'index'

--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import tempfile
 
 from pageql.http_utils import _http_get
+from pageql import jws_serialize_compact, jws_deserialize_compact
 from playwright_helpers import run_server_in_task
+import json
+import re
 
 
 def test_githubauth_page_renders_button():
@@ -23,6 +26,13 @@ def test_githubauth_page_renders_button():
         assert status == 200
         assert "github.com/login/oauth/authorize" in body
         assert "Iv23liGYF2X5uR4izdC3" in body
+
+        m = re.search(r"state=([^\"]+)", body)
+        assert m is not None
+        token = m.group(1)
+        data = json.loads(jws_deserialize_compact(token).decode())
+        assert data["ongoing"] == 1
+        assert data["path"] == "/githubauth"
 
 
 def test_githubauth_callback_fetch(monkeypatch):
@@ -53,16 +63,17 @@ def test_githubauth_callback_fetch(monkeypatch):
             monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
             try:
                 server, task, port = await run_server_in_task(tmpdir)
+                state = jws_serialize_compact('{"ongoing":1,"path":"/githubauth"}')
                 status, _headers, body = await _http_get(
-                    f"http://127.0.0.1:{port}/githubauth/callback?code=abc&state=xyz"
+                    f"http://127.0.0.1:{port}/githubauth/callback?code=abc&state={state}"
                 )
                 server.should_exit = True
                 await task
             finally:
                 pql_mod.fetch_sync = old_fetch
-            return status, body.decode(), seen
+            return status, body.decode(), seen, state
 
-        status, body, urls = asyncio.run(run_test())
+        status, body, urls, state = asyncio.run(run_test())
 
         assert status == 200
         assert "access_token" in body
@@ -72,7 +83,7 @@ def test_githubauth_callback_fetch(monkeypatch):
         assert "Iv23liGYF2X5uR4izdC3" in token_url
         assert "client_secret=secret" in token_url
         assert "code=abc" in token_url
-        assert "state=xyz" in token_url
+        assert f"state={state}" in token_url
         assert user_url == "https://api.github.com/user"
         assert user_headers == {"Authorization": "Bearer t"}
 

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -1,4 +1,5 @@
-{{#let state = lower(hex(randomblob(16)))}}
+{{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
+{{#let state jws_serialize_compact(:payload)}}
 <a href="https://github.com/login/oauth/authorize?client_id=Iv23liGYF2X5uR4izdC3&state={{state}}">
   <button>Login with GitHub</button>
 </a>


### PR DESCRIPTION
## Summary
- use JWS to sign the GitHub OAuth state
- expose request path in PageQLApp parameters
- test signed GitHub auth state token

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685136f39c48832f8fa4c7bb6dadd35a