### PR TITLE
Fix rendering flags for reactive DB listeners

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -949,7 +949,10 @@ class PageQL:
                         for i, col_name in enumerate(col_names):
                             row_params[col_name] = ReadOnly(ev[1][i])
                         row_buf = []
+                        prev = ctx.rendering
+                        ctx.rendering = True
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
+                        ctx.rendering = prev
                         row_content = ''.join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
                     ctx.append_script(f"pinsert('{row_id}',{json.dumps(row_content)})")
@@ -964,7 +967,10 @@ class PageQL:
                             row_params[col_name] = ReadOnly(ev[2][i])
                         row_buf = []
                         #print("processing node for update", body)
+                        prev = ctx.rendering
+                        ctx.rendering = True
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
+                        ctx.rendering = prev
                         row_content = ''.join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
                     ctx.append_script(f"pupdate('{old_id}','{new_id}',{json.dumps(row_content)})")

--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -537,7 +537,10 @@ class PageQLAsync(PageQL):
                         for i, col_name in enumerate(col_names):
                             row_params[col_name] = ReadOnly(ev[1][i])
                         row_buf = []
+                        prev = ctx.rendering
+                        ctx.rendering = True
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
+                        ctx.rendering = prev
                         row_content = "".join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
                     ctx.append_script(f"pinsert('{row_id}',{json.dumps(row_content)})")
@@ -551,7 +554,10 @@ class PageQLAsync(PageQL):
                         for i, col_name in enumerate(col_names):
                             row_params[col_name] = ReadOnly(ev[2][i])
                         row_buf = []
+                        prev = ctx.rendering
+                        ctx.rendering = True
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
+                        ctx.rendering = prev
                         row_content = "".join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
                     ctx.append_script(f"pupdate('{old_id}','{new_id}',{json.dumps(row_content)})")


### PR DESCRIPTION
## Summary
- preserve context.rendering around table event listeners

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68528fbbf500832f98a1948ae7eb1974