### PR TITLE
Add redirect_uri parameter for Facebook auth

### DIFF
--- a/tests/test_facebookauth_page.py
+++ b/tests/test_facebookauth_page.py
@@ -27,6 +27,7 @@ def test_facebookauth_page_renders_button(monkeypatch):
         assert status == 200
         assert "facebook.com" in body
         assert "123456789" in body
+        assert "redirect_uri=http://127.0.0.1/facebookauth/callback" in body
 
         m = re.search(r"state=([^\"]+)", body)
         assert m is not None
@@ -87,6 +88,7 @@ def test_facebookauth_callback_fetch(monkeypatch):
         assert "client_secret=secret" in token_url
         assert "code=abc" in token_url
         assert f"state={state}" in token_url
+        assert "redirect_uri=http://127.0.0.1/facebookauth/callback" in token_url
         assert user_url == "https://graph.facebook.com/me"
         assert user_headers == {
             "Authorization": "Bearer t",

--- a/website/facebookauth.pageql
+++ b/website/facebookauth.pageql
@@ -1,7 +1,8 @@
 {{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
 {{#let state jws_serialize_compact(:payload)}}
 {{#let client_id = env.FACEBOOK_CLIENT_ID}}
-<a href="https://www.facebook.com/v18.0/dialog/oauth?client_id={{client_id}}&state={{state}}">
+{{#let redirect_uri = 'http://'||:headers.host||replace(:path, '"', '')||'/callback'}}
+<a href="https://www.facebook.com/v18.0/dialog/oauth?client_id={{client_id}}&redirect_uri={{redirect_uri}}&state={{state}}">
   <button>Login with Facebook</button>
 </a>
 
@@ -15,8 +16,10 @@
   <p>Payload path: {{:payload_path}}</p>
   {{#let client_id = env.FACEBOOK_CLIENT_ID}}
 
+  {{#let redirect_uri = 'http://'||:headers.host||replace(:payload_path, '"', '')||'/callback'}}
+
   {{#let client_secret = env.FACEBOOK_CLIENT_SECRET}}
-  {{#fetch async token from 'https://graph.facebook.com/v18.0/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&state='||:state}}
+  {{#fetch async token from 'https://graph.facebook.com/v18.0/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&state='||:state}}
     {{#if :token.status_code == 200}}
       {{#let access_token = query_param(:token.body, 'access_token')}}
       <p>Extracted access token: {{access_token}}</p>


### PR DESCRIPTION
## Summary
- add redirect_uri to Facebook OAuth example
- trim path values to avoid quoting
- assert redirect_uri in Facebook auth tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68541fb98cd0832f96d480455a46c405