### PR TITLE
Add body parameter to fetch directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ reachable from outside the container.
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
     *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
-*   `#fetch async <var> from <url_expression> [header=<expr>] [method=<expr>]`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes. The optional `header` expression supplies request headers as a mapping. The `method` expression chooses the HTTP verb (default `GET`).
+*   `#fetch async <var> from <url_expression> [header=<expr>] [method=<expr>] [body=<expr>]`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes. The optional `header` expression supplies request headers as a mapping. The `method` expression chooses the HTTP verb (default `GET`). The `body` expression sends a request payload encoded as bytes if provided.
 
     ```pageql
     {{#fetch async horse from "https://t3.ftcdn.net/jpg/03/26/50/04/360_F_326500445_ZD1zFSz2cMT1qOOjDy7C5xCD4shawQfM.jpg"}}

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -758,20 +758,26 @@ class PageQLAsync(PageQL):
         ctx,
         out,
     ):
-        if len(node_content) == 5:
+        if len(node_content) == 6:
+            var, expr, is_async, header_expr, method_expr, body_expr = node_content
+        elif len(node_content) == 5:
             var, expr, is_async, header_expr, method_expr = node_content
+            body_expr = None
         elif len(node_content) == 4:
             var, expr, is_async, header_expr = node_content
             method_expr = None
+            body_expr = None
         elif len(node_content) == 3:
             var, expr, is_async = node_content
             header_expr = None
             method_expr = None
+            body_expr = None
         else:
             var, expr = node_content
             is_async = False
             header_expr = None
             method_expr = None
+            body_expr = None
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")
@@ -804,6 +810,13 @@ class PageQLAsync(PageQL):
                 method = "GET"
             else:
                 method = str(method).upper()
+        req_body = None
+        if body_expr is not None:
+            req_body = evalone(self.db, body_expr, params, reactive, self.tables)
+            if isinstance(req_body, Signal):
+                req_body = req_body.value
+            if isinstance(req_body, str):
+                req_body = req_body.encode()
         self.db.commit()
         if is_async:
             body_sig = Signal(None)
@@ -813,15 +826,15 @@ class PageQLAsync(PageQL):
             params[f"{var}__status_code"] = status_sig
             params[f"{var}__headers"] = headers_sig
 
-            async def do_fetch(url=url, b=body_sig, s=status_sig, h=headers_sig, headers=req_headers, meth=method):
-                data = await fetch(str(url), headers=headers, method=meth)
+            async def do_fetch(url=url, b=body_sig, s=status_sig, h=headers_sig, headers=req_headers, meth=method, body=req_body):
+                data = await fetch(str(url), headers=headers, method=meth, body=body)
                 b.set_value(data.get("body"))
                 s.set_value(data.get("status_code"))
                 h.set_value(data.get("headers"))
 
             tasks.append(do_fetch())
         else:
-            data = await fetch(str(url), headers=req_headers, method=method)
+            data = await fetch(str(url), headers=req_headers, method=method, body=req_body)
             for k, v in flatten_params(data).items():
                 params[f"{var}__{k}"] = v
         return reactive


### PR DESCRIPTION
## Summary
- extend README to describe optional body parameter for `#fetch`
- support parsing `body=` argument in parser
- handle body data in sync and async processing
- track dependencies for fetch body expressions
- test fetch body across sync & async code paths

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685148d0df9c832faa596ef78be29cce