### PR TITLE
Fix closing HTML tag highlighting

### DIFF
--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -151,7 +151,7 @@ def _highlight_html_tag(tag: str) -> str:
     out = [f'<span style="color: {_HTML_BRACKET}">&lt;']
     i = 1
     if tag.startswith('</'):
-        out.append('</span><span style="color: {_HTML_BRACKET}">/</span>')
+        out.append(f'</span><span style="color: {_HTML_BRACKET}">/</span>')
         i = 2
     m = re.match(r'([a-zA-Z0-9_-]+)', tag[i:])
     if m:

--- a/tests/test_highlighter.py
+++ b/tests/test_highlighter.py
@@ -43,3 +43,8 @@ def test_highlight_block_wraps_highlight():
     assert '<div class="highlight"' in block
     assert highlight(plain) in block
     assert block.rstrip().endswith('</pre></div></div></div>')
+
+
+def test_highlight_closing_tag_slash():
+    result = highlight("</h1>")
+    assert '<span style="color: #808080;">/</span>' in result


### PR DESCRIPTION
## Summary
- fix missing `f` prefix in `_highlight_html_tag`
- test highlighting of closing tags

## Testing
- `PYTHONPATH=src pytest tests/test_highlighter.py::test_highlight_closing_tag_slash -vv`
- `PYTHONPATH=src pytest tests/test_highlighter.py -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853e8ee1748832f90a01f4d79d58624