### PR TITLE
Add todos page ordered by text

### DIFF
--- a/tests/test_todos_ordered_page.py
+++ b/tests/test_todos_ordered_page.py
@@ -1,0 +1,19 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pathlib import Path
+from pageql.pageql import PageQL
+
+def test_todos_ordered_by_text():
+    src = Path("website/todos_ordered.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("todos_ordered", src)
+    r.db.execute(
+        "CREATE TABLE IF NOT EXISTS todos(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT NOT NULL, completed INTEGER DEFAULT 0 CHECK(completed IN (0,1)))"
+    )
+    r.db.execute("INSERT INTO todos(text) VALUES ('b'), ('a')")
+    result = r.render("/todos_ordered", reactive=False)
+    body = result.body
+    assert body.index(">a</label>") < body.index(">b</label>")

--- a/website/todos_ordered.pageql
+++ b/website/todos_ordered.pageql
@@ -1,0 +1,337 @@
+{{#param filter default='all' pattern="^(all|active|completed)$"}}
+
+{{!-- Ensure the table exists (harmless if already created) --}}
+{{#create table if not exists todos (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    text TEXT NOT NULL,
+    completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
+)}}
+
+{{#let active_count    = COUNT(*) from todos WHERE completed = 0}}
+{{#let completed_count = COUNT(*) from todos WHERE completed = 1}}
+{{#let total_count     = COUNT(*) from todos}}
+{{#let all_complete    = (:active_count == 0 AND :total_count > 0)}}
+
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>TODOMVC</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 0.5rem; }
+    li.completed label { text-decoration: line-through; color: #777; }
+    .filters { margin-top: 1rem; }
+    .filters a { text-decoration: none; margin: 0 0.5rem; }
+    .filters a.selected { font-weight: bold; }
+    .back-link {
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid #ccc;
+      font-size: 1.8rem;
+      font-weight: bold;
+    }
+    .back-link a {
+      color: #be5028;
+      text-decoration: none;
+    }
+    .code-column {
+      overflow-x: auto;
+    }
+    
+    /* Mobile styles */
+    @media (max-width: 768px) {
+      body { 
+        margin: 0; 
+        padding: 0;
+      }
+      .back-link {
+        margin-bottom: 1rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="back-link"><a href="/">&larr; PageQL</a> <span style="font-size: 1.8rem; font-weight: bold; color:rgb(40, 170, 190);">TODOMVC</span></div>
+  <div>
+      {{#if :total_count < 20}}
+      <input name="text" placeholder="What needs to be done?" maxlength="100" autofocus autocomplete="off"
+        hx-post="/todos/add" hx-trigger="keyup[key=='Enter']" hx-on:htmx:after-on-load="this.value=''">
+      {{/if}}
+      <ul>
+        {{#from todos
+          WHERE (:filter == 'all')
+                OR (:filter == 'active'    AND completed = 0)
+                OR (:filter == 'completed' AND completed = 1)
+          ORDER BY text}}
+            <li {{#if completed}}class="completed"{{/if}}>
+                <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {{#if completed}}checked{{/if}}>
+                <label
+                  contenteditable="false"
+                  onclick="this.contentEditable=true;this.focus();"
+                  onblur="this.contentEditable=false;"
+                  onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}"
+                  oninput="if(this.innerText.length>100){this.innerText=this.innerText.slice(0,100);}"
+                  hx-patch="/todos/{{id}}"
+                  hx-trigger="blur"
+                  hx-vals='js:{text: event.target.innerText.slice(0, 100)}'
+                  hx-swap="none"
+                >{{text}}</label>
+
+                <button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;">✕</button>
+            </li>
+        {{/from}}
+      </ul>
+
+  <input id="toggle-all" class="toggle-all" type="checkbox" {{#if all_complete}}checked{{/if}} hx-post="/todos/toggle_all">
+  <label for="toggle-all">Mark all as complete</label>
+
+<span class="todo-count">
+  <strong>{{active_count}}</strong>
+  item{{#if :active_count != 1}}s{{/if}} left
+</span>
+
+
+{{#if :completed_count > 0}}
+  <button class="clear-completed" hx-post="/todos/clear_completed">Clear completed</button>
+{{/if}}
+<div class="filters">
+  <a {{#if :filter == 'all'}}class="selected"{{/if}} href="/todos?filter=all">All</a> |
+  <a {{#if :filter == 'active'}}class="selected"{{/if}} href="/todos?filter=active">Active</a> |
+  <a {{#if :filter == 'completed'}}class="selected"{{/if}} href="/todos?filter=completed">Completed</a>
+</div>
+</div>
+  <h2 style="color:rgb(50, 56, 86); margin-top: 2rem; margin-bottom: 0.5rem;">Source code</h2>
+<div style="position: relative;">
+  <button onclick="copySourceCode(this)" style="position: absolute; top: 8px; right: 8px; z-index: 10; background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.3); border-radius: 4px; padding: 8px; cursor: pointer; color: #d4d4d4; transition: all 0.2s;">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+    </svg>
+  </button>
+<div class="code-column">
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#param</span> <span style="color: #9cdcfe;">filter</span> <span style="color: #dcdcaa;">default</span>=<span style="color: #ce9178;">'all'</span> <span style="color: #dcdcaa;">pattern</span>=<span style="color: #ce9178;">"^(all|active|completed)$"</span>&#125;&#125;
+
+&#123;&#123;<span style="color: #6a9955; font-style: italic;">!-- Ensure the table exists (harmless if already created) --</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#create</span> <span style="color: #c586c0; font-weight: bold;">table</span> <span style="color: #c586c0; font-weight: bold;">if</span> <span style="color: #c586c0; font-weight: bold;">not</span> <span style="color: #c586c0; font-weight: bold;">exists</span> todos (
+    id <span style="color: #4fc1ff; font-weight: bold;">INTEGER</span> <span style="color: #c586c0; font-weight: bold;">PRIMARY</span> <span style="color: #c586c0; font-weight: bold;">KEY</span> <span style="color: #c586c0; font-weight: bold;">AUTOINCREMENT</span>,
+    text <span style="color: #4fc1ff; font-weight: bold;">TEXT</span> <span style="color: #c586c0; font-weight: bold;">NOT</span> <span style="color: #c586c0; font-weight: bold;">NULL</span>,
+    completed <span style="color: #4fc1ff; font-weight: bold;">INTEGER</span> <span style="color: #c586c0; font-weight: bold;">DEFAULT</span> <span style="color: #ce9178;">0</span> <span style="color: #c586c0; font-weight: bold;">CHECK</span>(completed <span style="color: #c586c0; font-weight: bold;">IN</span> (<span style="color: #ce9178;">0</span>,<span style="color: #ce9178;">1</span>))
+)&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">active_count</span>    = <span style="color: #4fc1ff; font-weight: bold;">COUNT</span>(*) <span style="color: #c586c0; font-weight: bold;">from</span> todos <span style="color: #c586c0; font-weight: bold;">WHERE</span> completed = <span style="color: #ce9178;">0</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">completed_count</span> = <span style="color: #4fc1ff; font-weight: bold;">COUNT</span>(*) <span style="color: #c586c0; font-weight: bold;">from</span> todos <span style="color: #c586c0; font-weight: bold;">WHERE</span> completed = <span style="color: #ce9178;">1</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">total_count</span>     = <span style="color: #4fc1ff; font-weight: bold;">COUNT</span>(*) <span style="color: #c586c0; font-weight: bold;">from</span> todos&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">all_complete</span>    = (<span style="color: #9cdcfe;">:active_count</span> == <span style="color: #ce9178;">0</span> <span style="color: #c586c0; font-weight: bold;">AND</span> <span style="color: #9cdcfe;">:total_count</span> &gt; <span style="color: #ce9178;">0</span>)&#125;&#125;
+
+
+<span style="color: #808080; font-style: italic;">&lt;!doctype html&gt;</span>
+<span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">html</span> <span style="color: #92c5f8;">lang</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"en"</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">head</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">meta</span> <span style="color: #92c5f8;">charset</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"utf-8"</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">title</span><span style="color: #808080;">&gt;</span>TODOMVC<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">title</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">style</span><span style="color: #808080;">&gt;</span>
+<span style="color: #d4d4d4;">    </span><span style="color: #d7ba7d;">body</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">font-family</span><span style="color: #d4d4d4;">: Arial, </span><span style="color: #ce9178;">sans-serif</span><span style="color: #d4d4d4;">; </span><span style="color: #9cdcfe;">margin</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">2</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    </span><span style="color: #d7ba7d;">ul</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">list-style</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">none</span><span style="color: #d4d4d4;">; </span><span style="color: #9cdcfe;">padding</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">0</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    </span><span style="color: #d7ba7d;">li</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">margin-bottom</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">0.5</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    </span><span style="color: #d7ba7d;">li</span><span style="color: #d4d4d4;">.</span><span style="color: #4ec9b0;">completed</span><span style="color: #d4d4d4;"> </span><span style="color: #d7ba7d;">label</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">text-decoration</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">line-through</span><span style="color: #d4d4d4;">; </span><span style="color: #9cdcfe;">color</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">#777</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">filters</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">margin-top</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">1</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">filters</span><span style="color: #d4d4d4;"> </span><span style="color: #d7ba7d;">a</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">text-decoration</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">none</span><span style="color: #d4d4d4;">; </span><span style="color: #9cdcfe;">margin</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">0</span><span style="color: #d4d4d4;"> </span><span style="color: #b5cea8;">0.5</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">filters</span><span style="color: #d4d4d4;"> </span><span style="color: #d7ba7d;">a</span><span style="color: #d4d4d4;">.</span><span style="color: #4ec9b0;">selected</span><span style="color: #d4d4d4;"> { </span><span style="color: #9cdcfe;">font-weight</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">bold</span><span style="color: #d4d4d4;">; }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">back-link</span><span style="color: #d4d4d4;"> {</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">margin-bottom</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">2</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">padding-bottom</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">1</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">border-bottom</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">1</span><span style="color: #9cdcfe;">px</span><span style="color: #d4d4d4;"> </span><span style="color: #ce9178;">solid</span><span style="color: #d4d4d4;"> </span><span style="color: #b5cea8;">#ccc</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">font-size</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">1.8</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">font-weight</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">bold</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">    }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">back-link</span><span style="color: #d4d4d4;"> </span><span style="color: #d7ba7d;">a</span><span style="color: #d4d4d4;"> {</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">color</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">#be5028</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">text-decoration</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">none</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">    }</span>
+<span style="color: #d4d4d4;">    .</span><span style="color: #4ec9b0;">code-column</span><span style="color: #d4d4d4;"> {</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #9cdcfe;">overflow-x</span><span style="color: #d4d4d4;">: </span><span style="color: #ce9178;">auto</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">    }</span>
+    
+    <span style="color: #6a9955; font-style: italic;">/* Mobile styles */</span>
+    <span style="color: #569cd6;">@media</span> <span style="color: #d4d4d4;">(</span><span style="color: #9cdcfe;">max-width</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">768</span><span style="color: #9cdcfe;">px</span><span style="color: #d4d4d4;">) {</span>
+<span style="color: #d4d4d4;">      </span><span style="color: #d7ba7d;">body</span><span style="color: #d4d4d4;"> { </span>
+<span style="color: #d4d4d4;">        </span><span style="color: #9cdcfe;">margin</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">0</span><span style="color: #d4d4d4;">; </span>
+<span style="color: #d4d4d4;">        </span><span style="color: #9cdcfe;">padding</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">0</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      }</span>
+<span style="color: #d4d4d4;">      .</span><span style="color: #4ec9b0;">back-link</span><span style="color: #d4d4d4;"> {</span>
+<span style="color: #d4d4d4;">        </span><span style="color: #9cdcfe;">margin-bottom</span><span style="color: #d4d4d4;">: </span><span style="color: #b5cea8;">1</span><span style="color: #9cdcfe;">rem</span><span style="color: #d4d4d4;">;</span>
+<span style="color: #d4d4d4;">      }</span>
+<span style="color: #d4d4d4;">    }</span>
+  <span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">style</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">head</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">body</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">div</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"back-link"</span><span style="color: #808080;">&gt;&lt;</span><span style="color: #569cd6; font-weight: bold;">a</span> <span style="color: #92c5f8;">href</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/"</span><span style="color: #808080;">&gt;</span>&amp;larr; PageQL<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">a</span><span style="color: #808080;">&gt;</span> <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">span</span> <span style="color: #92c5f8;">style</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"font-size: 1.8rem; font-weight: bold; color:rgb(40, 170, 190);"</span><span style="color: #808080;">&gt;</span>TODOMVC<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">span</span><span style="color: #808080;">&gt;&lt;/</span><span style="color: #569cd6; font-weight: bold;">div</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">h1</span><span style="color: #808080;">&gt;</span>TODOMVC<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">h1</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">div</span><span style="color: #808080;">&gt;</span>
+      &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:total_count</span> &lt; <span style="color: #ce9178;">20</span>&#125;&#125;
+      <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">input</span> <span style="color: #92c5f8;">name</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"text"</span> <span style="color: #92c5f8;">placeholder</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"What needs to be done?"</span> <span style="color: #92c5f8;">maxlength</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"100"</span> <span style="color: #92c5f8;">autofocus</span> <span style="color: #92c5f8;">autocomplete</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"off"</span>
+        <span style="color: #92c5f8;">hx-post</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/add"</span> <span style="color: #92c5f8;">hx-trigger</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"keyup[key=='Enter']"</span> <span style="color: #92c5f8;">hx-on:htmx:after-on-load</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"this.value=''"</span><span style="color: #808080;">&gt;</span>
+      &#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125;
+      <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">ul</span><span style="color: #808080;">&gt;</span>
+        &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#from</span> todos
+          <span style="color: #c586c0; font-weight: bold;">WHERE</span> (<span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'all'</span>)
+                <span style="color: #c586c0; font-weight: bold;">OR</span> (<span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'active'</span>    <span style="color: #c586c0; font-weight: bold;">AND</span> completed = <span style="color: #ce9178;">0</span>)
+                <span style="color: #c586c0; font-weight: bold;">OR</span> (<span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'completed'</span> <span style="color: #c586c0; font-weight: bold;">AND</span> completed = <span style="color: #ce9178;">1</span>)
+                <span style="color: #c586c0; font-weight: bold;">ORDER</span> <span style="color: #c586c0; font-weight: bold;">BY</span> text&#125;&#125;
+            <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">li</span> &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> completed&#125;&#125;<span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"completed"</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125;<span style="color: #808080;">&gt;</span>
+                <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">input</span> <span style="color: #92c5f8;">hx-post</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/&#123;&#123;id&#125;&#125;/toggle"</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"toggle"</span> <span style="color: #92c5f8;">type</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"checkbox"</span> &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> completed&#125;&#125;<span style="color: #92c5f8;">checked</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125;<span style="color: #808080;">&gt;</span>
+                <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">label</span>
+                  <span style="color: #92c5f8;">contenteditable</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"false"</span>
+                  <span style="color: #92c5f8;">onclick</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"this.contentEditable=true;this.focus();"</span>
+                  <span style="color: #92c5f8;">onblur</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"this.contentEditable=false;"</span>
+                  <span style="color: #92c5f8;">onkeydown</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"if(event.key==='Enter'){event.preventDefault();this.blur();}"</span>
+                  <span style="color: #92c5f8;">oninput</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"if(this.innerText.length&gt;100){this.innerText=this.innerText.slice(0,100);}"</span>
+                  <span style="color: #92c5f8;">hx-patch</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/&#123;&#123;id&#125;&#125;"</span>
+                  <span style="color: #92c5f8;">hx-trigger</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"blur"</span>
+                  <span style="color: #92c5f8;">hx-vals</span><span style="color: #808080;">=</span><span style="color: #ce9178;">'js:{text: event.target.innerText.slice(0, 100)}'</span>
+                  <span style="color: #92c5f8;">hx-swap</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"none"</span>
+                <span style="color: #808080;">&gt;</span>&#123;&#123;text&#125;&#125;<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">label</span><span style="color: #808080;">&gt;</span>
+                
+                <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">button</span> <span style="color: #92c5f8;">hx-delete</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/&#123;&#123;id&#125;&#125;"</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"destroy"</span>
+                  <span style="color: #92c5f8;">style</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"cursor:pointer; background:none; border:none; color:#ac4a1a;"</span><span style="color: #808080;">&gt;</span>✕<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">button</span><span style="color: #808080;">&gt;</span>
+            <span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">li</span><span style="color: #808080;">&gt;</span>
+        &#123;&#123;<span style="color: #569cd6; font-weight: bold;">/from</span>&#125;&#125;
+      <span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">ul</span><span style="color: #808080;">&gt;</span>
+
+      <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">input</span> <span style="color: #92c5f8;">id</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"toggle-all"</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"toggle-all"</span> <span style="color: #92c5f8;">type</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"checkbox"</span>
+        &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> all_complete&#125;&#125;<span style="color: #92c5f8;">checked</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125; <span style="color: #92c5f8;">hx-post</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/toggle_all"</span><span style="color: #808080;">&gt;</span>
+      <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">label</span> <span style="color: #92c5f8;">for</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"toggle-all"</span><span style="color: #808080;">&gt;</span>Mark all as complete<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">label</span><span style="color: #808080;">&gt;</span>
+
+<span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">span</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"todo-count"</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">strong</span><span style="color: #808080;">&gt;</span>&#123;&#123;active_count&#125;&#125;<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">strong</span><span style="color: #808080;">&gt;</span>
+  item&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:active_count</span> != <span style="color: #ce9178;">1</span>&#125;&#125;s&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125; left
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">span</span><span style="color: #808080;">&gt;</span>
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:completed_count</span> &gt; <span style="color: #ce9178;">0</span>&#125;&#125;
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">button</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"clear-completed"</span> <span style="color: #92c5f8;">hx-post</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos/clear_completed"</span><span style="color: #808080;">&gt;</span>Clear completed<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">button</span><span style="color: #808080;">&gt;</span>
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125;
+<span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">div</span> <span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"filters"</span><span style="color: #808080;">&gt;</span>
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">a</span> &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'all'</span>&#125;&#125;<span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"selected"</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125; <span style="color: #92c5f8;">href</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos?filter=all"</span><span style="color: #808080;">&gt;</span>All<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">a</span><span style="color: #808080;">&gt;</span> |
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">a</span> &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'active'</span>&#125;&#125;<span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"selected"</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125; <span style="color: #92c5f8;">href</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos?filter=active"</span><span style="color: #808080;">&gt;</span>Active<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">a</span><span style="color: #808080;">&gt;</span> |
+  <span style="color: #808080;">&lt;</span><span style="color: #569cd6; font-weight: bold;">a</span> &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:filter</span> == <span style="color: #ce9178;">'completed'</span>&#125;&#125;<span style="color: #92c5f8;">class</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"selected"</span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125; <span style="color: #92c5f8;">href</span><span style="color: #808080;">=</span><span style="color: #ce9178;">"/todos?filter=completed"</span><span style="color: #808080;">&gt;</span>Completed<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">a</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">div</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">div</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">body</span><span style="color: #808080;">&gt;</span>
+<span style="color: #808080;">&lt;/</span><span style="color: #569cd6; font-weight: bold;">html</span><span style="color: #808080;">&gt;</span>
+<div class="highlight" style="background:rgb(24, 28, 29); border-radius: 8px; padding: 1rem; overflow-x: auto;"><pre style="line-height: 125%; color: #d4d4d4; margin: 0;"><span></span>&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">post</span> <span style="color: #4ec9b0;">add</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#param</span> <span style="color: #9cdcfe;">text</span> <span style="color: #dcdcaa;">maxlength</span>=<span style="color: #ce9178;">100</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">current_total</span> = <span style="color: #4fc1ff; font-weight: bold;">COUNT</span>(*) <span style="color: #c586c0; font-weight: bold;">from</span> todos&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#if</span> <span style="color: #9cdcfe;">:current_total</span> &lt; <span style="color: #ce9178;">20</span>&#125;&#125;
+    &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#insert</span> <span style="color: #c586c0; font-weight: bold;">into</span> todos(text) <span style="color: #c586c0; font-weight: bold;">values</span> (<span style="color: #9cdcfe;">:text</span>)&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">/if</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">post</span> <span style="color: #9cdcfe;">:id</span>/<span style="color: #4ec9b0;">toggle</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#update</span> todos <span style="color: #c586c0; font-weight: bold;">set</span> completed = <span style="color: #ce9178;">1</span> - completed <span style="color: #c586c0; font-weight: bold;">WHERE</span> id = <span style="color: #9cdcfe;">:id</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">patch</span> <span style="color: #9cdcfe;">:id</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#param</span> <span style="color: #9cdcfe;">text</span> <span style="color: #dcdcaa;">maxlength</span>=<span style="color: #ce9178;">100</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#update</span> todos <span style="color: #c586c0; font-weight: bold;">set</span> text = <span style="color: #9cdcfe;">:text</span> <span style="color: #c586c0; font-weight: bold;">WHERE</span> id = <span style="color: #9cdcfe;">:id</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">post</span> <span style="color: #4ec9b0;">toggle_all</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#let</span> <span style="color: #9cdcfe;">active_count</span> = <span style="color: #4fc1ff; font-weight: bold;">COUNT</span>(*) <span style="color: #c586c0; font-weight: bold;">from</span> todos <span style="color: #c586c0; font-weight: bold;">WHERE</span> completed = <span style="color: #ce9178;">0</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#update</span> todos <span style="color: #c586c0; font-weight: bold;">set</span> completed = <span style="color: #4fc1ff; font-weight: bold;">IIF</span>(<span style="color: #9cdcfe;">:active_count</span> = <span style="color: #ce9178;">0</span>, <span style="color: #ce9178;">0</span>, <span style="color: #ce9178;">1</span>)&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">delete</span> <span style="color: #9cdcfe;">:id</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#delete</span> <span style="color: #c586c0; font-weight: bold;">from</span> todos <span style="color: #c586c0; font-weight: bold;">WHERE</span> id = <span style="color: #9cdcfe;">:id</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+
+
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">#partial</span> <span style="color: #dcdcaa;">post</span> <span style="color: #4ec9b0;">clear_completed</span>&#125;&#125;
+  &#123;&#123;<span style="color: #569cd6; font-weight: bold;">#delete</span> <span style="color: #c586c0; font-weight: bold;">from</span> todos <span style="color: #c586c0; font-weight: bold;">WHERE</span> completed = <span style="color: #ce9178;">1</span>&#125;&#125;
+&#123;&#123;<span style="color: #569cd6; font-weight: bold;">/partial</span>&#125;&#125;
+</pre></div>
+    </div>
+</div>
+
+  <script>
+    function copySourceCode(button) {
+      const codeBlock = button.parentElement.querySelector('pre');
+      const textToCopy = codeBlock.textContent;
+      
+      navigator.clipboard.writeText(textToCopy).then(() => {
+        const originalHTML = button.innerHTML;
+        button.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"></path></svg>';
+        button.style.background = 'rgba(56, 161, 105, 0.5)';
+        
+        setTimeout(() => {
+          button.innerHTML = originalHTML;
+          button.style.background = 'rgba(255,255,255,0.15)';
+        }, 2000);
+      });
+    }
+
+    function makeCodeClickable() {
+      const codeBlock = document.querySelector('.highlight pre');
+      if (codeBlock) {
+        codeBlock.style.cursor = 'pointer';
+        codeBlock.addEventListener('click', () => {
+          const text = codeBlock.textContent;
+          navigator.clipboard.writeText(text).then(() => {
+            const copyButton = document.querySelector('button[onclick*="copySourceCode"]');
+            const originalHTML = copyButton.innerHTML;
+            copyButton.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6L9 17l-5-5"></path></svg>';
+            copyButton.style.background = 'rgba(56, 161, 105, 0.5)';
+            
+            setTimeout(() => {
+              copyButton.innerHTML = originalHTML;
+              copyButton.style.background = 'rgba(255,255,255,0.15)';
+            }, 2000);
+          });
+        });
+      }
+    }
+
+    // Initialize when DOM is loaded
+    document.addEventListener('DOMContentLoaded', makeCodeClickable);
+  </script>
+</body>
+</html>
+{{#partial post add}}
+  {{#param text maxlength=100}}
+  {{#let current_total = COUNT(*) from todos}}
+  {{#if :current_total < 20}}
+    {{#insert into todos(text) values (:text)}}
+  {{/if}}
+{{/partial}}
+
+{{#partial post :id/toggle}}
+  {{#update todos set completed = 1 - completed WHERE id = :id}}
+{{/partial}}
+
+{{#partial patch :id}}
+  {{#param text maxlength=100}}
+  {{#update todos set text = :text WHERE id = :id}}
+{{/partial}}
+
+{{#partial post toggle_all}}
+  {{#let active_count = COUNT(*) from todos WHERE completed = 0}}
+  {{#update todos set completed =  IIF(:active_count = 0, 0, 1)}}
+{{/partial}}
+
+{{#partial delete :id}}
+  {{#delete from todos WHERE id = :id}}
+{{/partial}}
+
+{{#partial post clear_completed}}
+  {{#delete from todos WHERE completed = 1}}
+{{/partial}}


### PR DESCRIPTION
## Summary
- duplicate todos example page as `todos_ordered.pageql`
- order todos by text rather than insertion order
- add regression test ensuring the tasks are sorted alphabetically

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d893a20a4832fb24ddb761ee493cf