### PR TITLE
Wrap infinite results in Order

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -876,12 +876,7 @@ class PageQL:
                 comp = parse_reactive(expr, self.tables, params)
                 if cache_allowed:
                     self._from_cache[cache_key] = comp
-            if (
-                len(node) > 4
-                and node[4]
-                and not isinstance(comp, Order)
-                and hasattr(comp, "conn")
-            ):
+            if infinite and not isinstance(comp, Order) and hasattr(comp, "conn"):
                 comp = Order(comp, "", limit=100)
             try:
                 cursor = self.db.execute(comp.sql, converted_params)

--- a/tests/test_from_infinite_wraps_order.py
+++ b/tests/test_from_infinite_wraps_order.py
@@ -1,0 +1,27 @@
+import types, sys
+sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
+sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+sys.path.insert(0, "src")
+
+from pageql.pageql import PageQL
+from pageql.reactive import Order
+
+
+def test_infinite_from_wraps_order_limit_100():
+    page = """
+    {{#create table items(id INTEGER)}}
+    {{#insert into items(id) values (1)}}
+    <div>
+    {{#from items infinite}}
+      {{id}}
+    {{/from}}
+    </div>
+    """
+    r = PageQL(":memory:")
+    r.load_module("test", page)
+    result = r.render("/test")
+    ctx = result.context
+    assert len(ctx.infinites) == 1
+    order = list(ctx.infinites.values())[0]
+    assert isinstance(order, Order)
+    assert order.limit == 100


### PR DESCRIPTION
## Summary
- change infinite `#from` queries so their components get wrapped in an `Order`
- add regression test for the new behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6860fb8f5ec8832fb1c66dae1b0b5939