### PR TITLE
Add group_by option to Aggregate

### DIFF
--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -311,6 +311,31 @@ def test_aggregate_constant_expression():
     assert_eq(events[-1], [3, [0, 42], [1, 42]])
 
 
+def test_aggregate_group_by():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE nums(id INTEGER PRIMARY KEY, grp INTEGER, n INTEGER)")
+    rt = ReactiveTable(conn, "nums")
+    ag = Aggregate(rt, ("COUNT(*)", "SUM(n)"), group_by="grp")
+    events = []
+    ag.listeners.append(events.append)
+
+    rt.insert("INSERT INTO nums(grp,n) VALUES (1,10)", {})
+    assert_eq(events[-1], [1, (1, 1, 10)])
+
+    rt.insert("INSERT INTO nums(grp,n) VALUES (1,5)", {})
+    assert_eq(events[-1], [3, (1, 1, 10), (1, 2, 15)])
+
+    rid = conn.execute("SELECT id FROM nums WHERE n=5").fetchone()[0]
+    rt.update("UPDATE nums SET grp=2 WHERE id=:id", {"id": rid})
+    assert events[-2:] == [[3, (1, 2, 15), (1, 1, 10)], [1, (2, 1, 5)]]
+
+    rid = conn.execute("SELECT id FROM nums WHERE grp=1").fetchone()[0]
+    rt.delete("DELETE FROM nums WHERE id=:id", {"id": rid})
+    assert_eq(events[-1], [2, (1, 1, 10)])
+
+    check_component(ag, lambda: None)
+
+
 def test_signal_and_derived():
     a_val = [1]
     b_val = [2]


### PR DESCRIPTION
## Summary
- support grouping in `Aggregate` via new `group_by` parameter
- add tests covering grouped aggregates

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68567a9da840832fa08de3305c71de34