### PR TITLE
Add highlight_block helper with copy button

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -10,7 +10,7 @@ from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
 from .jws_utils import jws_serialize_compact, jws_deserialize_compact
-from .highlighter import highlight
+from .highlighter import highlight, highlight_block
 # Define the version
 __version__ = "0.1.0"
 
@@ -25,4 +25,5 @@ __all__ = [
     "jws_serialize_compact",
     "jws_deserialize_compact",
     "highlight",
+    "highlight_block",
 ]

--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -202,3 +202,30 @@ def highlight(source: str) -> str:
         result.append(_highlight_text(source[pos:]))
     return ''.join(result)
 
+
+def highlight_block(source: str) -> str:
+    """Return a block of HTML with highlighted ``source`` and a copy button."""
+    code = highlight(source)
+    return (
+        '<div style="position: relative;">\n'
+        '  <button onclick="copySourceCode(this)" '
+        'style="position: absolute; top: 8px; right: 8px; z-index: 10; '
+        'background: rgba(255,255,255,0.15); border: 1px solid '
+        'rgba(255,255,255,0.3); border-radius: 4px; padding: 8px; '
+        'cursor: pointer; color: #d4d4d4; transition: all 0.2s;">\n'
+        '    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" '
+        'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">\n'
+        '      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>\n'
+        '      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>\n'
+        '    </svg>\n'
+        '  </button>\n'
+        '<div class="code-column">\n'
+        '<div class="highlight" style="background:rgb(24, 28, 29); '
+        'border-radius: 8px; padding: 1rem; overflow-x: auto;">'
+        '<pre style="line-height: 125%; color: #d4d4d4; margin: 0;">'
+        f'{code}</pre></div>\n'
+        '    </div>\n'
+        '</div>'
+    )
+

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import time
 
-from pageql.highlighter import highlight
+from pageql.highlighter import highlight, highlight_block
 
 
 def _extract_snippet(html: str) -> str:
@@ -9,6 +9,15 @@ def _extract_snippet(html: str) -> str:
     start = html.index('>', html.index('<pre', start)) + 1
     end = html.index('</pre>', start)
     return html[start:end]
+
+
+def _extract_block(html: str) -> str:
+    start = html.index('<div style="position: relative;">')
+    end_pre = html.index('</pre>', start)
+    end1 = html.index('</div>', end_pre)
+    end2 = html.index('</div>', end1 + 6)
+    end3 = html.index('</div>', end2 + 6)
+    return html[start:end3 + 6]
 
 
 def test_highlight_matches_example():
@@ -22,3 +31,13 @@ def test_highlight_matches_example():
     snippet = _extract_snippet(website)
 
     assert result[:200] == snippet[:200]
+
+
+def test_highlight_block_matches_example():
+    src = Path('examples/templates/todos.pageql').read_text()
+    result = highlight_block(src)
+
+    website = Path('website/todos.pageql').read_text()
+    block = _extract_block(website)
+
+    assert result[:200] == block[:200]


### PR DESCRIPTION
## Summary
- extend `pageql.highlighter` with `highlight_block` to wrap highlighted code
- export `highlight_block`
- test new helper for consistency with website example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685333bafd38832faed03a4c995fc1b9