### PR TITLE
Add #attach directive

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -78,6 +78,7 @@ DIRECTIVE_HELP: dict[str, str] = {
     "#insert into <table> (cols) values (vals)": "execute an SQL INSERT",
     "#log <message>": "log a message",
     "#merge <sql>": "execute an SQL MERGE",
+    "#attach database <db> as <name>": "attach a SQLite database",
     "#param <name> [type] [attrs]": "declare and validate a request parameter",
     "#partial <name>": "define a reusable partial block",
     "#reactive on|off": "toggle reactive rendering mode",
@@ -643,6 +644,16 @@ class PageQL:
         _run_sql(lambda sql, p: db_execute_dot(self.db, sql, p), node_type, node_content, params)
         return reactive
 
+    def _process_attach_directive(self, node_content, params, path, includes,
+                                  http_verb, reactive, ctx):
+        _run_sql(
+            lambda sql, p: db_execute_dot(self.db, sql, p),
+            "#attach",
+            node_content,
+            params,
+        )
+        return reactive
+
     def _process_import_directive(self, node_content, params, path, includes,
                                   http_verb, reactive, ctx):
         parts = node_content.split()
@@ -1101,6 +1112,8 @@ class PageQL:
                 return self._process_cookie_directive(node_content, params, path, includes, http_verb, reactive, ctx)
             elif node_type == '#fetch':
                 return self._process_fetch_directive(node_content, params, path, includes, http_verb, reactive, ctx)
+            elif node_type == '#attach':
+                return self._process_attach_directive(node_content, params, path, includes, http_verb, reactive, ctx)
             elif node_type in ('#update', '#insert', '#delete'):
                 return self._process_update_directive(node_content, params, path, includes, http_verb, reactive, ctx, node_type)
             elif node_type in ('#create', '#merge'):

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -489,7 +489,7 @@ def ast_param_dependencies(ast):
                 deps.update(get_dependencies(_convert_dot_sql(c)))
             elif t == "#let":
                 deps.update(get_dependencies(_convert_dot_sql(c[1])))
-            elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#redirect", "#statuscode", "#error"}:
+            elif t in {"#update", "#insert", "#delete", "#merge", "#create", "#attach", "#redirect", "#statuscode", "#error"}:
                 deps.update(get_dependencies(_convert_dot_sql(c)))
             elif t == "#respond":
                 status_expr, body_expr = c

--- a/tests/test_attach_directive.py
+++ b/tests/test_attach_directive.py
@@ -1,0 +1,36 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast, ast_param_dependencies
+from pageql.pageql import PageQL
+import sqlite3
+
+
+def test_attach_directive_parsed():
+    tokens = tokenize("{{#attach database 'file.db' as other}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert body == [("#attach", "database 'file.db' as other")]
+
+
+def test_attach_directive_dependencies():
+    tokens = tokenize("{{#attach database :p as other}}")
+    ast = build_ast(tokens, dialect="sqlite")
+    deps = ast_param_dependencies(ast)
+    assert deps == {"p"}
+
+
+def test_attach_directive_render(tmp_path):
+    other = tmp_path / "other.db"
+    conn = sqlite3.connect(other)
+    conn.execute("create table t(x int)")
+    conn.execute("insert into t values (1)")
+    conn.commit()
+    conn.close()
+
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#attach database :p as other}}{{count(*) from other.t}}")
+    out = r.render("/m", {"p": str(other)}, reactive=False).body.strip()
+    assert out == "1"
+


### PR DESCRIPTION
## Summary
- add `#attach database` directive help description
- implement `_process_attach_directive`
- parse attach parameters in dependency analysis
- call new directive from node processor
- test attach directive parsing, dependencies and rendering

## Testing
- `pytest -k attach -vv`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685f97dffd44832fa48572c707d80b7a