### PR TITLE
Rename CountAll to Aggregate

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -310,7 +310,7 @@ class Where(Signal):
                     listener([3, event[1], event[2]])
 
 
-class CountAll(Signal):
+class Aggregate(Signal):
     def __init__(self, parent, exprs=("COUNT(*)",)):
         super().__init__(None)
         self.parent = parent

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -6,7 +6,7 @@ from .reactive import (
     Where,
     Union,
     UnionAll,
-    CountAll,
+    Aggregate,
     DerivedSignal,
     DerivedSignal2,
     OneValue,
@@ -137,13 +137,13 @@ def build_reactive(expr, tables: Tables):
                 return parent
             if isinstance(col, exp.Count) and not col.args.get("distinct"):
                 expr_sql = col.sql(dialect=tables.dialect)
-                return CountAll(parent, (expr_sql,))
+                return Aggregate(parent, (expr_sql,))
             if isinstance(col, exp.Sum):
                 expr_sql = col.sql(dialect=tables.dialect)
-                return CountAll(parent, (expr_sql,))
+                return Aggregate(parent, (expr_sql,))
             if isinstance(col, exp.Avg):
                 expr_sql = col.sql(dialect=tables.dialect)
-                return CountAll(parent, (expr_sql,))
+                return Aggregate(parent, (expr_sql,))
         select_sql = ", ".join(col.sql(dialect=tables.dialect) for col in select_list)
         return Select(parent, select_sql)
     if isinstance(expr, exp.Table):

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -56,7 +56,7 @@ def test_select_delete_event_should_be_labeled_delete():
 import sqlite3
 from pageql.reactive import (
     ReactiveTable,
-    CountAll,
+    Aggregate,
     OneValue,
     DerivedSignal,
     DerivedSignal2,
@@ -173,7 +173,7 @@ def test_delete_propagates_renderresultexception():
 def test_count_all():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    cnt = CountAll(rt)
+    cnt = Aggregate(rt)
     events = []
     cnt.listeners.append(events.append)
 
@@ -185,7 +185,7 @@ def test_count_all():
 def test_count_expression():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    cnt = CountAll(rt, ("COUNT(name)",))
+    cnt = Aggregate(rt, ("COUNT(name)",))
     events = []
     cnt.listeners.append(events.append)
 
@@ -210,7 +210,7 @@ def test_sum_expression():
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE nums(id INTEGER PRIMARY KEY, n INTEGER)")
     rt = ReactiveTable(conn, "nums")
-    sm = CountAll(rt, ("SUM(n)",))
+    sm = Aggregate(rt, ("SUM(n)",))
     events = []
     sm.listeners.append(events.append)
 
@@ -236,7 +236,7 @@ def test_avg_expression():
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE nums(id INTEGER PRIMARY KEY, n INTEGER)")
     rt = ReactiveTable(conn, "nums")
-    av = CountAll(rt, ("AVG(n)",))
+    av = Aggregate(rt, ("AVG(n)",))
     events = []
     av.listeners.append(events.append)
 
@@ -325,7 +325,7 @@ def test_select():
 def test_count_all_decrement():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    cnt = CountAll(rt)
+    cnt = Aggregate(rt)
     events = []
     cnt.listeners.append(events.append)
 
@@ -344,7 +344,7 @@ def test_count_all_decrement():
 def test_countall_multiple_expressions():
     conn = _db()
     rt = ReactiveTable(conn, "items")
-    cnt = CountAll(rt, ("COUNT(*)", "COUNT(name)"))
+    cnt = Aggregate(rt, ("COUNT(*)", "COUNT(name)"))
     events = []
     cnt.listeners.append(events.append)
 
@@ -820,7 +820,7 @@ def test_one_value_reset():
     conn = _db()
     rt = ReactiveTable(conn, "items")
 
-    cnt = CountAll(rt)
+    cnt = Aggregate(rt)
     dv = OneValue(cnt)
     seen = []
     dv.listeners.append(seen.append)
@@ -1046,7 +1046,7 @@ def fuzz_components(iterations=20, seed=None):
         (rt, rt),
         (Where(rt, "name LIKE 'x%'") , rt),
         (Select(rt, "name"), rt),
-        (CountAll(rt), rt),
+        (Aggregate(rt), rt),
     ]
 
     # UnionAll requires two tables

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
-from pageql.reactive import Tables, ReactiveTable, Select, Where, CountAll, UnionAll
+from pageql.reactive import Tables, ReactiveTable, Select, Where, Aggregate, UnionAll
 from pageql.reactive_sql import parse_reactive, FallbackReactive
 from pageql.reactive import ReadOnly
 
@@ -56,7 +56,7 @@ def test_parse_count():
     sql = "SELECT COUNT(*) FROM items"
     expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
-    assert isinstance(comp, CountAll)
+    assert isinstance(comp, Aggregate)
     assert_sql_equivalent(conn, sql, comp.sql)
 
 
@@ -66,7 +66,7 @@ def test_parse_count_expr():
     sql = "SELECT COUNT(name) FROM items"
     expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
-    assert isinstance(comp, CountAll)
+    assert isinstance(comp, Aggregate)
     assert_sql_equivalent(conn, sql, comp.sql)
 
 
@@ -77,7 +77,7 @@ def test_parse_sum_expr():
     sql = "SELECT SUM(n) FROM nums"
     expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
-    assert isinstance(comp, CountAll)
+    assert isinstance(comp, Aggregate)
     assert_sql_equivalent(conn, sql, comp.sql)
 
 
@@ -88,7 +88,7 @@ def test_parse_avg_expr():
     sql = "SELECT AVG(n) FROM nums"
     expr = sqlglot.parse_one(sql, read="sqlite")
     comp = parse_reactive(expr, tables, {})
-    assert isinstance(comp, CountAll)
+    assert isinstance(comp, Aggregate)
     assert_sql_equivalent(conn, sql, comp.sql)
 
 

--- a/tests/test_reactive_stateful.py
+++ b/tests/test_reactive_stateful.py
@@ -14,7 +14,7 @@ from pageql.reactive import (
     ReactiveTable,
     Where,
     Select,
-    CountAll,
+    Aggregate,
     UnionAll,
     Union,
     Intersect,
@@ -40,7 +40,7 @@ class ReactiveStateMachine(RuleBasedStateMachine):
         # Derived components
         self.where_items = Where(self.rt_items, "name LIKE 'x%'")
         self.select_items = Select(self.rt_items, "name")
-        self.count_items = CountAll(self.rt_items)
+        self.count_items = Aggregate(self.rt_items)
         self.union_all = UnionAll(self.rt_a, self.rt_b)
         self.union = Union(self.rt_a, self.rt_b)
         self.intersect = Intersect(self.rt_a, self.rt_b)


### PR DESCRIPTION
## Summary
- rename `CountAll` class to `Aggregate`
- update references in parser and tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68566df4a090832f96e1713931aa1164