### PR TITLE
Use websocket for infinite scroll trigger

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -948,7 +948,9 @@ class PageQL:
         if ctx and reactive:
             ctx.append_script(f"pend({mid})")
             if len(node) > 4 and node[4]:
-                ctx.append_script(f"console.log('infinite ' + {mid})")
+                ctx.append_script(
+                    f"maybe_load_more(document.body, {mid})"
+                )
 
             def on_event(ev, *, mid=mid, ctx=ctx,
                            body=body, col_names=col_names, path=path,

--- a/tests/test_from_infinite_console.py
+++ b/tests/test_from_infinite_console.py
@@ -14,6 +14,6 @@ def test_infinite_from_logs_mid_after_pend():
     expected = (
         f"<script>pstart(0)</script>"
         f"<script>pstart('0_{h}')</script>1<script>pend('0_{h}')</script>\n"
-        f"<script>pend(0)</script><script>console.log('infinite ' + 0)</script>"
+        f"<script>pend(0)</script><script>maybe_load_more(document.body, 0)</script>"
     )
     assert result.body == expected


### PR DESCRIPTION
## Summary
- call `maybe_load_more` when `#from ... infinite` is rendered
- update infinite scroll test for new behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860419ce20c832f8047c9dc0463cb99