### PR TITLE
Remove ordering from todo pages

### DIFF
--- a/examples/templates/todos.pageql
+++ b/examples/templates/todos.pageql
@@ -63,7 +63,7 @@
   WHERE (:filter == 'all')
         OR (:filter == 'active'    AND completed = 0)
         OR (:filter == 'completed' AND completed = 1)
-  ORDER BY id}}
+  }}
     <li {{#if completed}}class="completed"{{/if}}>
         <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {{#if completed}}checked{{/if}}>
         <label

--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -65,7 +65,7 @@
           WHERE (:filter == 'all')
                 OR (:filter == 'active'    AND completed = 0)
                 OR (:filter == 'completed' AND completed = 1)
-          ORDER BY id}}
+          }}
             <li {{#if completed}}class="completed"{{/if}}>
                 <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {{#if completed}}checked{{/if}}>
                 <label


### PR DESCRIPTION
## Summary
- remove ORDER BY clause from todo page templates

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d75c15480832fb4c9626855f7f34a