### PR TITLE
Add Gmail OAuth example

### DIFF
--- a/tests/test_gmailauth_page.py
+++ b/tests/test_gmailauth_page.py
@@ -1,0 +1,95 @@
+import asyncio
+from pathlib import Path
+import tempfile
+
+from pageql.http_utils import _http_get
+from pageql import jws_serialize_compact, jws_deserialize_compact
+from playwright_helpers import run_server_in_task
+import json
+import re
+
+
+def test_gmailauth_page_renders_button(monkeypatch):
+    src = Path("website/gmailauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "gmailauth.pageql").write_text(src, encoding="utf-8")
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "123456789.apps.googleusercontent.com")
+
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            status, _headers, body = await _http_get(f"http://127.0.0.1:{port}/gmailauth")
+            server.should_exit = True
+            await task
+            return status, body.decode()
+
+        status, body = asyncio.run(run_test())
+
+        assert status == 200
+        assert "accounts.google.com/o/oauth2/v2/auth" in body
+        assert "123456789.apps.googleusercontent.com" in body
+
+        m = re.search(r"state=([^\"]+)", body)
+        assert m is not None
+        token = m.group(1)
+        data = json.loads(jws_deserialize_compact(token).decode())
+        assert data["ongoing"] == 1
+        assert data["path"] == "/gmailauth"
+
+
+def test_gmailauth_callback_fetch(monkeypatch):
+    src = Path("website/gmailauth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "gmailauth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            from pageql import pageql as pql_mod
+            seen = []
+
+            async def fake_fetch(url: str, headers=None, method="GET", body=None, **kwargs):
+                seen.append((url, headers, method))
+                if "www.googleapis.com/oauth2/v3/userinfo" in url:
+                    return {
+                        "status_code": 200,
+                        "headers": [],
+                        "body": '{"email": "octo@example.com"}',
+                    }
+                return {
+                    "status_code": 200,
+                    "headers": [],
+                    "body": 'access_token=t&token_type=bearer&scope=',
+                }
+
+            old_fetch = pql_mod.fetch
+            pql_mod.fetch = fake_fetch
+            monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
+            monkeypatch.setenv("GOOGLE_CLIENT_ID", "123456789.apps.googleusercontent.com")
+            try:
+                server, task, port = await run_server_in_task(tmpdir)
+                state = jws_serialize_compact('{"ongoing":1,"path":"/gmailauth"}')
+                status, _headers, body = await _http_get(
+                    f"http://127.0.0.1:{port}/gmailauth/callback?code=abc&state={state}"
+                )
+                server.should_exit = True
+                await task
+            finally:
+                pql_mod.fetch = old_fetch
+            return status, body.decode(), seen, state
+
+        status, body, urls, state = asyncio.run(run_test())
+
+        assert status == 200
+        assert "Loading token" in body
+        assert "access_token" not in body
+        assert "octo@example.com" not in body
+        (token_url, token_headers, token_method), (user_url, user_headers, user_method) = urls
+        assert token_url.startswith("https://oauth2.googleapis.com/token")
+        assert "123456789.apps.googleusercontent.com" in token_url
+        assert "client_secret=secret" in token_url
+        assert "code=abc" in token_url
+        assert f"state={state}" in token_url
+        assert user_url == "https://www.googleapis.com/oauth2/v3/userinfo"
+        assert user_headers == {
+            "Authorization": "Bearer t",
+        }
+        assert token_method == "GET"
+        assert user_method == "GET"

--- a/website/gmailauth.pageql
+++ b/website/gmailauth.pageql
@@ -1,0 +1,36 @@
+{{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
+{{#let state jws_serialize_compact(:payload)}}
+{{#let client_id = env.GOOGLE_CLIENT_ID}}
+<a href="https://accounts.google.com/o/oauth2/v2/auth?client_id={{client_id}}&response_type=code&scope=openid%20email%20profile&state={{state}}">
+  <button>Login with Gmail</button>
+</a>
+
+{{#partial GET callback}}
+  {{#param code required}}
+  {{#param state required}}
+  {{#let payload jws_deserialize_compact(:state)}}
+  {{#let payload_path = json_extract(:payload, '$.path')}}
+  <p>Payload: {{:payload}}</p>
+  <p>Payload path: {{:payload_path}}</p>
+  {{#let client_id = env.GOOGLE_CLIENT_ID}}
+
+  {{#let client_secret = env.GOOGLE_CLIENT_SECRET}}
+  {{#fetch async token from 'https://oauth2.googleapis.com/token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&grant_type=authorization_code&state='||:state}}
+    {{#if :token.status_code == 200}}
+      {{#let access_token = query_param(:token.body, 'access_token')}}
+      <p>Extracted access token: {{access_token}}</p>
+      {{#let header = 'Authorization: Bearer '||:access_token}}
+      {{#fetch async user from 'https://www.googleapis.com/oauth2/v3/userinfo' header=:header}}
+        {{#if :user.status_code == 200}}
+          {{user.body}}
+        {{#elif :user.status_code IS NOT NULL}}
+          <p>Error: {{:user.status_code}} {{:user.body}}</p>
+        {{#else}}
+          <p>Loading user...</p>
+        {{/if}}
+      {{/fetch}}
+    {{#else}}
+      <p>Loading token...</p>
+    {{/if}}
+  {{/fetch}}
+{{/partial}}


### PR DESCRIPTION
## Summary
- create a new `gmailauth.pageql` page showing Gmail OAuth flow
- add matching unit tests

## Testing
- `PYTHONPATH=src pytest tests/test_gmailauth_page.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853ed078de8832f99b59185e9cb0075