### PR TITLE
Support multiple expressions in CountAll

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -137,10 +137,10 @@ def build_reactive(expr, tables: Tables):
                 return parent
             if isinstance(col, exp.Count) and not col.args.get("distinct"):
                 expr_sql = col.sql(dialect=tables.dialect)
-                return CountAll(parent, expr_sql)
+                return CountAll(parent, (expr_sql,))
             if isinstance(col, exp.Sum):
                 expr_sql = col.sql(dialect=tables.dialect)
-                return CountAll(parent, expr_sql)
+                return CountAll(parent, (expr_sql,))
         select_sql = ", ".join(col.sql(dialect=tables.dialect) for col in select_list)
         return Select(parent, select_sql)
     if isinstance(expr, exp.Table):


### PR DESCRIPTION
## Summary
- extend `CountAll` to accept multiple aggregate expressions
- update SQL parser to use new CountAll API
- adjust tests for new CountAll behaviour
- add test for multiple expressions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856681484dc832fbaaf0cd23d5122e0