### PR TITLE
Add GDPR privacy page

### DIFF
--- a/tests/test_privacy_policy_page.py
+++ b/tests/test_privacy_policy_page.py
@@ -1,0 +1,20 @@
+import asyncio
+from pathlib import Path
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_privacy_policy_html_served(tmp_path):
+    html = Path(tmp_path) / "privacy_policy.html"
+    html.write_text("<h1>Policy</h1>", encoding="utf-8")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, body_bytes = await _http_get(f"http://127.0.0.1:{port}/privacy_policy.html")
+        server.should_exit = True
+        await task
+        return status, body_bytes.decode()
+
+    status, body = asyncio.run(run_test())
+    assert status == 200
+    assert "<h1>Policy</h1>" in body

--- a/website/index.html
+++ b/website/index.html
@@ -509,6 +509,9 @@ pageql data.db templates --create</code></pre>
   </div>
 
     </main>
+    <footer style="text-align: center; padding: 1rem 0;">
+      <a href="privacy_policy.html" style="color: var(--text-muted);">Privacy Policy</a>
+    </footer>
   </div>
   <script>
     function copyTerminalCode(button) {

--- a/website/privacy_policy.html
+++ b/website/privacy_policy.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-gradient-start: #1a2233;
+      --bg-gradient-end:   #2d3748;
+      --card-bg:  #2a2e3a;
+      --text:     #e2e2e2;
+      --text-muted: #b0b8c4;
+      --primary:  #be5028;
+      --border-subtle: #3a4259;
+    }
+    * { box-sizing: border-box; font-family: 'Inter', sans-serif; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+      color: var(--text);
+      line-height: 1.6;
+      padding: 2rem;
+    }
+    h1 { text-align: center; color: var(--primary); }
+    .card {
+      background: var(--card-bg);
+      border-radius: 12px;
+      padding: 2rem;
+      max-width: 800px;
+      margin: 0 auto;
+      border: 1px solid var(--border-subtle);
+    }
+    a { color: var(--primary); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Privacy Policy</h1>
+    <p>This demo application stores data you enter only for testing purposes. The data is not used for marketing or shared with third parties.</p>
+    <p>Cookies may be used to maintain session information. Server logs may record IP addresses for security and debugging.</p>
+    <p>You may request removal of your data at any time by contacting the PageQL maintainers.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple privacy policy HTML page
- link to policy page from index
- test that privacy page is served

## Testing
- `pytest tests/test_privacy_policy_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68559bc28bbc832fbb490ca30d816898