### PR TITLE
Add Facebook OAuth example

### DIFF
--- a/tests/test_facebookauth_page.py
+++ b/tests/test_facebookauth_page.py
@@ -1,0 +1,96 @@
+import asyncio
+from pathlib import Path
+import tempfile
+
+from pageql.http_utils import _http_get
+from pageql import jws_serialize_compact, jws_deserialize_compact
+from playwright_helpers import run_server_in_task
+import json
+import re
+
+
+def test_facebookauth_page_renders_button(monkeypatch):
+    src = Path("website/facebookauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "facebookauth.pageql").write_text(src, encoding="utf-8")
+        monkeypatch.setenv("FACEBOOK_CLIENT_ID", "123456789")
+
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            status, _headers, body = await _http_get(f"http://127.0.0.1:{port}/facebookauth")
+            server.should_exit = True
+            await task
+            return status, body.decode()
+
+        status, body = asyncio.run(run_test())
+
+        assert status == 200
+        assert "facebook.com" in body
+        assert "123456789" in body
+
+        m = re.search(r"state=([^\"]+)", body)
+        assert m is not None
+        token = m.group(1)
+        data = json.loads(jws_deserialize_compact(token).decode())
+        assert data["ongoing"] == 1
+        assert data["path"] == "/facebookauth"
+
+
+def test_facebookauth_callback_fetch(monkeypatch):
+    src = Path("website/facebookauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "facebookauth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            from pageql import pageql as pql_mod
+            seen = []
+
+            async def fake_fetch(url: str, headers=None, method="GET", body=None, **kwargs):
+                seen.append((url, headers, method))
+                if "graph.facebook.com/me" in url:
+                    return {
+                        "status_code": 200,
+                        "headers": [],
+                        "body": '{"name": "fuser"}',
+                    }
+                return {
+                    "status_code": 200,
+                    "headers": [],
+                    "body": 'access_token=t&token_type=bearer&scope=',
+                }
+
+            old_fetch = pql_mod.fetch
+            pql_mod.fetch = fake_fetch
+            monkeypatch.setenv("FACEBOOK_CLIENT_SECRET", "secret")
+            monkeypatch.setenv("FACEBOOK_CLIENT_ID", "123456789")
+            try:
+                server, task, port = await run_server_in_task(tmpdir)
+                state = jws_serialize_compact('{"ongoing":1,"path":"/facebookauth"}')
+                status, _headers, body = await _http_get(
+                    f"http://127.0.0.1:{port}/facebookauth/callback?code=abc&state={state}"
+                )
+                server.should_exit = True
+                await task
+            finally:
+                pql_mod.fetch = old_fetch
+            return status, body.decode(), seen, state
+
+        status, body, urls, state = asyncio.run(run_test())
+
+        assert status == 200
+        assert "Loading token" in body
+        assert "access_token" not in body
+        assert "fuser" not in body
+        (token_url, token_headers, token_method), (user_url, user_headers, user_method) = urls
+        assert token_url.startswith("https://graph.facebook.com")
+        assert "123456789" in token_url
+        assert "client_secret=secret" in token_url
+        assert "code=abc" in token_url
+        assert f"state={state}" in token_url
+        assert user_url == "https://graph.facebook.com/me"
+        assert user_headers == {
+            "Authorization": "Bearer t",
+            "User-Agent": "PageQL",
+        }
+        assert token_method == "GET"
+        assert user_method == "GET"

--- a/website/facebookauth.pageql
+++ b/website/facebookauth.pageql
@@ -1,0 +1,38 @@
+{{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
+{{#let state jws_serialize_compact(:payload)}}
+{{#let client_id = env.FACEBOOK_CLIENT_ID}}
+<a href="https://www.facebook.com/v18.0/dialog/oauth?client_id={{client_id}}&state={{state}}">
+  <button>Login with Facebook</button>
+</a>
+
+
+{{#partial GET callback}}
+  {{#param code required}}
+  {{#param state required}}
+  {{#let payload jws_deserialize_compact(:state)}}
+  {{#let payload_path = json_extract(:payload, '$.path')}}
+  <p>Payload: {{:payload}}</p>
+  <p>Payload path: {{:payload_path}}</p>
+  {{#let client_id = env.FACEBOOK_CLIENT_ID}}
+
+  {{#let client_secret = env.FACEBOOK_CLIENT_SECRET}}
+  {{#fetch async token from 'https://graph.facebook.com/v18.0/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&state='||:state}}
+    {{#if :token.status_code == 200}}
+      {{#let access_token = query_param(:token.body, 'access_token')}}
+      <p>Extracted access token: {{access_token}}</p>
+      {{#let header = 'Authorization: Bearer '||:access_token}}
+      {{#let user_agent_header = 'User-Agent: PageQL'}}
+      {{#fetch async user from 'https://graph.facebook.com/me' header=:header header=:user_agent_header}}
+        {{#if :user.status_code == 200}}
+          {{user.body}}
+        {{#elif :user.status_code IS NOT NULL}}
+          <p>Error: {{:user.status_code}} {{:user.body}}</p>
+        {{#else}}
+          <p>Loading user...</p>
+        {{/if}}
+      {{/fetch}}
+    {{#else}}
+      <p>Loading token...</p>
+    {{/if}}
+  {{/fetch}}
+{{/partial}}


### PR DESCRIPTION
## Summary
- add `facebookauth.pageql` for Facebook OAuth login
- test facebook OAuth page similar to GitHub OAuth example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853ed0c90dc832f9f6cf1768e2bec0a