### PR TITLE
Use POST when fetching Facebook token

### DIFF
--- a/tests/test_facebookauth_page.py
+++ b/tests/test_facebookauth_page.py
@@ -83,16 +83,14 @@ def test_facebookauth_callback_fetch(monkeypatch):
         assert "access_token" not in body
         assert "fuser" not in body
         (token_url, token_headers, token_method), (user_url, user_headers, user_method) = urls
-        assert token_url.startswith("https://graph.facebook.com")
-        assert "123456789" in token_url
-        assert "client_secret=secret" in token_url
-        assert "code=abc" in token_url
-        assert f"state={state}" in token_url
-        assert "redirect_uri=http://127.0.0.1/facebookauth/callback" in token_url
+        assert token_url == "https://graph.facebook.com/v18.0/oauth/access_token"
+        assert token_headers == {
+            "Content-Type": "application/x-www-form-urlencoded"
+        }
         assert user_url == "https://graph.facebook.com/me"
         assert user_headers == {
             "Authorization": "Bearer t",
             "User-Agent": "PageQL",
         }
-        assert token_method == "GET"
+        assert token_method == "POST"
         assert user_method == "GET"

--- a/website/facebookauth.pageql
+++ b/website/facebookauth.pageql
@@ -19,7 +19,9 @@
   {{#let redirect_uri = 'http://'||:headers.host||replace(:payload_path, '"', '')||'/callback'}}
 
   {{#let client_secret = env.FACEBOOK_CLIENT_SECRET}}
-  {{#fetch async token from 'https://graph.facebook.com/v18.0/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&state='||:state}}
+  {{#let body = 'client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&redirect_uri='||:redirect_uri||'&state='||:state}}
+  {{#let ct_header = 'Content-Type: application/x-www-form-urlencoded'}}
+  {{#fetch async token from 'https://graph.facebook.com/v18.0/oauth/access_token' method='POST' body=:body header=:ct_header}}
     {{#if :token.status_code == 200}}
       {{#let access_token = query_param(:token.body, 'access_token')}}
       <p>Extracted access token: {{access_token}}</p>


### PR DESCRIPTION
## Summary
- switch Facebook OAuth token fetch to POST
- verify POST usage and headers in Facebook auth tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685498e7a534832f9b67de01c8a3a811