### PR TITLE
Update CountAll interface to parse COUNT expressions

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -310,25 +310,32 @@ class Where(Signal):
 
 
 class CountAll(Signal):
-    def __init__(self, parent, expr: str | None = None):
+    def __init__(self, parent, expr: str = "COUNT(*)"):
         super().__init__(None)
         self.parent = parent
         self.expr = expr
         self.conn = self.parent.conn
-        if expr is None:
+
+        m = re.fullmatch(r"\s*count\s*\(\s*(\*|[^)]*)\s*\)\s*", expr, re.I)
+        if not m:
+            raise ValueError("expr must be of the form COUNT(*) or COUNT(expr)")
+        inner = m.group(1).strip()
+        self._inner = None if inner == "*" else inner
+
+        if self._inner is None:
             self.sql = f"SELECT COUNT(*) FROM ({self.parent.sql})"
         else:
-            self.sql = f"SELECT COUNT({expr}) FROM ({self.parent.sql})"
+            self.sql = f"SELECT COUNT({self._inner}) FROM ({self.parent.sql})"
             placeholders = ", ".join(f"? AS {c}" for c in self.parent.columns)
-            self._expr_sql = f"SELECT {expr} FROM (SELECT {placeholders})"
+            self._expr_sql = f"SELECT {self._inner} FROM (SELECT {placeholders})"
         self.value = execute(self.conn, self.sql, []).fetchone()[0]
         self.parent.listeners.append(self.onevent)
-        self.columns = f"COUNT({expr if expr else '*'} )".replace(' )', ')')
+        self.columns = f"COUNT({inner})"  # normalized expression
         self.deps = [self.parent]
         self.update = self.onevent
 
     def _expr_not_null(self, row):
-        if self.expr is None:
+        if self._inner is None:
             return True
         cur = execute(self.conn, self._expr_sql, row)
         return cur.fetchone()[0] is not None

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -135,12 +135,9 @@ def build_reactive(expr, tables: Tables):
             col = select_list[0]
             if isinstance(col, exp.Star):
                 return parent
-            if isinstance(col, exp.Count):
-                if isinstance(col.this, exp.Star):
-                    return CountAll(parent)
-                if not col.args.get("distinct"):
-                    expr_sql = col.this.sql(dialect=tables.dialect)
-                    return CountAll(parent, expr_sql)
+            if isinstance(col, exp.Count) and not col.args.get("distinct"):
+                expr_sql = col.sql(dialect=tables.dialect)
+                return CountAll(parent, expr_sql)
         select_sql = ", ".join(col.sql(dialect=tables.dialect) for col in select_list)
         return Select(parent, select_sql)
     if isinstance(expr, exp.Table):

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -185,7 +185,7 @@ def test_count_all():
 def test_count_expression():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    cnt = CountAll(rt, "name")
+    cnt = CountAll(rt, "COUNT(name)")
     events = []
     cnt.listeners.append(events.append)
 


### PR DESCRIPTION
## Summary
- change `CountAll` to take full `COUNT(*)` or `COUNT(expr)` string
- update SQL parser to pass full COUNT expression
- adjust tests for new interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685663bb3aec832fb19a0f1d60d4ca73