### PR TITLE
Implement infinite_load_more event support

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -852,6 +852,7 @@ class PageQL:
     def _process_from_directive(self, node, params, path, includes,
                                 http_verb, reactive, ctx):
         query, expr = node[1]
+        infinite = node[4] if len(node) > 4 else False
         if len(node) >= 4 and isinstance(node[2], set):
             _, _, deps, body = node[:4]
         else:
@@ -895,6 +896,8 @@ class PageQL:
             ctx.append_script(f"pstart({mid})")
             if isinstance(comp, Order):
                 order_mid = ctx.marker_id()
+            if infinite and isinstance(comp, Order):
+                ctx.infinites[mid] = comp
         saved_params = params.copy()
         extra_cache_key = ""
         if ctx and reactive:

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -341,6 +341,18 @@ class PageQLApp:
                         fut_waiter = self._body_waiters.pop(client_id)
                         if not fut_waiter.done():
                             fut_waiter.set_result(result.get("text", ""))
+                    if client_id:
+                        text = result.get("text", "")
+                        if text.startswith("infinite_load_more"):
+                            try:
+                                mid = int(text.split()[1])
+                            except Exception:
+                                mid = None
+                            if mid is not None:
+                                for ctx in self.render_contexts.get(client_id, []):
+                                    comp = ctx.infinites.get(mid)
+                                    if comp is not None and comp.limit is not None:
+                                        comp.set_limit(comp.limit + 100)
                     receive_task = asyncio.create_task(receive())
                     continue
                 if isinstance(result, dict) and result.get("type") == "websocket.disconnect":

--- a/src/pageql/render_context.py
+++ b/src/pageql/render_context.py
@@ -41,6 +41,7 @@ class RenderContext:
         self.reactiveelement = None
         self.headers: list[tuple[str, str]] = []
         self.cookies: list[tuple[str, str, dict]] = []
+        self.infinites: dict[int, object] = {}
 
     def marker_id(self) -> int:
         mid = self.next_id

--- a/tests/test_infinite_load_more.py
+++ b/tests/test_infinite_load_more.py
@@ -1,0 +1,70 @@
+import sqlite3
+from pathlib import Path
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+import asyncio
+import pytest
+import pageql.pageqlapp
+from pageql.pageql import PageQL, RenderContext
+from pageql.reactive import ReactiveTable, Order
+
+
+def test_infinite_from_adds_order_to_context():
+    page = """
+    {{#create table items(id INTEGER)}}
+    {{#insert into items(id) values (1)}}
+    <div>
+    {{#from items order by id limit 1 infinite}}
+      {{id}}
+    {{/from}}
+    </div>
+    """
+    r = PageQL(":memory:")
+    r.load_module("test", page)
+    result = r.render("/test")
+    ctx = result.context
+    assert len(ctx.infinites) == 1
+    order = list(ctx.infinites.values())[0]
+    assert isinstance(order, Order)
+    assert order.limit == 1
+
+
+def test_pageqlapp_handles_infinite_load_more(tmp_path):
+    app = pageql.pageqlapp.PageQLApp(":memory:", tmp_path, create_db=True, should_reload=False)
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE items(id INTEGER)")
+    conn.executemany("INSERT INTO items(id) VALUES (?)", [(1,), (2,), (3,)])
+    rt = ReactiveTable(conn, "items")
+    order = Order(rt, "id", limit=1)
+
+    ctx = RenderContext()
+    mid = ctx.marker_id()
+    ctx.infinites[mid] = order
+    app.render_contexts["cid"].append(ctx)
+
+    messages = [
+        {"type": "websocket.connect"},
+        {"type": "websocket.receive", "text": f"infinite_load_more {mid}"},
+        {"type": "websocket.disconnect"},
+    ]
+
+    sent = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    async def receive():
+        return messages.pop(0)
+
+    scope = {"type": "websocket", "path": "/reload-request-ws", "query_string": b"clientId=cid"}
+
+    async def run_ws():
+        await app._handle_reload_websocket(scope, receive, send)
+
+    asyncio.run(run_ws())
+
+    assert order.limit == 101


### PR DESCRIPTION
## Summary
- track infinite lists in `RenderContext`
- store `Order` comps for infinite `#from` directives
- respond to `infinite_load_more` websocket event by extending the limit
- test new infinite scroll behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686030e6edd4832f853118e583fa5d03