### PR TITLE
Use env for github client id

### DIFF
--- a/tests/test_githubauth_page.py
+++ b/tests/test_githubauth_page.py
@@ -9,10 +9,11 @@ import json
 import re
 
 
-def test_githubauth_page_renders_button():
+def test_githubauth_page_renders_button(monkeypatch):
     src = Path("website/githubauth.pageql").read_text()
     with tempfile.TemporaryDirectory() as tmpdir:
         Path(tmpdir, "githubauth.pageql").write_text(src, encoding="utf-8")
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "Iv23liGYF2X5uR4izdC3")
 
         async def run_test():
             server, task, port = await run_server_in_task(tmpdir)
@@ -61,6 +62,7 @@ def test_githubauth_callback_fetch(monkeypatch):
             old_fetch = pql_mod.fetch
             pql_mod.fetch = fake_fetch
             monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
+            monkeypatch.setenv("GITHUB_CLIENT_ID", "Iv23liGYF2X5uR4izdC3")
             try:
                 server, task, port = await run_server_in_task(tmpdir)
                 state = jws_serialize_compact('{"ongoing":1,"path":"/githubauth"}')

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -1,6 +1,7 @@
 {{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
 {{#let state jws_serialize_compact(:payload)}}
-<a href="https://github.com/login/oauth/authorize?client_id=Iv23liGYF2X5uR4izdC3&state={{state}}">
+{{#let client_id = env.GITHUB_CLIENT_ID}}
+<a href="https://github.com/login/oauth/authorize?client_id={{client_id}}&state={{state}}">
   <button>Login with GitHub</button>
 </a>
 
@@ -12,9 +13,10 @@
   {{#let payload_path = json_extract(:payload, '$.path')}}
   <p>Payload: {{:payload}}</p>
   <p>Payload path: {{:payload_path}}</p>
+  {{#let client_id = env.GITHUB_CLIENT_ID}}
 
   {{#let client_secret = env.GITHUB_CLIENT_SECRET}}
-  {{#fetch async token from 'https://github.com/login/oauth/access_token?client_id=Iv23liGYF2X5uR4izdC3&client_secret='||:client_secret||'&code='||:code||'&state='||:state}}
+  {{#fetch async token from 'https://github.com/login/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&state='||:state}}
     {{#if :token.status_code == 200}}
       {{#let access_token = query_param(:token.body, 'access_token')}}
       <p>Extracted access token: {{access_token}}</p>


### PR DESCRIPTION
## Summary
- pull GitHub OAuth client ID from `env.GITHUB_CLIENT_ID` instead of a hard-coded value
- update GitHub auth tests to provide this environment variable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b6e8eed8832f86e7adcc7a8e7a37