### PR TITLE
Enable async fetch browser tests

### DIFF
--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -283,7 +283,6 @@ async def test_get_text_body_from_client(setup):
 
 
 @pytest.mark.filterwarnings("ignore:.*:DeprecationWarning")
-@pytest.mark.xfail(reason="async fetch updates flaky in headless environment")
 async def test_fetch_async_directive_in_browser(setup):
     """Async fetch should update the page once the HTTP request completes."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -304,7 +303,6 @@ async def test_fetch_async_directive_in_browser(setup):
 
 
 @pytest.mark.filterwarnings("ignore:.*:DeprecationWarning")
-@pytest.mark.xfail(reason="Async nested fetch does not always update in time")
 async def test_fetch_async_healthz_in_browser(setup):
     """Async fetch should resolve relative URLs using the request host."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- enable the async fetch browser integration tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b13d1ae4832f9ac7a897a9ea3a0c