### PR TITLE
Add static html flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ pageql ./templates path/to/your/database.sqlite
 *   `-q, --quiet`: (Optional) Only output errors when running the server.
 *   `--fallback-url <url>`: (Optional) Forward unknown routes to this base URL.
 *   `--no-csrf`: (Optional) Disable CSRF protection. Useful for local testing but not recommended in production.
+*   `--static-html`: (Optional) Serve HTML files without injecting the client script.
 *   `--test`: (Optional) Run template tests and exit instead of serving.
 *   `--http-disconnect-cleanup-timeout <seconds>`: (Optional) Delay before cleaning up HTTP disconnect contexts.
 *   `--profile`: (Optional) Profile the server using `cProfile` and print statistics when it stops.

--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -60,6 +60,7 @@ def main():
     parser.add_argument('-q', '--quiet', action='store_true', help="Only show errors in output.")
     parser.add_argument('--fallback-url', help="Forward unknown routes to this base URL")
     parser.add_argument('--no-csrf', action='store_true', help="Disable CSRF protection")
+    parser.add_argument('--static-html', action='store_true', help="Don't send client script for HTML files")
     parser.add_argument('--test', action='store_true', help="Run tests instead of serving")
     parser.add_argument(
         '--profile',
@@ -99,6 +100,7 @@ def main():
         "fallback_url": args.fallback_url,
         "csrf_protect": not args.no_csrf,
         "http_disconnect_cleanup_timeout": args.http_disconnect_cleanup_timeout,
+        "static_html": args.static_html,
     }
     app = PageQLApp(args.db_file, args.templates_dir, **kwargs)
     app.log_level = args.log_level

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -150,6 +150,7 @@ class PageQLApp:
         fallback_url: Optional[str] = None,
         csrf_protect: bool = True,
         http_disconnect_cleanup_timeout: float = 10.0,
+        static_html: bool = False,
     ):
         self.stop_event = None
         self.notifies = []
@@ -170,6 +171,7 @@ class PageQLApp:
         self.fallback_url = fallback_url
         self.csrf_protect = csrf_protect
         self.http_disconnect_cleanup_timeout = http_disconnect_cleanup_timeout
+        self.static_html = static_html
         self.load_builtin_static()
         self.prepare_server(db_path, template_dir, create_db)
 
@@ -260,7 +262,7 @@ class PageQLApp:
         if content_type == 'text/html':
             content_type = 'text/html; charset=utf-8'
             body = self.static_files[path_cleaned]
-            if include_scripts:
+            if include_scripts and not self.static_html:
                 body = client_script(client_id).encode('utf-8') + body
         else:
             body = self.static_files[path_cleaned]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ def test_cli_fallback_url(monkeypatch, tmp_path):
             fallback_url=None,
             csrf_protect=True,
             http_disconnect_cleanup_timeout=10.0,
+            static_html=False,
         ):
             created["db"] = db_file
             created["tpl"] = templates_dir
@@ -72,6 +73,7 @@ def test_cli_http_disconnect_timeout(monkeypatch, tmp_path):
             fallback_url=None,
             csrf_protect=True,
             http_disconnect_cleanup_timeout=10.0,
+            static_html=False,
         ):
             created["timeout"] = http_disconnect_cleanup_timeout
 
@@ -88,5 +90,38 @@ def test_cli_http_disconnect_timeout(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", argv)
     cli.main()
     assert created["timeout"] == 0.5
+
+
+def test_cli_static_html(monkeypatch, tmp_path):
+    created = {}
+
+    class DummyApp:
+        def __init__(
+            self,
+            db_file,
+            templates_dir,
+            create_db=False,
+            should_reload=True,
+            quiet=False,
+            fallback_app=None,
+            fallback_url=None,
+            csrf_protect=True,
+            http_disconnect_cleanup_timeout=10.0,
+            static_html=False,
+        ):
+            created["static_html"] = static_html
+
+    monkeypatch.setattr(cli, "PageQLApp", DummyApp)
+    monkeypatch.setattr(cli.uvicorn, "run", lambda *a, **kw: None)
+
+    argv = [
+        "pageql",
+        str(tmp_path),
+        "db",
+        "--static-html",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert created["static_html"] is True
 
 

--- a/tests/test_htmx_headers.py
+++ b/tests/test_htmx_headers.py
@@ -62,3 +62,41 @@ def test_htmx_request_omits_js_headers():
             assert "reload-request-ws" not in body
 
     asyncio.run(run())
+
+
+def test_static_html_flag_disables_client_script():
+    async def run():
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "index.html").write_text("<h1>Home</h1>", encoding="utf-8")
+            app = PageQLApp(":memory:", tmpdir, create_db=True, should_reload=False)
+
+            sent = []
+
+            async def send(msg):
+                sent.append(msg)
+
+            async def receive():
+                return {"type": "http.request"}
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/index.html",
+                "headers": [],
+                "query_string": b"",
+            }
+
+            await app.pageql_handler(scope, receive, send)
+
+            body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body").decode()
+            assert "/htmx.min.js" in body
+
+            sent.clear()
+            app.static_html = True
+            await app.pageql_handler(scope, receive, send)
+
+            body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body").decode()
+            assert "/htmx.min.js" not in body
+            assert "reload-request-ws" not in body
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add `--static-html` CLI option
- handle flag in `PageQLApp` and `cli`
- document flag in README
- test CLI argument and serving static html without the client script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68559b8fef64832fbb154fa19066edc1