### PR TITLE
Add debug prints for async tasks

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -609,6 +609,7 @@ class PageQL:
                 s.set_value(data.get("status_code"))
                 h.set_value(data.get("headers"))
 
+            print(f"queued async fetch for {url}")
             tasks.append(do_fetch())
         else:
             data = fetch_sync(str(url), headers=req_headers, method=method, body=req_body)

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -813,6 +813,7 @@ class PageQLAsync(PageQL):
                 s.set_value(data.get("status_code"))
                 h.set_value(data.get("headers"))
 
+            print(f"queued async fetch for {url}")
             tasks.append(do_fetch())
         else:
             data = await fetch(str(url), headers=req_headers, method=method, body=req_body)


### PR DESCRIPTION
## Summary
- add logging for task execution and websocket script flushing
- print when async fetch tasks are queued

## Testing
- `PYTHONPATH=src pytest tests/test_app.py::test_run_tasks_called -vv`

------
https://chatgpt.com/codex/tasks/task_e_6851576ca484832f8b68a4de2224b50b