### PR TITLE
Ensure deterministic ORDER BY in reactive Order

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -833,6 +833,8 @@ class Order(Signal):
         self.parent = parent
         self.order_sql = order_sql
         self.conn = self.parent.conn
+        extra_order = ", ".join(str(i + 1) for i in range(len(self.parent.columns)))
+        self.order_sql = f"{self.order_sql}, {extra_order}"
         self.sql = f"SELECT * FROM ({self.parent.sql}) ORDER BY {self.order_sql}"
         self.columns = self.parent.columns
         self.parent.listeners.append(self.onevent)

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1060,3 +1060,21 @@ def test_order_events():
     rt.delete("DELETE FROM items WHERE id=2", {})
     assert seen == [[2, 0]]
     assert ordered.value == [(3, "c"), (4, "a")]
+
+
+def test_order_deterministic_sql():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    rt = ReactiveTable(conn, "items")
+    ordered = Order(rt, "name")
+
+    assert (
+        ordered.sql
+        == "SELECT * FROM (SELECT * FROM items) ORDER BY name, 1, 2"
+    )
+
+    rt.insert("INSERT INTO items(id,name) VALUES (1,'b')", {})
+    rt.insert("INSERT INTO items(id,name) VALUES (2,'b')", {})
+    rt.insert("INSERT INTO items(id,name) VALUES (3,'a')", {})
+
+    assert ordered.value == [(3, "a"), (1, "b"), (2, "b")]


### PR DESCRIPTION
## Summary
- improve reactive Order SQL to append numeric columns for deterministic ordering
- add regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857de5f2b18832fb8fa238a6e62604d