### PR TITLE
Add failing reactive order test

### DIFF
--- a/tests/test_todos_ordered_page.py
+++ b/tests/test_todos_ordered_page.py
@@ -6,6 +6,7 @@ sys.path.insert(0, "src")
 from pathlib import Path
 from pageql.pageql import PageQL
 
+
 def test_todos_ordered_by_text():
     src = Path("website/todos_ordered.pageql").read_text()
     r = PageQL(":memory:")
@@ -15,5 +16,18 @@ def test_todos_ordered_by_text():
     )
     r.db.execute("INSERT INTO todos(text) VALUES ('b'), ('a')")
     result = r.render("/todos_ordered", reactive=False)
+    body = result.body
+    assert body.index(">a</label>") < body.index(">b</label>")
+
+
+def test_todos_ordered_by_text_reactive():
+    src = Path("website/todos_ordered.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("todos_ordered", src)
+    r.db.execute(
+        "CREATE TABLE IF NOT EXISTS todos(id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT NOT NULL, completed INTEGER DEFAULT 0 CHECK(completed IN (0,1)))"
+    )
+    r.db.execute("INSERT INTO todos(text) VALUES ('b'), ('a')")
+    result = r.render("/todos_ordered", reactive=True)
     body = result.body
     assert body.index(">a</label>") < body.index(">b</label>")


### PR DESCRIPTION
## Summary
- demonstrate sorting issue for `/todos_ordered` page when rendered reactively

## Testing
- `pytest tests/test_todos_ordered_page.py::test_todos_ordered_by_text_reactive -vv --color=no` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685da42542bc832fb92f17cb6806823b