### PR TITLE
Add scroll event load more script

### DIFF
--- a/tests/test_scroll_load_more_js.py
+++ b/tests/test_scroll_load_more_js.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_scroll_script_has_core_logic():
+    src = Path("website/infinite_scroll_infinite.pageql").read_text()
+    assert "addEventListener('scroll'" in src
+    assert "console.log('load more')" in src
+    assert "canLoadMore = false" in src

--- a/website/infinite_scroll_infinite.pageql
+++ b/website/infinite_scroll_infinite.pageql
@@ -11,3 +11,17 @@
   {{n}}<br>
 {{/from}}
 </div>
+
+<script>
+let canLoadMore = true;
+function maybeLoadMore() {
+  if (!canLoadMore) return;
+  const scrollPosition = window.scrollY + window.innerHeight;
+  const threshold = document.documentElement.scrollHeight - 150;
+  if (scrollPosition >= threshold) {
+    console.log('load more');
+    canLoadMore = false;
+  }
+}
+window.addEventListener('scroll', maybeLoadMore);
+</script>


### PR DESCRIPTION
## Summary
- add a small browser script to log "load more" on scroll
- check that the script contains expected logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68602f0a026c832fbb4a6dc3351dd0bf