### PR TITLE
Support parsing 'infinite' option for #from

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -852,8 +852,8 @@ class PageQL:
     def _process_from_directive(self, node, params, path, includes,
                                 http_verb, reactive, ctx):
         query, expr = node[1]
-        if len(node) == 4:
-            _, _, deps, body = node
+        if len(node) >= 4 and isinstance(node[2], set):
+            _, _, deps, body = node[:4]
         else:
             body = node[2]
 
@@ -898,7 +898,7 @@ class PageQL:
         saved_params = params.copy()
         extra_cache_key = ""
         if ctx and reactive:
-            dep_set = deps if len(node) == 4 else set()
+            dep_set = deps if len(node) >= 4 and isinstance(node[2], set) else set()
             extra_params = sorted(d for d in dep_set if d not in col_names)
             if extra_params:
                 extra_cache_values = {}

--- a/tests/test_from_infinite.py
+++ b/tests/test_from_infinite.py
@@ -1,0 +1,15 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.parser import tokenize, build_ast
+
+
+def test_from_parses_infinite_keyword():
+    tokens = tokenize("{{#from items infinite}}{{/from}}")
+    body, _ = build_ast(tokens, dialect="sqlite")
+    node = body[0]
+    assert node[0] == "#from"
+    assert node[4] is True
+    assert node[1][0] == "items"


### PR DESCRIPTION
## Summary
- extend `#from` parsing to optionally accept an `infinite` keyword
- keep this new flag on the AST but currently ignore it during execution
- adjust reactive element helpers and dependency collection
- add regression test for `infinite` parsing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ff9bebf1c832f81c7e8b71d973af9