### PR TITLE
Implement infinite #from order wrapping

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -875,6 +875,13 @@ class PageQL:
                 comp = parse_reactive(expr, self.tables, params)
                 if cache_allowed:
                     self._from_cache[cache_key] = comp
+            if (
+                len(node) > 4
+                and node[4]
+                and not isinstance(comp, Order)
+                and hasattr(comp, "conn")
+            ):
+                comp = Order(comp, "", limit=100)
             try:
                 cursor = self.db.execute(comp.sql, converted_params)
             except sqlite3.Error as e:


### PR DESCRIPTION
## Summary
- ensure infinite #from wraps results in an `Order` with default limit if needed
- keep output reactive when wrapping

## Testing
- `pytest tests/test_from_infinite.py tests/test_from_infinite_console.py -q`
- `pytest tests/test_infinite_scroll.py tests/test_infinite_scroll_infinite_page.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860321a8764832f9c2556ff71001cb8