### PR TITLE
Add failing test for Order listener removal bug

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -892,6 +892,13 @@ class Order(Signal):
             for l in self.listeners:
                 l(ev)
 
+    def remove_listener(self, listener):
+        if listener in self.listeners:
+            self.listeners.remove(listener)
+        if not self.listeners:
+            self.parent.remove_listener(self.onevent)
+            self.listeners = None
+
     def _fetch_rows(self):
         cur = execute(self.conn, self.sql, [])
         return list(cur.fetchall())

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1193,3 +1193,20 @@ def test_order_update_row_outside_limit():
 
     rt.update("UPDATE items SET id=4 WHERE id=2", {})
     assert ordered.value == [(1, "a"), (3, "c")]
+
+
+def test_order_event_after_last_listener_removed():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT)")
+    rt = ReactiveTable(conn, "items")
+    ordered = Order(rt, "id")
+
+    cb = lambda _=None: None
+    ordered.listeners.append(cb)
+    ordered.remove_listener(cb)
+
+    assert ordered.listeners is None
+    assert ordered.onevent not in (rt.listeners or [])
+
+    rt.insert("INSERT INTO items(name) VALUES ('x')", {})
+    assert ordered.value == []


### PR DESCRIPTION
## Summary
- add regression test capturing issue where `Order` continues listening after its last listener is removed
- detach `Order.onevent` from parent when the signal has no more listeners

## Testing
- `PYTHONPATH=src pytest tests/test_reactive.py::test_order_event_after_last_listener_removed -vv`

------
https://chatgpt.com/codex/tasks/task_e_685eacff132c832f96a640aedd075bbf