### PR TITLE
Refactor Join implementation to query parent tables

### DIFF
--- a/src/pageql/join.py
+++ b/src/pageql/join.py
@@ -34,7 +34,6 @@ class Join(Signal):
             f"SELECT a.* FROM ({self.parent1.sql}) AS a JOIN (SELECT {right_cols}) AS b ON {self.on_sql}"
         )
 
-        self.rows1 = list(execute(self.conn, self.parent1.sql, []).fetchall())
 
     def _emit(self, event):
         for listener in self.listeners:
@@ -53,7 +52,6 @@ class Join(Signal):
         return list(cur.fetchall())
 
     def _insert_left(self, row):
-        self.rows1.append(row)
         for r2 in self._fetch_right(row):
             self._emit([1, row + r2])
 
@@ -62,10 +60,6 @@ class Join(Signal):
             self._emit([1, r1 + row])
 
     def _delete_left(self, row):
-        try:
-            self.rows1.remove(row)
-        except ValueError:
-            return
         for r2 in self._fetch_right(row):
             self._emit([2, row + r2])
 
@@ -76,9 +70,6 @@ class Join(Signal):
     def _update_left(self, oldrow, newrow):
         if oldrow == newrow:
             return
-        idx = self.rows1.index(oldrow)
-        self.rows1[idx] = newrow
-
         old_matches = self._fetch_right(oldrow)
         new_matches = self._fetch_right(newrow)
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -460,6 +460,29 @@ def test_join_update():
     assert_eq(events, [[3, (aid, 'x', bid, aid, 't1'), (aid, 'x', bid, aid, 't2')]])
 
 
+def test_join_delete():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE a(id INTEGER PRIMARY KEY, name TEXT)")
+    conn.execute("CREATE TABLE b(id INTEGER PRIMARY KEY, a_id INTEGER, title TEXT)")
+    r1, r2 = ReactiveTable(conn, "a"), ReactiveTable(conn, "b")
+    j = Join(r1, r2, "a.id = b.a_id")
+    events = []
+    j.listeners.append(events.append)
+
+    r1.insert("INSERT INTO a(name) VALUES ('x')", {})
+    aid = conn.execute("SELECT id FROM a WHERE name='x'").fetchone()[0]
+    r2.insert("INSERT INTO b(a_id, title) VALUES (:a, 't')", {"a": aid})
+    bid = conn.execute("SELECT id FROM b WHERE a_id=:a", {"a": aid}).fetchone()[0]
+    events.clear()
+
+    r2.delete("DELETE FROM b WHERE id=:id", {"id": bid})
+    assert_eq(events, [[2, (aid, 'x', bid, aid, 't')]])
+    events.clear()
+
+    r1.delete("DELETE FROM a WHERE id=:id", {"id": aid})
+    assert events == []
+
+
 def test_intersect_deduplication():
     conn = sqlite3.connect(":memory:")
     for t in ("a", "b"):


### PR DESCRIPTION
## Summary
- remove cached `rows1` from `Join`
- fetch rows directly from parent relations when processing events
- cover join deletion events

## Testing
- `PYTHONPATH=src pytest tests/test_reactive.py::test_join_basic tests/test_reactive.py::test_join_update tests/test_reactive.py::test_join_delete -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685652357754832fa989eecfb1e926a0