### PR TITLE
Update highlighter param color

### DIFF
--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -30,6 +30,8 @@ FUNC_NAMES = {"COUNT", "IIF"}
 
 HTTP_VERBS = {"post", "patch", "delete", "get", "put"}
 
+PARAM_ATTRS = {"maxlength", "default", "pattern"}
+
 
 _DIRECTIVE_COLOR = "#569cd6; font-weight: bold;"
 _SQL_COLOR = "#c586c0; font-weight: bold;"
@@ -103,7 +105,7 @@ def _highlight_pageql_expr(text: str) -> str:
                 color = _DIRECTIVE_COLOR
                 if word_lower in ('#param', '#let'):
                     next_as_var = True
-            elif word_lower in HTTP_VERBS:
+            elif word_lower in HTTP_VERBS or word_lower in PARAM_ATTRS:
                 color = _HTTPVERB_COLOR
             elif word_upper in FUNC_NAMES:
                 color = _FUNC_COLOR

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -28,7 +28,7 @@ def test_highlight_roundtrip():
     duration = time.perf_counter() - start
     assert duration < 0.01
 
-    assert rehighlighted[:300] == snippet[:300]
+    assert rehighlighted[:400] == snippet[:400]
 
 
 def test_highlight_block_wraps_highlight():


### PR DESCRIPTION
## Summary
- expand checked snippet section in highlighting test
- highlight param attributes like `maxlength`, `default`, and `pattern` using the HTTP verb color

## Testing
- `pytest tests/test_highlighter.py::test_highlight_roundtrip -vv`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853a22f9d9c832fbdd8ef6db1225b97