### PR TITLE
Add Hypothesis stateful test for reactive components

### DIFF
--- a/tests/test_reactive_stateful.py
+++ b/tests/test_reactive_stateful.py
@@ -1,0 +1,107 @@
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from hypothesis.stateful import RuleBasedStateMachine, rule, run_state_machine_as_test
+from hypothesis import strategies as st, assume
+
+# Ensure import path and stub watchfiles
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+
+from pageql.reactive import (
+    ReactiveTable,
+    Where,
+    Select,
+    CountAll,
+    UnionAll,
+    Union,
+    Intersect,
+)
+from pageql.join import Join
+
+
+class ReactiveStateMachine(RuleBasedStateMachine):
+    def __init__(self):
+        super().__init__()
+        self.conn = sqlite3.connect(":memory:")
+        self.conn_expected = sqlite3.connect(":memory:")
+        for c in (self.conn, self.conn_expected):
+            c.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+            c.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, name TEXT)")
+            c.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, name TEXT)")
+
+        # Reactive tables
+        self.rt_items = ReactiveTable(self.conn, "items")
+        self.rt_a = ReactiveTable(self.conn, "a")
+        self.rt_b = ReactiveTable(self.conn, "b")
+
+        # Derived components
+        self.where_items = Where(self.rt_items, "name LIKE 'x%'")
+        self.select_items = Select(self.rt_items, "name")
+        self.count_items = CountAll(self.rt_items)
+        self.union_all = UnionAll(self.rt_a, self.rt_b)
+        self.union = Union(self.rt_a, self.rt_b)
+        self.intersect = Intersect(self.rt_a, self.rt_b)
+        self.join_ab = Join(self.rt_a, self.rt_b, "a.name = b.name")
+
+        self.components = [
+            self.rt_items,
+            self.where_items,
+            self.select_items,
+            self.count_items,
+            self.union_all,
+            self.union,
+            self.intersect,
+            self.join_ab,
+        ]
+
+        self.next_id = {"items": 1, "a": 1, "b": 1}
+        self.ids = {"items": set(), "a": set(), "b": set()}
+
+    def _rt(self, table):
+        return {
+            "items": self.rt_items,
+            "a": self.rt_a,
+            "b": self.rt_b,
+        }[table]
+
+    def _assert_components(self):
+        for comp in self.components:
+            res = sorted(self.conn.execute(comp.sql).fetchall())
+            exp = sorted(self.conn_expected.execute(comp.sql).fetchall())
+            assert res == exp
+
+    @rule(table=st.sampled_from(["items", "a", "b"]), name=st.sampled_from(["x", "y", "z"]))
+    def insert_row(self, table, name):
+        rid = self.next_id[table]
+        self.next_id[table] += 1
+        self.conn_expected.execute(f"INSERT INTO {table}(id, name) VALUES (?, ?)", (rid, name))
+        rt = self._rt(table)
+        rt.insert(f"INSERT INTO {table}(id, name) VALUES (:id, :name)", {"id": rid, "name": name})
+        self.ids[table].add(rid)
+        self._assert_components()
+
+    @rule(table=st.sampled_from(["items", "a", "b"]), name=st.sampled_from(["x", "y", "z"]))
+    def update_row(self, table, name):
+        assume(self.ids[table])
+        rid = next(iter(self.ids[table]))
+        self.conn_expected.execute(f"UPDATE {table} SET name=? WHERE id=?", (name, rid))
+        rt = self._rt(table)
+        rt.update(f"UPDATE {table} SET name=:name WHERE id=:id", {"name": name, "id": rid})
+        self._assert_components()
+
+    @rule(table=st.sampled_from(["items", "a", "b"]))
+    def delete_row(self, table):
+        assume(self.ids[table])
+        rid = next(iter(self.ids[table]))
+        self.conn_expected.execute(f"DELETE FROM {table} WHERE id=?", (rid,))
+        rt = self._rt(table)
+        rt.delete(f"DELETE FROM {table} WHERE id=:id", {"id": rid})
+        self.ids[table].remove(rid)
+        self._assert_components()
+
+
+def test_reactive_state_machine():
+    run_state_machine_as_test(ReactiveStateMachine)


### PR DESCRIPTION
## Summary
- add stateful Hypothesis test generating sequences of insert, update and delete operations on reactive components
- compare SQL results from reactive DB to a mirror DB after each operation to ensure consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853371ecfe8832fbd5676bf03aaa722