### PR TITLE
Add demo GDPR terms

### DIFF
--- a/website/gdpr_terms.html
+++ b/website/gdpr_terms.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GDPR Terms &amp; Conditions</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background: #1a2233;
+      color: #e2e2e2;
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      padding: 2rem;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 800px;
+      margin: auto;
+      background: #2a2e3a;
+      padding: 2rem;
+      border-radius: 8px;
+    }
+    h1 { margin-top: 0; }
+    a { color: #be5028; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>GDPR Terms and Conditions</h1>
+    <p>This demo application showcases the PageQL web framework. It stores data only for testing purposes.</p>
+    <p><strong>Data Collected:</strong> Any information you enter while testing (such as usernames or todos) is stored in a local database. No analytics or tracking cookies are used.</p>
+    <p><strong>Purpose of Processing:</strong> The data enables the interactive examples to function. It is not used for marketing or shared with third parties.</p>
+    <p><strong>Retention:</strong> Data may be cleared at any time by resetting the demo database. Because this site is intended for experimentation, do not enter real personal data.</p>
+    <p><strong>Your Rights:</strong> You may request deletion or a copy of the data you entered by contacting the maintainer of this repository.</p>
+    <p>This page exists solely for demonstration and does not constitute legal advice.</p>
+    <p><a href="index.html">Back to Home</a></p>
+  </div>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -227,6 +227,11 @@
     .feature-text p {
       margin: 0;
     }
+    footer {
+      margin-top: 2rem;
+      text-align: center;
+      font-size: 0.9rem;
+    }
     @media (max-width: 768px) {
       .two-columns {
         grid-template-columns: 1fr;
@@ -509,6 +514,9 @@ pageql data.db templates --create</code></pre>
   </div>
 
     </main>
+    <footer>
+      <a href="gdpr_terms.html" style="color: var(--text);">GDPR Terms &amp; Conditions</a>
+    </footer>
   </div>
   <script>
     function copyTerminalCode(button) {


### PR DESCRIPTION
## Summary
- add gdpr_terms.html with demo compliance info
- link to terms from homepage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68559bd91364832f90335c055ce932b0