### PR TITLE
Increase highlighter test range

### DIFF
--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -96,7 +96,11 @@ def _highlight_pageql_expr(text: str) -> str:
             word_lower = word.lower()
             word_upper = word.upper()
             if word.startswith('#') or word.startswith('/'):
-                color = _DIRECTIVE_COLOR
+                inner = word.lstrip('#/')
+                if inner.lower() in ("param", "if"):
+                    color = _SQL_COLOR
+                else:
+                    color = _DIRECTIVE_COLOR
             elif word_lower in HTTP_VERBS:
                 color = _HTTPVERB_COLOR
             elif word_upper in FUNC_NAMES:

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -28,7 +28,7 @@ def test_highlight_roundtrip():
     duration = time.perf_counter() - start
     assert duration < 0.01
 
-    assert rehighlighted[:200] == snippet[:200]
+    assert rehighlighted[:250] == snippet[:250]
 
 
 def test_highlight_block_wraps_highlight():


### PR DESCRIPTION
## Summary
- verify 250 chars when checking highlighting output
- color `#param` and `#if` directives as SQL keywords

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685390837ee0832f99906c6bb4a04d64