### PR TITLE
Add showsource directive to infinite scroll example

### DIFF
--- a/website/infinite_scroll.pageql
+++ b/website/infinite_scroll.pageql
@@ -1,3 +1,5 @@
+{{#showsource}}
+
 {{#partial numbers/:f}}
 {{#param f type=integer}}
 {{#if :f < 1000}}


### PR DESCRIPTION
## Summary
- show source code for `infinite_scroll.pageql`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853c9340b08832fa42ecb8c37ec5c4b