### PR TITLE
Fix nested fetch async tasks

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -689,6 +689,8 @@ class PageQL:
                 cur = ctx.reactiveelement
                 ctx.reactiveelement = []
                 self.process_nodes(node[1], params, path, includes, http_verb, True, ctx, out=new_buf)
+                from .pageqlapp import run_tasks
+                run_tasks()
                 ctx.reactiveelement = cur
                 html_content = "".join(new_buf).strip()
                 tag = ''
@@ -771,6 +773,8 @@ class PageQL:
                         buf = []
                         if new_idx is not None:
                             self.process_nodes(bodies[new_idx], params, path, includes, http_verb, True, ctx, out=buf)
+                        from .pageqlapp import run_tasks
+                        run_tasks()
                         html_content = "".join(buf).strip()
                         ctx.append_script(
                             f"pset({mid},{json.dumps(html_content)})",

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -272,6 +272,8 @@ class PageQLAsync(PageQL):
                 cur = ctx.reactiveelement
                 ctx.reactiveelement = []
                 self.process_nodes(node[1], params, path, includes, http_verb, True, ctx, out=new_buf)
+                from .pageqlapp import run_tasks
+                run_tasks()
                 ctx.reactiveelement = cur
                 html_content = "".join(new_buf).strip()
                 tag = ""
@@ -363,6 +365,8 @@ class PageQLAsync(PageQL):
                         buf = []
                         if new_idx is not None:
                             self.process_nodes(bodies[new_idx], params, path, includes, http_verb, True, ctx, out=buf)
+                        from .pageqlapp import run_tasks
+                        run_tasks()
                         html_content = "".join(buf).strip()
                         ctx.append_script(
                             f"pset({mid},{json.dumps(html_content)})",


### PR DESCRIPTION
## Summary
- run pending tasks when reactive listeners update

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlglot')*

------
https://chatgpt.com/codex/tasks/task_e_68513d029940832f89e57c0473a6cff9