### PR TITLE
Fix highlight output for longer snippet

### DIFF
--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -56,6 +56,7 @@ def _span(content: str, color: str) -> str:
 def _highlight_pageql_expr(text: str) -> str:
     i = 0
     out: list[str] = []
+    next_as_var = False
     while i < len(text):
         ch = text[i]
         if ch.isspace():
@@ -95,8 +96,13 @@ def _highlight_pageql_expr(text: str) -> str:
             word = text[i:j]
             word_lower = word.lower()
             word_upper = word.upper()
-            if word.startswith('#') or word.startswith('/'):
+            if next_as_var:
+                color = _VAR_COLOR
+                next_as_var = False
+            elif word.startswith('#') or word.startswith('/'):
                 color = _DIRECTIVE_COLOR
+                if word_lower in ('#param', '#let'):
+                    next_as_var = True
             elif word_lower in HTTP_VERBS:
                 color = _HTTPVERB_COLOR
             elif word_upper in FUNC_NAMES:

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -28,7 +28,7 @@ def test_highlight_roundtrip():
     duration = time.perf_counter() - start
     assert duration < 0.01
 
-    assert rehighlighted[:250] == snippet[:250]
+    assert rehighlighted[:300] == snippet[:300]
 
 
 def test_highlight_block_wraps_highlight():


### PR DESCRIPTION
## Summary
- extend highlight test comparison to first 300 characters
- color parameter and let names correctly in the highlighter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68539c891b60832f964dc7de0023fed0