### PR TITLE
Relax highlighter speed test

### DIFF
--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -19,6 +19,11 @@ def _remove_color_spans(html_text: str) -> str:
 
 
 def test_highlight_roundtrip():
+    """Verify highlight() output and that it runs reasonably fast.
+
+    The duration limit is a heuristic intended to catch extreme slowdowns
+    rather than an exact performance benchmark.
+    """
     page = Path("website/todos.pageql").read_text()
     snippet = _extract_snippet(page)
     plain = _remove_color_spans(snippet)
@@ -26,7 +31,9 @@ def test_highlight_roundtrip():
     start = time.perf_counter()
     rehighlighted = highlight(plain)
     duration = time.perf_counter() - start
-    assert duration < 0.01
+    # Allow a small buffer because this check is only to detect drastic
+    # regressions in performance.
+    assert duration < 0.05
 
     assert rehighlighted[:700] == snippet[:700]
 


### PR DESCRIPTION
## Summary
- relax the highlighter timing threshold in `test_highlighter.py`
- clarify via docstring that the check is a heuristic for slowdowns

## Testing
- `pytest tests/test_highlighter.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e8e16a68832faa0f3cc5f43c4353