### PR TITLE
Remove counting in reactive Intersect

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -552,96 +552,56 @@ class Intersect(Signal):
                 f"Intersect: parent1 and parent2 must have the same columns {self.parent1.columns} != {self.parent2.columns}"
             )
 
-        # Track counts per parent so duplicates from the same parent don't
-        # result in duplicate intersection rows.
-        self._counts1 = {}
-        self._counts2 = {}
-        for row in execute(self.conn, self.parent1.sql, []).fetchall():
-            self._counts1[row] = self._counts1.get(row, 0) + 1
-        for row in execute(self.conn, self.parent2.sql, []).fetchall():
-            self._counts2[row] = self._counts2.get(row, 0) + 1
-
         # Set of rows currently present in the intersection
-        self._rows = {
-            row for row in self._counts1.keys() if self._counts2.get(row, 0) > 0
-        }
+        self._rows = set(execute(self.conn, self.sql, []).fetchall())
+
+        qcols = " AND ".join([f"{c} IS ?" for c in self.columns])
+        self._exists_sql1 = f"SELECT 1 FROM ({self.parent1.sql}) WHERE {qcols} LIMIT 1"
+        self._exists_sql2 = f"SELECT 1 FROM ({self.parent2.sql}) WHERE {qcols} LIMIT 1"
 
     def _emit(self, event):
         for listener in self.listeners:
             listener(event)
 
-    def _insert(self, row, counts_self, counts_other):
-        prev = counts_self.get(row, 0)
-        counts_self[row] = prev + 1
-        if prev == 0 and counts_other.get(row, 0) > 0 and row not in self._rows:
+    def _exists1(self, row):
+        return execute(self.conn, self._exists_sql1, row).fetchone() is not None
+
+    def _exists2(self, row):
+        return execute(self.conn, self._exists_sql2, row).fetchone() is not None
+
+    def _insert(self, row, which):
+        if which == 1:
+            other_exists = self._exists2(row)
+        else:
+            other_exists = self._exists1(row)
+        if other_exists and row not in self._rows:
             self._rows.add(row)
             self._emit([1, row])
 
-    def _delete(self, row, counts_self, counts_other):
-        prev = counts_self.get(row, 0)
-        if prev <= 1:
-            if row in counts_self:
-                del counts_self[row]
-            if prev == 1 and counts_other.get(row, 0) > 0 and row in self._rows:
-                self._rows.remove(row)
-                self._emit([2, row])
+    def _delete(self, row, which):
+        if which == 1:
+            exists_self = self._exists1(row)
+            exists_other = self._exists2(row)
         else:
-            counts_self[row] = prev - 1
+            exists_self = self._exists2(row)
+            exists_other = self._exists1(row)
+        if row in self._rows and (not exists_self or not exists_other):
+            self._rows.remove(row)
+            self._emit([2, row])
 
-    def _update(self, oldrow, newrow, counts_self, counts_other):
+    def _update(self, oldrow, newrow, which):
         if oldrow == newrow:
             return
-
-        old_in = oldrow in self._rows
-        new_in = newrow in self._rows
-
-        # Adjust counts
-        oldcnt = counts_self.get(oldrow, 0)
-        if oldcnt <= 1:
-            if oldrow in counts_self:
-                del counts_self[oldrow]
-        else:
-            counts_self[oldrow] = oldcnt - 1
-
-        counts_self[newrow] = counts_self.get(newrow, 0) + 1
-
-        old_after = counts_self.get(oldrow, 0) > 0 and counts_other.get(oldrow, 0) > 0
-        new_after = counts_self.get(newrow, 0) > 0 and counts_other.get(newrow, 0) > 0
-
-        if old_in and not old_after and oldrow in self._rows:
-            self._rows.remove(oldrow)
-        if not old_in and old_after:
-            self._rows.add(oldrow)
-        if new_in != new_after:
-            if new_after:
-                self._rows.add(newrow)
-            else:
-                self._rows.discard(newrow)
-
-        removed = old_in and not old_after
-        added = not new_in and new_after
-
-        if removed and added:
-            self._emit([3, oldrow, newrow])
-        elif removed:
-            self._emit([2, oldrow])
-        elif added:
-            self._emit([1, newrow])
+        self._delete(oldrow, which)
+        self._insert(newrow, which)
 
     def onevent(self, event, which):
-        if which == 1:
-            counts_self = self._counts1
-            counts_other = self._counts2
-        else:
-            counts_self = self._counts2
-            counts_other = self._counts1
-
         if event[0] == 1:
-            self._insert(event[1], counts_self, counts_other)
+            self._insert(event[1], which)
         elif event[0] == 2:
-            self._delete(event[1], counts_self, counts_other)
+            self._delete(event[1], which)
         else:
-            self._update(event[1], event[2], counts_self, counts_other)
+            self._update(event[1], event[2], which)
 
     def remove_listener(self, listener):
         """Remove *listener* and detach from parents when unused."""


### PR DESCRIPTION
## Summary
- simplify Intersect by querying other table for membership instead of keeping counts

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68564de778b0832f9829846f9169b71d