### PR TITLE
Add terms and conditions page

### DIFF
--- a/tests/test_terms_and_conditions_page.py
+++ b/tests/test_terms_and_conditions_page.py
@@ -1,0 +1,22 @@
+import asyncio
+from pathlib import Path
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_terms_and_conditions_html_served(tmp_path):
+    html = Path(tmp_path) / "terms_and_conditions.html"
+    html.write_text("<h1>Terms</h1>", encoding="utf-8")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, body_bytes = await _http_get(
+            f"http://127.0.0.1:{port}/terms_and_conditions.html"
+        )
+        server.should_exit = True
+        await task
+        return status, body_bytes.decode()
+
+    status, body = asyncio.run(run_test())
+    assert status == 200
+    assert "<h1>Terms</h1>" in body

--- a/website/index.html
+++ b/website/index.html
@@ -511,6 +511,8 @@ pageql data.db templates --create</code></pre>
     </main>
     <footer style="text-align: center; padding: 1rem 0;">
       <a href="privacy_policy.html" style="color: var(--text-muted);">Privacy Policy</a>
+      |
+      <a href="terms_and_conditions.html" style="color: var(--text-muted);">Terms and Conditions</a>
     </footer>
   </div>
   <script>

--- a/website/terms_and_conditions.html
+++ b/website/terms_and_conditions.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms and Conditions</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-gradient-start: #1a2233;
+      --bg-gradient-end:   #2d3748;
+      --card-bg:  #2a2e3a;
+      --text:     #e2e2e2;
+      --text-muted: #b0b8c4;
+      --primary:  #be5028;
+      --border-subtle: #3a4259;
+    }
+    * { box-sizing: border-box; font-family: 'Inter', sans-serif; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+      color: var(--text);
+      line-height: 1.6;
+      padding: 2rem;
+    }
+    h1 { text-align: center; color: var(--primary); }
+    .card {
+      background: var(--card-bg);
+      border-radius: 12px;
+      padding: 2rem;
+      max-width: 800px;
+      margin: 0 auto;
+      border: 1px solid var(--border-subtle);
+    }
+    a { color: var(--primary); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Terms and Conditions</h1>
+    <p>This demo application is provided for testing the PageQL framework. The application has no warranty.</p>
+    <p>By using this demo you agree that all data entered is for testing only and may be removed at any time.</p>
+    <p>No liability is assumed for any loss or damages resulting from the use of this demo.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Terms and Conditions page for demo website
- link new page from the main index
- test that Terms and Conditions is served correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855afe0f618832f864c39ccf70a2b92