### PR TITLE
Fix infinite FROM handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -873,7 +873,7 @@ class PageQL:
             cache_allowed = "randomblob" not in cache_key.lower()
             comp = self._from_cache.get(cache_key) if cache_allowed else None
             if comp is None or not comp.listeners:
-                comp = parse_reactive(expr, self.tables, params)
+                comp = parse_reactive(expr, self.tables, params, force_reactive=infinite)
                 if cache_allowed:
                     self._from_cache[cache_key] = comp
             if infinite and not isinstance(comp, Order) and hasattr(comp, "conn"):

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -270,6 +270,7 @@ def parse_reactive(
     *,
     cache: bool = True,
     one_value: bool = False,
+    force_reactive: bool = False,
 ):
     """Parse a SQL ``Expression`` into reactive components.
 
@@ -291,11 +292,11 @@ def parse_reactive(
             return comp
 
     # If the expression references no tables (ignoring CTEs) the result is
-    # constant, so return a simple ReadOnly wrapper instead of a reactive
-    # component.
+    # constant. Unless *force_reactive* is True, return a simple ReadOnly
+    # wrapper instead of a reactive component.
     cte_names = {c.alias_or_name for c in expr.find_all(exp.CTE)}
     table_refs = [t for t in expr.find_all(exp.Table) if t.name not in cte_names]
-    if not table_refs:
+    if not table_refs and not force_reactive:
         cur = execute(tables.conn, sql, [])
         if one_value:
             row = cur.fetchone()

--- a/tests/test_from_infinite_console.py
+++ b/tests/test_from_infinite_console.py
@@ -3,17 +3,28 @@ sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
-from pageql.pageql import PageQL, _row_hash
+from pageql.pageql import PageQL
+from pageql.reactive import Order
 
 
 def test_infinite_from_logs_mid_after_pend():
     r = PageQL(":memory:")
     r.load_module("m", "{{#from (select 1 as id) infinite}}{{id}}{{/from}}")
     result = r.render("/m")
-    h = _row_hash((1,))
     expected = (
-        f"<script>pstart(0)</script>"
-        f"<script>pstart('0_{h}')</script>1<script>pend('0_{h}')</script>\n"
-        f"<script>pend(0)</script><script>maybe_load_more(document.body, 0)</script>"
+        "<script>pstart(0)</script>"
+        "<script>pstart(1)</script>1<script>pend(1)</script>\n"
+        "<script>pend(0)</script><script>maybe_load_more(document.body, 0)</script>"
     )
     assert result.body == expected
+
+
+def test_infinite_from_constant_adds_order():
+    r = PageQL(":memory:")
+    r.load_module("m", "{{#from (select 1 as id) infinite}}{{id}}{{/from}}")
+    result = r.render("/m")
+    ctx = result.context
+    assert len(ctx.infinites) == 1
+    order = list(ctx.infinites.values())[0]
+    assert isinstance(order, Order)
+    assert order.limit == 100


### PR DESCRIPTION
## Summary
- avoid returning ReadOnly when `#from` uses `infinite`
- cache Order objects when processing `#from` with `infinite`
- cover constant infinite queries

## Testing
- `pytest` *(fails: test_infinite_scroll_in_browser)*

------
https://chatgpt.com/codex/tasks/task_e_68613b460f24832f9c5b95d66b7e45bf