### PR TITLE
Expose html_escape sqlite function

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,3 +462,4 @@ starts:
 * `jws_serialize_compact(payload)` - sign a payload using JSON Web Signature
 * `jws_deserialize_compact(token)` - extract the payload from a JWS token
 * `query_param(qs, name)` - return the first value of ``name`` from ``qs``
+* `html_escape(text)` - escape special characters in ``text`` for safe HTML output

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -3,6 +3,7 @@ import os, time
 import sqlite3
 import mimetypes
 import base64
+import html
 from urllib.parse import urlparse, parse_qs
 from watchfiles import awatch
 import uuid
@@ -656,6 +657,10 @@ class PageQLApp:
                 self.conn.create_function(
                     "query_param", 2,
                     _query_param,
+                )
+                self.conn.create_function(
+                    "html_escape", 1,
+                    lambda txt: html.escape(str(txt)) if txt is not None else None,
                 )
             except Exception as e:
                 self._log(f"Warning: could not register base64_encode: {e}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ import pageql.pageqlapp
 from pageql.http_utils import _http_get
 import asyncio
 import base64
+import html
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
@@ -156,6 +157,12 @@ def test_query_param_function_is_registered(tmp_path):
     assert result == 'two'
     result_none = app.conn.execute("select query_param('a=1', 'b')").fetchone()[0]
     assert result_none is None
+
+
+def test_html_escape_function_is_registered(tmp_path):
+    app = pageql.pageqlapp.PageQLApp(":memory:", tmp_path, create_db=True, should_reload=False)
+    result = app.conn.execute("select html_escape('<div>&')").fetchone()[0]
+    assert result == html.escape('<div>&')
 
 
 def test_before_hook_handles_bytes(tmp_path):


### PR DESCRIPTION
## Summary
- register `html_escape` function in PageQLApp
- document helper SQL functions
- test that `html_escape` is available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685141883810832f9847188069e0af64