### PR TITLE
Adjust CLI arg order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ EXPOSE 8000
 VOLUME ["/data", "/app/website"]
 
 ENTRYPOINT ["pageql"]
-CMD ["/data/data.db", "/app/website", "--create", "--host", "0.0.0.0"]
+CMD ["/app/website", "/data/data.db", "--create", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It was inspired by ColdFusion language that allows embedding SQL and Handlebars 
 
 PageQL is **reactive-first**: rendered HTML automatically updates when the underlying database data changes.
 
-Usage: ```pageql <database> templates [--create] [--test]```
+Usage: ```pageql templates <database> [--create] [--test]```
 
 Install: pip install pageql  # uvicorn[standard] is installed automatically
 
@@ -65,11 +65,11 @@ To maintain focus and simplicity, several design choices have been made:
 PageQL is intended to be run via a command-line tool. The basic usage involves pointing the tool at a directory of `.pageql` files and specifying the SQLite database or a database URL to use.
 
 ```bash
-pageql path/to/your/database.sqlite ./templates
+pageql ./templates path/to/your/database.sqlite
 ```
 
-*   `<database>`: (Required) Path to the SQLite database file or a PostgreSQL/MySQL connection URL.
 *   `<path>`: (Required) Path to the directory containing the PageQL template files (`.pageql`) to be served.
+*   `<database>`: (Required) Path to the SQLite database file or a PostgreSQL/MySQL connection URL.
 *   `--port <number>`: (Optional) Port number to run the development server on. Defaults to a standard port (e.g., 8000 or 8080).
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   `--fallback-url <url>`: (Optional) Forward unknown routes to this base URL.
@@ -103,7 +103,7 @@ docker run -p 8000:8000 \
     pageql
 ```
 
-The container runs `pageql /data/data.db /app/website --create --host 0.0.0.0` so
+The container runs `pageql /app/website /data/data.db --create --host 0.0.0.0` so
 a new database is created automatically on first use and the server is
 reachable from outside the container.
 

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -51,8 +51,8 @@ def main():
     parser = argparse.ArgumentParser(description="Run the PageQL development server.")
 
     # Add positional arguments - these will be the primary way to use the command
-    parser.add_argument('db_file', help="Path to the SQLite database file or a database URL")
     parser.add_argument('templates_dir', help="Path to the directory containing .pageql template and static files")
+    parser.add_argument('db_file', help="Path to the SQLite database file or a database URL")
     parser.add_argument('--host', default='127.0.0.1', help="Host interface to bind the server.")
     parser.add_argument('--port', type=int, default=8000, help="Port number to run the server on.")
     parser.add_argument('--create', action='store_true', help="Create the database file if it doesn't exist.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,8 +34,8 @@ def test_cli_fallback_url(monkeypatch, tmp_path):
 
     argv = [
         "pageql",
-        "test.db",
         str(tmp_path),
+        "test.db",
         "--fallback-url",
         "http://example.com",
     ]
@@ -48,7 +48,7 @@ def test_cli_test_command(monkeypatch, tmp_path, capsys):
     (tmp_path / "t.pageql").write_text(
         "{{#test a}}{{#create table t(x int)}}{{#insert into t values (1)}}{{count(*) from t}}{{/test}}"
     )
-    argv = ["pageql", "db.sqlite", str(tmp_path), "--test"]
+    argv = ["pageql", str(tmp_path), "db.sqlite", "--test"]
     monkeypatch.setattr(sys, "argv", argv)
     with pytest.raises(SystemExit) as exc:
         cli.main()
@@ -80,8 +80,8 @@ def test_cli_http_disconnect_timeout(monkeypatch, tmp_path):
 
     argv = [
         "pageql",
-        "db",
         str(tmp_path),
+        "db",
         "--http-disconnect-cleanup-timeout",
         "0.5",
     ]


### PR DESCRIPTION
## Summary
- update CLI positional argument order to take templates first then database
- document new ordering in README and Dockerfile
- adjust tests for new CLI parameter order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b6552a98832f91802313ad3daf69