### PR TITLE
Fix index calculation for order inserts

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -996,14 +996,14 @@ class Order(Signal):
                 offset -= i2 - i1
             elif tag == "insert":
                 for idx in range(j1, j2):
-                    events.append([1, i1 + offset, new[idx]])
+                    events.append([1, i1 + offset + (idx - j1), new[idx]])
                 offset += j2 - j1
             else:
                 for idx in range(i1, i2):
                     events.append([2, idx + offset])
                 offset -= i2 - i1
                 for idx in range(j1, j2):
-                    events.append([1, i1 + offset, new[idx]])
+                    events.append([1, i1 + offset + (idx - j1), new[idx]])
                 offset += j2 - j1
         return events
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1149,7 +1149,7 @@ def test_order_set_limit():
     seen.clear()
     ordered.set_limit(None)
     assert ordered.value == [(1, "a"), (2, "b"), (3, "c")]
-    assert seen == [[1, 1, (2, "b")], [1, 1, (3, "c")]]
+    assert seen == [[1, 1, (2, "b")], [1, 2, (3, "c")]]
 
 
 def test_one_value_with_order():


### PR DESCRIPTION
## Summary
- fix Order._diff_patch so insert indices increment correctly
- update reactive test to verify indices

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862cb0b7b34832f85e261c3847c7fc9