### PR TITLE
Send infinite load more errors to client

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -5,6 +5,7 @@ import mimetypes
 import base64
 import markdown
 import html
+import json
 from urllib.parse import urlparse, parse_qs
 from watchfiles import awatch
 import uuid
@@ -348,17 +349,34 @@ class PageQLApp:
                                 mid = int(text.split()[1])
                             except Exception:
                                 mid = None
+                                err = (
+                                    f"Error: infinite_load_more: {client_id} invalid message '{text}'"
+                                )
+                                print(err)
+                                queue_ws_script(
+                                    send, f"console.error({json.dumps(err)})", self.log_level
+                                )
                             if self.log_level == "debug":
                                 print(f"infinite_load_more: {client_id} mid: {mid}")
                             if mid is not None:
                                 for ctx in self.render_contexts.get(client_id, []):
                                     comp = ctx.infinites.get(mid)
                                     if not comp:
-                                        print(f"Error: infinite_load_more: {client_id} mid: {mid} not found, possible infinites: {ctx.infinites.keys()}")
+                                        err = (
+                                            f"Error: infinite_load_more: {client_id} mid: {mid} not found, possible infinites: {ctx.infinites.keys()}"
+                                        )
+                                        print(err)
+                                        queue_ws_script(
+                                            send,
+                                            f"console.error({json.dumps(err)})",
+                                            self.log_level,
+                                        )
                                         continue
                                     if comp is not None and comp.limit is not None:
                                         if self.log_level == "debug":
-                                            print(f"infinite_load_more set_limit: {client_id} mid: {mid} limit: {comp.limit}")
+                                            print(
+                                                f"infinite_load_more set_limit: {client_id} mid: {mid} limit: {comp.limit}"
+                                            )
                                         comp.set_limit(comp.limit + 100)
                     receive_task = asyncio.create_task(receive())
                     continue


### PR DESCRIPTION
## Summary
- return websocket errors when `infinite_load_more` messages are invalid
- test websocket error handling

## Testing
- `PYTHONPATH=src pytest tests/test_infinite_load_more.py::test_infinite_load_more_error_sends_ws -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6861a69e674c832f8e1f03f822663b22