### PR TITLE
Add highlight_block utility for copyable code

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -10,7 +10,7 @@ from .reactive import ReadOnly
 from .pageqlapp import PageQLApp
 from .reactive_sql import parse_reactive
 from .jws_utils import jws_serialize_compact, jws_deserialize_compact
-from .highlighter import highlight
+from .highlighter import highlight, highlight_block
 # Define the version
 __version__ = "0.1.0"
 
@@ -25,4 +25,5 @@ __all__ = [
     "jws_serialize_compact",
     "jws_deserialize_compact",
     "highlight",
+    "highlight_block",
 ]

--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -202,3 +202,39 @@ def highlight(source: str) -> str:
         result.append(_highlight_text(source[pos:]))
     return ''.join(result)
 
+
+def highlight_block(source: str) -> str:
+    """Return HTML for a highlighted code block with copy button."""
+    highlighted = highlight(source)
+    button_svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" '
+        'viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" '
+        'aria-hidden="true">'
+        '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>'
+        '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>'
+        '</svg>'
+    )
+    button = (
+        '<button onclick="copySourceCode(this)" '
+        'style="position: absolute; top: 8px; right: 8px; z-index: 10; '
+        'background: rgba(255,255,255,0.15); border: 1px solid '
+        'rgba(255,255,255,0.3); border-radius: 4px; padding: 8px; '
+        'cursor: pointer; color: #d4d4d4; transition: all 0.2s;">'
+        f'{button_svg}</button>'
+    )
+    pre_start = (
+        '<div class="code-column">'
+        '<div class="highlight" '
+        'style="background:rgb(24, 28, 29); border-radius: 8px; '
+        'padding: 1rem; overflow-x: auto;"><pre '
+        'style="line-height: 125%; color: #d4d4d4; margin: 0;">'
+    )
+    pre_end = '</pre></div></div>'
+    return (
+        '<div style="position: relative;">'
+        f'{button}'
+        f'{pre_start}{highlighted}{pre_end}'
+        '</div>'
+    )
+

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -3,7 +3,7 @@ import html
 import re
 import time
 
-from pageql.highlighter import highlight
+from pageql.highlighter import highlight, highlight_block
 
 
 def _extract_snippet(page: str) -> str:
@@ -29,3 +29,17 @@ def test_highlight_roundtrip():
     assert duration < 0.01
 
     assert rehighlighted[:200] == snippet[:200]
+
+
+def test_highlight_block_wraps_highlight():
+    page = Path("website/todos.pageql").read_text()
+    snippet = _extract_snippet(page)
+    plain = _remove_color_spans(snippet)
+
+    block = highlight_block(plain)
+
+    assert block.startswith('<div style="position: relative;">')
+    assert '<button onclick="copySourceCode(this)"' in block
+    assert '<div class="highlight"' in block
+    assert highlight(plain) in block
+    assert block.rstrip().endswith('</pre></div></div></div>')


### PR DESCRIPTION
## Summary
- extend highlighter with `highlight_block` that wraps syntax highlighted output in the same markup used in the todo example
- export `highlight_block` from the package
- test new helper and wrapping semantics

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685335d9577c832f982f8dab4388f685