### PR TITLE
Fix nested async fetch updates

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -712,7 +712,10 @@ class PageQL:
                 new_buf = []
                 cur = ctx.reactiveelement
                 ctx.reactiveelement = []
+                prev = ctx.rendering
+                ctx.rendering = True
                 self.process_nodes(node[1], params, path, includes, http_verb, True, ctx, out=new_buf)
+                ctx.rendering = prev
                 from .pageqlapp import run_tasks
                 run_tasks()
                 ctx.reactiveelement = cur
@@ -795,7 +798,10 @@ class PageQL:
                         new_idx = pick_index()
                         buf = []
                         if new_idx is not None:
+                            prev = ctx.rendering
+                            ctx.rendering = True
                             self.process_nodes(bodies[new_idx], params, path, includes, http_verb, True, ctx, out=buf)
+                            ctx.rendering = prev
                         from .pageqlapp import run_tasks
                         run_tasks()
                         html_content = "".join(buf).strip()

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -268,7 +268,10 @@ class PageQLAsync(PageQL):
                 new_buf = []
                 cur = ctx.reactiveelement
                 ctx.reactiveelement = []
+                prev = ctx.rendering
+                ctx.rendering = True
                 self.process_nodes(node[1], params, path, includes, http_verb, True, ctx, out=new_buf)
+                ctx.rendering = prev
                 from .pageqlapp import run_tasks
                 run_tasks()
                 ctx.reactiveelement = cur
@@ -360,7 +363,10 @@ class PageQLAsync(PageQL):
                         new_idx = pick_index()
                         buf = []
                         if new_idx is not None:
+                            prev = ctx.rendering
+                            ctx.rendering = True
                             self.process_nodes(bodies[new_idx], params, path, includes, http_verb, True, ctx, out=buf)
+                            ctx.rendering = prev
                         from .pageqlapp import run_tasks
                         run_tasks()
                         html_content = "".join(buf).strip()

--- a/tests/test_fetchhealth_page.py
+++ b/tests/test_fetchhealth_page.py
@@ -48,3 +48,40 @@ def test_fetchhealth_nested_fetch(monkeypatch):
             ("/healthz", "http://127.0.0.1"),
             ("/healthz", "http://127.0.0.1"),
         ]
+
+
+def test_fetchhealth_nested_fetch_scripts(monkeypatch):
+    src = Path("website/fetchhealth.pageql").read_text()
+    src = src.replace("/healthz", "http://x/healthz")
+
+    async def run_test():
+        from pageql import pageql as pql_mod
+
+        async def fake_fetch(url: str, headers=None, method="GET", body=None, **kwargs):
+            return {"status_code": 200, "headers": [], "body": "OK"}
+
+        old_fetch = pql_mod.fetch
+        pql_mod.fetch = fake_fetch
+        try:
+            r = pql_mod.PageQL(":memory:")
+            r.load_module("fetchhealth", src)
+            result = r.render("/fetchhealth")
+            ctx = result.context
+            while pql_mod.tasks:
+                await pql_mod.tasks.pop(0)
+                await asyncio.sleep(0)
+            await asyncio.sleep(0.1)
+            scripts = ctx.scripts
+        finally:
+            pql_mod.fetch = old_fetch
+            pql_mod.tasks.clear()
+        return scripts
+
+    scripts = asyncio.run(run_test())
+
+    assert scripts[0] == 'pset(1,"OK")'
+    assert scripts[2] == 'pset(3,"OK")'
+    assert scripts[3] == 'pset(2,"Fetched twice")'
+    assert scripts[1].startswith('pset(0,"<script>pstart(2)</script>')
+    assert '<script>pstart(3)</script>' in scripts[1]
+    assert scripts[1].endswith('<script>pend(2)</script>")')


### PR DESCRIPTION
## Summary
- ensure nested reactive updates build HTML in-memory
- test nested async fetch output scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68528b300720832f83fbb52b0a3a81dc