### PR TITLE
Fix nested fetch updates

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -719,7 +719,7 @@ class PageQL:
                     html_content += f"</{tag}>"
                 ctx.append_script(
                     f"pupdatetag({mid},{json.dumps(html_content)})",
-                    out,
+                    out if ctx.rendering else None,
                 )
 
             for sig in signals:
@@ -787,7 +787,7 @@ class PageQL:
                         html_content = "".join(buf).strip()
                         ctx.append_script(
                             f"pset({mid},{json.dumps(html_content)})",
-                            out,
+                            out if ctx.rendering else None,
                         )
 
                     for sig in signals:


### PR DESCRIPTION
## Summary
- ensure reactive listeners send scripts directly when page is no longer rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516259ee14832f91728bf4ba33f1b1