### PR TITLE
Move script escaping out of RenderContext

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -35,7 +35,12 @@ from pageql.reactive import (
     ReadOnly,
     _convert_dot_sql,
 )
-from pageql.render_context import RenderContext, RenderResult, RenderResultException
+from pageql.render_context import (
+    RenderContext,
+    RenderResult,
+    RenderResultException,
+    escape_script,
+)
 from pageql.reactive_sql import parse_reactive, _replace_placeholders
 from pageql.database import (
     connect_database,
@@ -392,9 +397,8 @@ class PageQL:
             ctx.append_script(f"pend({mid})")
 
             def listener(v=None, *, sig=signal, mid=mid, ctx=ctx):
-                ctx.append_script(
-                    f"pset({mid},{json.dumps(str(sig.value))})",
-                )
+                safe_json = escape_script(json.dumps(str(sig.value)))
+                ctx.append_script(f"pset({mid},{safe_json})")
 
             ctx.add_listener(signal, listener)
         else:
@@ -799,7 +803,8 @@ class PageQL:
                         from .pageqlapp import run_tasks
                         run_tasks()
                         html_content = "".join(buf).strip()
-                        ctx.append_script(f"pset({mid},{json.dumps(html_content)})")
+                        safe_json = escape_script(json.dumps(html_content))
+                        ctx.append_script(f"pset({mid},{safe_json})")
 
                     for sig in signals:
                         ctx.add_listener(sig, listener)
@@ -946,7 +951,8 @@ class PageQL:
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
                         row_content = ''.join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
-                    ctx.append_script(f"pinsert('{row_id}',{json.dumps(row_content)})")
+                    safe_json = escape_script(json.dumps(row_content))
+                    ctx.append_script(f"pinsert('{row_id}',{safe_json})")
                 elif ev[0] == 3:
                     old_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[1])).encode()).digest())[:8].decode()}"
                     new_id = f"{mid}_{base64.b64encode(hashlib.sha256(repr(tuple(ev[2])).encode()).digest())[:8].decode()}"
@@ -961,7 +967,8 @@ class PageQL:
                         self.process_nodes(body, row_params, path, includes, http_verb, True, ctx, out=row_buf)
                         row_content = ''.join(row_buf).strip()
                         _ONEVENT_CACHE[cache_key] = row_content
-                    ctx.append_script(f"pupdate('{old_id}','{new_id}',{json.dumps(row_content)})")
+                    safe_json = escape_script(json.dumps(row_content))
+                    ctx.append_script(f"pupdate('{old_id}','{new_id}',{safe_json})")
 
             ctx.add_listener(comp, on_event)
 

--- a/src/pageql/render_context.py
+++ b/src/pageql/render_context.py
@@ -1,5 +1,10 @@
 """Utilities and classes for managing rendering state."""
 
+
+def escape_script(content: str) -> str:
+    """Escape closing ``</script>`` tags in *content* for safe embedding."""
+    return content.replace("</script>", "<\\/script>")
+
 class RenderResult:
     """Holds the results of a render operation."""
 
@@ -57,16 +62,7 @@ class RenderContext:
         send_directly = not self.rendering
 
         if not send_directly:
-            # Avoid prematurely closing the script tag if ``content`` contains
-            # the ``</script>`` sequence by escaping it. This can happen when
-            # reactive HTML snippets include nested ``<script>`` tags that are
-            # inserted via ``pinsert`` or ``pupdate``.
-            # Escape any nested ``</script>`` sequences to avoid prematurely
-            # terminating the surrounding script tag. Using a double backslash
-            # prevents ``SyntaxWarning: invalid escape sequence`` from Python
-            # while producing the desired ``<\/script>`` string in HTML.
-            safe_content = content.replace("</script>", "<\\/script>")
-            self.out.append(f"<script>{safe_content}</script>")
+            self.out.append(f"<script>{content}</script>")
         else:
             if self.send_script is not None:
                 self.send_script(content)


### PR DESCRIPTION
## Summary
- move `</script>` escaping logic from `RenderContext.append_script`
- escape script content when building `pset`, `pinsert` and `pupdate` instructions instead

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68528eb56cf8832f9e0633838d4af9d5