### PR TITLE
Expand highlight test range

### DIFF
--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -59,6 +59,7 @@ def _highlight_pageql_expr(text: str) -> str:
     i = 0
     out: list[str] = []
     next_as_var = False
+    skip_next_type = False
     while i < len(text):
         ch = text[i]
         if ch.isspace():
@@ -113,7 +114,19 @@ def _highlight_pageql_expr(text: str) -> str:
                 color = _SQL_COLOR
             else:
                 color = _TYPENAME_COLOR
-            out.append(_span(escape(word), color))
+            if color is _TYPENAME_COLOR and skip_next_type:
+                out.append(escape(word))
+                skip_next_type = False
+            else:
+                out.append(_span(escape(word), color))
+            if color is _SQL_COLOR and word_lower in {
+                "from",
+                "into",
+                "update",
+                "delete",
+                "table",
+            }:
+                skip_next_type = True
             i = j
             continue
         out.append(escape(ch))

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -28,7 +28,7 @@ def test_highlight_roundtrip():
     duration = time.perf_counter() - start
     assert duration < 0.01
 
-    assert rehighlighted[:600] == snippet[:600]
+    assert rehighlighted[:700] == snippet[:700]
 
 
 def test_highlight_block_wraps_highlight():


### PR DESCRIPTION
## Summary
- allow table names to remain uncoloured when following SQL keywords
- verify first 700 characters of rehighlighted snippet

## Testing
- `pytest tests/test_highlighter.py::test_highlight_roundtrip -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b4ee0ddc832fbb4342e73dc8fb3f