### PR TITLE
Support relative URLs in fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ reachable from outside the container.
     *   **Access:** The validated (and potentially defaulted) parameter value is made available as `:<name>`. Direct access via `:<name>` without this tag bypasses validation and defaults.
     *   Dots in `<name>` are converted to `__` when the parameter is looked up, so `#param cookies.session` binds the value of `cookies__session`.
 
-*   `#fetch async <var> from <url_expression> [header=<expr>] [method=<expr>] [body=<expr>]`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes. The optional `header` expression supplies request headers as a mapping. The `method` expression chooses the HTTP verb (default `GET`). The `body` expression sends a request payload encoded as bytes if provided.
+*   `#fetch async <var> from <url_expression> [header=<expr>] [method=<expr>] [body=<expr>]`: Fetches an external URL in the background while rendering. `<var>.status_code`, `<var>.body`, and `<var>.headers` start as `NULL` but automatically update when the request completes. The optional `header` expression supplies request headers as a mapping. The `method` expression chooses the HTTP verb (default `GET`). The `body` expression sends a request payload encoded as bytes if provided. Relative URLs require a `base_url` to be specified.
 
     ```pageql
     {{#fetch async horse from "https://t3.ftcdn.net/jpg/03/26/50/04/360_F_326500445_ZD1zFSz2cMT1qOOjDy7C5xCD4shawQfM.jpg"}}

--- a/tests/test_fetch_utils.py
+++ b/tests/test_fetch_utils.py
@@ -1,0 +1,36 @@
+import asyncio
+import http.server
+import threading
+
+import pytest
+from pageql.http_utils import fetch
+
+
+def test_fetch_relative_url():
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = b"ok"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever)
+    t.start()
+    try:
+        result = asyncio.run(fetch("/healthz", base_url=f"http://127.0.0.1:{port}"))
+        assert result["status_code"] == 200
+        assert result["body"] == "ok"
+    finally:
+        server.shutdown()
+        t.join()
+
+
+def test_fetch_relative_url_without_base_url_raises():
+    with pytest.raises(ValueError):
+        asyncio.run(fetch("/bad"))


### PR DESCRIPTION
## Summary
- remove env-based base_url fallback from fetch
- require explicit base_url for relative URLs
- clarify docs and tests accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68519a1545cc832f981508012aaa3c31