### PR TITLE
Refactor highlighter stability test

### DIFF
--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -1,24 +1,31 @@
 from pathlib import Path
+import html
+import re
 import time
 
 from pageql.highlighter import highlight
 
 
-def _extract_snippet(html: str) -> str:
-    start = html.index('<div class="highlight')
-    start = html.index('>', html.index('<pre', start)) + 1
-    end = html.index('</pre>', start)
-    return html[start:end]
+def _extract_snippet(page: str) -> str:
+    start = page.index('<div class="highlight')
+    start = page.index('>', page.index('<pre', start)) + 1
+    end = page.index('</pre>', start)
+    return page[start:end]
 
 
-def test_highlight_matches_example():
-    src = Path('examples/templates/todos.pageql').read_text()
+def _remove_color_spans(html_text: str) -> str:
+    no_spans = re.sub(r"</?span[^>]*>", "", html_text)
+    return html.unescape(no_spans)
+
+
+def test_highlight_roundtrip():
+    page = Path("website/todos.pageql").read_text()
+    snippet = _extract_snippet(page)
+    plain = _remove_color_spans(snippet)
+
     start = time.perf_counter()
-    result = highlight(src)
+    rehighlighted = highlight(plain)
     duration = time.perf_counter() - start
     assert duration < 0.01
 
-    website = Path('website/todos.pageql').read_text()
-    snippet = _extract_snippet(website)
-
-    assert result[:200] == snippet[:200]
+    assert rehighlighted[:200] == snippet[:200]


### PR DESCRIPTION
## Summary
- update highlighter test to drop color styles before a roundtrip on the website snippet
- verify highlighting roundtrips correctly without colours

## Testing
- `PYTHONPATH=src pytest tests/test_highlighter.py::test_highlight_roundtrip -vv`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68532cdd0cec832fb16fb6fe275cb257