### PR TITLE
Simplify fetch directive handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -552,26 +552,7 @@ class PageQL:
 
     def _process_fetch_directive(self, node_content, params, path, includes,
                                  http_verb, reactive, ctx, out):
-        if len(node_content) == 6:
-            var, expr, is_async, header_expr, method_expr, body_expr = node_content
-        elif len(node_content) == 5:
-            var, expr, is_async, header_expr, method_expr = node_content
-            body_expr = None
-        elif len(node_content) == 4:
-            var, expr, is_async, header_expr = node_content
-            method_expr = None
-            body_expr = None
-        elif len(node_content) == 3:
-            var, expr, is_async = node_content
-            header_expr = None
-            method_expr = None
-            body_expr = None
-        else:
-            var, expr = node_content
-            is_async = False
-            header_expr = None
-            method_expr = None
-            body_expr = None
+        var, expr, is_async, header_expr, method_expr, body_expr = node_content
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -758,26 +758,7 @@ class PageQLAsync(PageQL):
         ctx,
         out,
     ):
-        if len(node_content) == 6:
-            var, expr, is_async, header_expr, method_expr, body_expr = node_content
-        elif len(node_content) == 5:
-            var, expr, is_async, header_expr, method_expr = node_content
-            body_expr = None
-        elif len(node_content) == 4:
-            var, expr, is_async, header_expr = node_content
-            method_expr = None
-            body_expr = None
-        elif len(node_content) == 3:
-            var, expr, is_async = node_content
-            header_expr = None
-            method_expr = None
-            body_expr = None
-        else:
-            var, expr = node_content
-            is_async = False
-            header_expr = None
-            method_expr = None
-            body_expr = None
+        var, expr, is_async, header_expr, method_expr, body_expr = node_content
         if var.startswith(":"):
             var = var[1:]
         var = var.replace(".", "__")

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -501,12 +501,15 @@ def ast_param_dependencies(ast):
                     deps.update(get_dependencies(_convert_dot_sql(body_expr)))
             elif t == "#fetch":
                 deps.update(get_dependencies(_convert_dot_sql(c[1])))
-                if len(c) > 3 and c[3] is not None:
-                    deps.update(get_dependencies(_convert_dot_sql(c[3])))
-                if len(c) > 4 and c[4] is not None:
-                    deps.update(get_dependencies(_convert_dot_sql(c[4])))
-                if len(c) > 5 and c[5] is not None:
-                    deps.update(get_dependencies(_convert_dot_sql(c[5])))
+                header_expr = c[3]
+                method_expr = c[4]
+                body_expr = c[5]
+                if header_expr is not None:
+                    deps.update(get_dependencies(_convert_dot_sql(header_expr)))
+                if method_expr is not None:
+                    deps.update(get_dependencies(_convert_dot_sql(method_expr)))
+                if body_expr is not None:
+                    deps.update(get_dependencies(_convert_dot_sql(body_expr)))
             elif t == "#header":
                 if isinstance(c, tuple):
                     _, expr = c


### PR DESCRIPTION
## Summary
- simplify fetch directive processing in PageQL and PageQLAsync
- make `ast_param_dependencies` assume fetch tuples always contain six fields

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68515081cc88832f955bd710a770ab06