### PR TITLE
Refactor pageql helpers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,5 @@
+from pageql.pageql import _normalize_param_name
+
+def test_normalize_param_name():
+    assert _normalize_param_name(':a.b') == 'a__b'
+    assert _normalize_param_name('foo') == 'foo'


### PR DESCRIPTION
## Summary
- consolidate parameter name mangling logic
- add `_eval_and_render` helper
- deduplicate ifdef/ifndef handling
- test `_normalize_param_name`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d585fe168832f926f8092eeb84993