### PR TITLE
Remove httpx from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "watchfiles",
     "sqlglot",
     "joserfc",
-    "httpx",
     "authlib",
 ]
 


### PR DESCRIPTION
## Summary
- remove unused `httpx` from project dependencies

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852b71cf990832fa23e864e52fb05cb