### PR TITLE
Implement COUNT(expr) support

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -135,8 +135,12 @@ def build_reactive(expr, tables: Tables):
             col = select_list[0]
             if isinstance(col, exp.Star):
                 return parent
-            if isinstance(col, exp.Count) and isinstance(col.this, exp.Star):
-                return CountAll(parent)
+            if isinstance(col, exp.Count):
+                if isinstance(col.this, exp.Star):
+                    return CountAll(parent)
+                if not col.args.get("distinct"):
+                    expr_sql = col.this.sql(dialect=tables.dialect)
+                    return CountAll(parent, expr_sql)
         select_sql = ", ".join(col.sql(dialect=tables.dialect) for col in select_list)
         return Select(parent, select_sql)
     if isinstance(expr, exp.Table):

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -60,6 +60,16 @@ def test_parse_count():
     assert_sql_equivalent(conn, sql, comp.sql)
 
 
+def test_parse_count_expr():
+    conn = _db()
+    tables = Tables(conn)
+    sql = "SELECT COUNT(name) FROM items"
+    expr = sqlglot.parse_one(sql, read="sqlite")
+    comp = parse_reactive(expr, tables, {})
+    assert isinstance(comp, CountAll)
+    assert_sql_equivalent(conn, sql, comp.sql)
+
+
 def test_parse_union_all():
     conn = sqlite3.connect(":memory:")
     for t in ("a", "b"):


### PR DESCRIPTION
## Summary
- extend `CountAll` to accept an optional expression
- detect `COUNT(expr)` in SQL parser
- test counting only non-null expressions
- test parsing `COUNT(name)`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685656888b64832f8ff2fc36a31e5a34