### PR TITLE
Fix infinite_scroll long lines

### DIFF
--- a/tests/test_infinite_scroll.py
+++ b/tests/test_infinite_scroll.py
@@ -1,0 +1,16 @@
+import sys, types
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pathlib import Path
+from pageql.pageql import PageQL
+
+
+def test_infinite_scroll_initial_numbers():
+    src = Path("website/infinite_scroll.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("infinite_scroll", src)
+    result = r.render("/infinite_scroll", reactive=False)
+    assert "/infinite_scroll/numbers/200" in result.body
+    assert result.body.count("<br>") == 100

--- a/website/infinite_scroll.pageql
+++ b/website/infinite_scroll.pageql
@@ -3,11 +3,21 @@
 {{#partial numbers/:f}}
 {{#param f type=integer}}
 {{#if :f < 1000}}
-<span hx-get="/infinite_scroll/numbers/{{:f+100}}" hx-trigger="revealed" hx-swap="beforeend" hx-target="#list">
-  {{#from (WITH RECURSIVE numbers AS (Select 1 as n UNION ALL SELECT n+1 FROM numbers WHERE n < 1000) SELECT n FROM numbers) limit :f,100}}
+<span
+  hx-get="/infinite_scroll/numbers/{{:f+100}}"
+  hx-trigger="revealed"
+  hx-swap="beforeend"
+  hx-target="#list"
+>
+  {{#from (
+    WITH RECURSIVE numbers AS (
+      Select 1 as n
+      UNION ALL SELECT n+1 FROM numbers WHERE n < 1000
+    ) SELECT n FROM numbers
+  ) limit :f,100}}
     {{n}}<br>
   {{/from}}
-  </span>
+</span>
 {{/if}}
 {{/partial}}
 


### PR DESCRIPTION
## Summary
- split long lines in `infinite_scroll.pageql`
- ensure infinite scroll works with a new test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853cb446820832fb926809744037ce4