### PR TITLE
Fix redirect URI in Google auth flow

### DIFF
--- a/tests/test_googleauth_page.py
+++ b/tests/test_googleauth_page.py
@@ -27,6 +27,7 @@ def test_googleauth_page_renders_button(monkeypatch):
         assert status == 200
         assert "accounts.google.com/o/oauth2/v2/auth" in body
         assert "123456789.apps.googleusercontent.com" in body
+        assert "redirect_uri=http://127.0.0.1/googleauth/callback" in body
 
         m = re.search(r"state=([^\"]+)", body)
         assert m is not None
@@ -86,6 +87,7 @@ def test_googleauth_callback_fetch(monkeypatch):
         assert "123456789.apps.googleusercontent.com" in token_url
         assert "client_secret=secret" in token_url
         assert "code=abc" in token_url
+        assert "redirect_uri=http://127.0.0.1/googleauth/callback" in token_url
         assert f"state={state}" in token_url
         assert user_url == "https://www.googleapis.com/oauth2/v3/userinfo"
         assert user_headers == {

--- a/website/googleauth.pageql
+++ b/website/googleauth.pageql
@@ -1,7 +1,8 @@
 {{#let payload json_set('{}', '$.ongoing', 1, '$.path', :path)}}
 {{#let state jws_serialize_compact(:payload)}}
 {{#let client_id = env.GOOGLE_CLIENT_ID}}
-<a href="https://accounts.google.com/o/oauth2/v2/auth?client_id={{client_id}}&response_type=code&scope=openid%20email%20profile&state={{state}}">
+{{#let redirect_uri = 'http://'||:headers.host||replace(:path, '"', '')||'/callback'}}
+<a href="https://accounts.google.com/o/oauth2/v2/auth?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type=code&scope=openid%20email%20profile&state={{state}}">
   <button>Login with Gmail</button>
 </a>
 
@@ -14,8 +15,10 @@
   <p>Payload path: {{:payload_path}}</p>
   {{#let client_id = env.GOOGLE_CLIENT_ID}}
 
+  {{#let redirect_uri = 'http://'||:headers.host||replace(:payload_path, '"', '')||'/callback'}}
+
   {{#let client_secret = env.GOOGLE_CLIENT_SECRET}}
-  {{#fetch async token from 'https://oauth2.googleapis.com/token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&grant_type=authorization_code&state='||:state}}
+  {{#fetch async token from 'https://oauth2.googleapis.com/token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&grant_type=authorization_code&state='||:state}}
     {{#if :token.status_code == 200}}
       {{#let access_token = query_param(:token.body, 'access_token')}}
       <p>Extracted access token: {{access_token}}</p>


### PR DESCRIPTION
## Summary
- include `redirect_uri` in `googleauth.pageql`
- verify redirect URI in Google auth tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68543d2fc494832fbdb67329d079a3c7