### PR TITLE
Add conditional to healthz fetch test

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -307,7 +307,11 @@ async def test_fetch_async_healthz_in_browser(setup):
     """Async fetch should resolve relative URLs using the request host."""
     with tempfile.TemporaryDirectory() as tmpdir:
         Path(tmpdir, "fetchrel.pageql").write_text(
-            "{{#fetch async d from '/healthz'}}{{d__body}}",
+            "{{#fetch async d from '/healthz'}}"
+            "{{#if :d.status_code == 200}}"
+            "{{d__body}}"
+            "{{#else}}Loading...{{/if}}"
+            "{{/fetch}}",
             encoding="utf-8",
         )
 


### PR DESCRIPTION
## Summary
- add `#if` block inside `test_fetch_async_healthz_in_browser`

## Testing
- `PYTHONPATH=src pytest tests/test_browser_integration.py::test_fetch_async_healthz_in_browser -vv`

------
https://chatgpt.com/codex/tasks/task_e_6852388c8a5c832fb64941cfc783ede9