### PR TITLE
Fix Google OAuth token request

### DIFF
--- a/website/googleauth.pageql
+++ b/website/googleauth.pageql
@@ -18,7 +18,10 @@
   {{#let redirect_uri = 'https://'||:headers.host||replace(:payload_path, '"', '')||'/callback'}}
 
   {{#let client_secret = env.GOOGLE_CLIENT_SECRET}}
-  {{#fetch async token from 'https://oauth2.googleapis.com/token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&grant_type=authorization_code&state='||:state}}
+  {{#let token_url = 'https://oauth2.googleapis.com/token'}}
+  {{#let token_body = 'client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&grant_type=authorization_code&state='||:state}}
+  {{#let token_hdr = 'Content-Type: application/x-www-form-urlencoded'}}
+  {{#fetch async token from :token_url method='POST' header=:token_hdr body=:token_body}}
     {{#if :token.status_code == 200}}
       {{#let access_token = query_param(:token.body, 'access_token')}}
       <p>Extracted access token: {{access_token}}</p>


### PR DESCRIPTION
## Summary
- adjust Google OAuth callback to POST to the token endpoint
- update Google authentication tests for POST request

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854979e90e8832fa4d8b6a69a8d8417