### PR TITLE
Handle base_url in fetch directive

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -44,7 +44,7 @@ def test_githubauth_callback_fetch(monkeypatch):
             from pageql import pageql as pql_mod
             seen = []
 
-            async def fake_fetch(url: str, headers=None, method="GET", body=None):
+            async def fake_fetch(url: str, headers=None, method="GET", body=None, **kwargs):
                 seen.append((url, headers, method))
                 if "api.github.com/user" in url:
                     return {


### PR DESCRIPTION
## Summary
- resolve relative URLs in `#fetch` by computing base_url from params
- update unit tests for new base_url argument
- add test ensuring relative URLs work in `#fetch`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_6851c156b02c832fb542a5757ddefb22