### PR TITLE
Use relative path in fetchhealth page

### DIFF
--- a/tests/test_fetchhealth_page.py
+++ b/tests/test_fetchhealth_page.py
@@ -13,10 +13,13 @@ def test_fetchhealth_nested_fetch(monkeypatch):
 
         async def run_test():
             from pageql import pageql as pql_mod
+
             seen = []
 
-            async def fake_fetch(url: str, headers=None, method="GET", body=None):
-                seen.append(url)
+            async def fake_fetch(
+                url: str, headers=None, method="GET", body=None, **kwargs
+            ):
+                seen.append((url, kwargs.get("base_url")))
                 return {
                     "status_code": 200,
                     "headers": [],
@@ -41,6 +44,6 @@ def test_fetchhealth_nested_fetch(monkeypatch):
         assert status == 200
         assert "Loading outer" in body
         assert urls == [
-            f"http://127.0.0.1:{port}/healthz",
-            f"http://127.0.0.1:{port}/healthz",
+            ("/healthz", "http://127.0.0.1"),
+            ("/healthz", "http://127.0.0.1"),
         ]

--- a/website/fetchhealth.pageql
+++ b/website/fetchhealth.pageql
@@ -1,7 +1,7 @@
 {{#param port required}}
-{{#fetch async outer from 'http://127.0.0.1:'||:port||'/healthz'}}
+{{#fetch async outer from '/healthz'}}
   {{#if :outer.status_code == 200}}
-    {{#fetch async inner from 'http://127.0.0.1:'||:port||'/healthz'}}
+    {{#fetch async inner from '/healthz'}}
       {{#if :inner.status_code == 200}}
         Fetched twice
       {{#else}}


### PR DESCRIPTION
## Summary
- fetch `/healthz` using a relative path in the sample `fetchhealth` template
- capture `base_url` in nested fetch health test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851e5a058f8832fb14770d0b6f97dd2