### PR TITLE
Add infinite scroll page with infinite keyword

### DIFF
--- a/tests/test_infinite_scroll_infinite_page.py
+++ b/tests/test_infinite_scroll_infinite_page.py
@@ -1,0 +1,25 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pathlib import Path
+from pageql.parser import tokenize, build_ast
+
+
+def _has_infinite_from(nodes):
+    for node in nodes:
+        if isinstance(node, list):
+            if node[0] == "#from" and len(node) > 4 and node[4] is True:
+                return True
+            for item in node:
+                if isinstance(item, list) and _has_infinite_from([item]):
+                    return True
+    return False
+
+
+def test_infinite_scroll_infinite_page_parses_with_infinite():
+    src = Path("website/infinite_scroll_infinite.pageql").read_text()
+    tokens = tokenize(src)
+    body, _ = build_ast(tokens, dialect="sqlite")
+    assert _has_infinite_from(body)

--- a/website/infinite_scroll_infinite.pageql
+++ b/website/infinite_scroll_infinite.pageql
@@ -1,0 +1,13 @@
+{{#showsource}}
+
+<div id="list">
+{{#let f = 100}}
+{{#from (
+  WITH RECURSIVE numbers AS (
+    Select 1 as n
+    UNION ALL SELECT n+1 FROM numbers WHERE n < 1000
+  ) SELECT n FROM numbers
+) limit :f,100 infinite}}
+  {{n}}<br>
+{{/from}}
+</div>


### PR DESCRIPTION
## Summary
- add a new example page `infinite_scroll_infinite.pageql` using the `infinite` keyword instead of `hx-get`
- add a unit test ensuring the new page parses and includes a `#from` node marked as infinite

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68602cba942c832f8933eaebde1f0362