### PR TITLE
Add nested async fetch health test

### DIFF
--- a/tests/test_fetchhealth_page.py
+++ b/tests/test_fetchhealth_page.py
@@ -1,0 +1,46 @@
+import asyncio
+from pathlib import Path
+import tempfile
+
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_fetchhealth_nested_fetch(monkeypatch):
+    src = Path("website/fetchhealth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "fetchhealth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            from pageql import pageql as pql_mod
+            seen = []
+
+            async def fake_fetch(url: str, headers=None, method="GET", body=None):
+                seen.append(url)
+                return {
+                    "status_code": 200,
+                    "headers": [],
+                    "body": "OK",
+                }
+
+            old_fetch = pql_mod.fetch
+            pql_mod.fetch = fake_fetch
+            try:
+                server, task, port = await run_server_in_task(tmpdir)
+                status, _headers, body = await _http_get(
+                    f"http://127.0.0.1:{port}/fetchhealth?port={port}"
+                )
+                server.should_exit = True
+                await task
+            finally:
+                pql_mod.fetch = old_fetch
+            return status, body.decode(), seen, port
+
+        status, body, urls, port = asyncio.run(run_test())
+
+        assert status == 200
+        assert "Loading outer" in body
+        assert urls == [
+            f"http://127.0.0.1:{port}/healthz",
+            f"http://127.0.0.1:{port}/healthz",
+        ]

--- a/website/fetchhealth.pageql
+++ b/website/fetchhealth.pageql
@@ -1,0 +1,14 @@
+{{#param port required}}
+{{#fetch async outer from 'http://127.0.0.1:'||:port||'/healthz'}}
+  {{#if :outer.status_code == 200}}
+    {{#fetch async inner from 'http://127.0.0.1:'||:port||'/healthz'}}
+      {{#if :inner.status_code == 200}}
+        Fetched twice
+      {{#else}}
+        Loading inner...
+      {{/if}}
+    {{/fetch}}
+  {{#else}}
+    Loading outer...
+  {{/if}}
+{{/fetch}}


### PR DESCRIPTION
## Summary
- add fetchhealth.pageql that nests async fetches to `/healthz`
- test nested async fetch requests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685172533bac832f9b088c6750a7e6ed