### PR TITLE
Add showsource tag

### DIFF
--- a/src/pageql/pageql_async.py
+++ b/src/pageql/pageql_async.py
@@ -694,6 +694,8 @@ class PageQLAsync(PageQL):
                 return self._process_log_directive(node_content, params, path, includes, http_verb, reactive, ctx)
             elif node_type == "#dump":
                 return self._process_dump_directive(node_content, params, path, includes, http_verb, reactive, ctx)
+            elif node_type == "#showsource":
+                return self._process_showsource_directive(node_content, params, path, includes, http_verb, reactive, ctx)
             else:
                 if not node_type.startswith("/"):
                     raise ValueError(format_unknown_directive(node_type))

--- a/tests/test_showsource_directive.py
+++ b/tests/test_showsource_directive.py
@@ -1,0 +1,22 @@
+import sys, types
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *a, **k: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast
+from pageql.pageql import PageQL
+from pageql.highlighter import highlight_block
+
+
+def test_showsource_directive_parses():
+    tokens = tokenize("{{#showsource}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert body == [("#showsource", None)]
+
+
+def test_showsource_outputs_highlighted_source():
+    r = PageQL(":memory:")
+    src = "hi\n{{#showsource}}"
+    r.load_module("m", src)
+    result = r.render("/m", reactive=False)
+    assert result.body == "hi\n" + highlight_block(src)


### PR DESCRIPTION
## Summary
- implement a `#showsource` directive
- save module source when loading modules
- expose highlighted source from `#showsource`
- test parsing and rendering of `#showsource`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685337f69a34832f8f106700975d60b3