### PR TITLE
Log mid for infinite #from

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -937,6 +937,8 @@ class PageQL:
 
         if ctx and reactive:
             ctx.append_script(f"pend({mid})")
+            if len(node) > 4 and node[4]:
+                ctx.append_script(f"console.log('infinite ' + {mid})")
 
             def on_event(ev, *, mid=mid, ctx=ctx,
                            body=body, col_names=col_names, path=path,

--- a/tests/test_from_infinite_console.py
+++ b/tests/test_from_infinite_console.py
@@ -1,0 +1,19 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL, _row_hash
+
+
+def test_infinite_from_logs_mid_after_pend():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#from (select 1 as id) infinite}}{{id}}{{/from}}")
+    result = r.render("/m")
+    h = _row_hash((1,))
+    expected = (
+        f"<script>pstart(0)</script>"
+        f"<script>pstart('0_{h}')</script>1<script>pend('0_{h}')</script>\n"
+        f"<script>pend(0)</script><script>console.log('infinite ' + 0)</script>"
+    )
+    assert result.body == expected


### PR DESCRIPTION
## Summary
- log to console when rendering an `#from` loop marked `infinite`
- test that the console log is present after the closing tag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860303a4eec832facfaf47b618cd8b5