### PR TITLE
Fix order update test

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -801,7 +801,7 @@ def test_order_by_update_with_limit_reorders_rows():
         f"<script>pstart('0_{h2}')</script>[2:2]<script>pend('0_{h2}')</script>\n"
         f"<script>pend(0)</script>"
         f"<script>pinsert('0_{h3_new}',\"[3:0]\")</script>"
-        f"<script>porderupdate(0,0,1)</script>"
+        f"<script>porderupdate(0,2,0)</script>"
         f"<script>pdelete('0_{h2}')</script>"
     )
     assert result.body == expected


### PR DESCRIPTION
## Summary
- adjust expected script for order update when row enters a limited result set

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685dc0a12314832fb615f873282f5182