### PR TITLE
Fix fetchhealth page

### DIFF
--- a/tests/test_fetchhealth_page.py
+++ b/tests/test_fetchhealth_page.py
@@ -31,7 +31,7 @@ def test_fetchhealth_nested_fetch(monkeypatch):
             try:
                 server, task, port = await run_server_in_task(tmpdir)
                 status, _headers, body = await _http_get(
-                    f"http://127.0.0.1:{port}/fetchhealth?port={port}"
+                    f"http://127.0.0.1:{port}/fetchhealth"
                 )
                 server.should_exit = True
                 await task

--- a/website/fetchhealth.pageql
+++ b/website/fetchhealth.pageql
@@ -1,4 +1,3 @@
-{{#param port required}}
 {{#fetch async outer from '/healthz'}}
   {{#if :outer.status_code == 200}}
     {{#fetch async inner from '/healthz'}}


### PR DESCRIPTION
## Summary
- remove unused `port` parameter from fetchhealth.pageql
- update fetchhealth test accordingly

## Testing
- `pytest -k fetchhealth_page -vv`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6851ecf209b0832f9a7af722322d10a4