### PR TITLE
Fix infinite scroll watcher reset

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -378,6 +378,11 @@ class PageQLApp:
                                                 f"infinite_load_more set_limit: {client_id} mid: {mid} limit: {comp.limit}"
                                             )
                                         comp.set_limit(comp.limit + 100)
+                                        queue_ws_script(
+                                            send,
+                                            f"maybe_load_more(document.body, {mid})",
+                                            self.log_level,
+                                        )
                     receive_task = asyncio.create_task(receive())
                     continue
                 if isinstance(result, dict) and result.get("type") == "websocket.disconnect":


### PR DESCRIPTION
## Summary
- send a `maybe_load_more` script after processing an `infinite_load_more` request
- test that the websocket sends the reset script

## Testing
- `PYTHONPATH=src pytest -k infinite_load_more -vv`
- `PYTHONPATH=src pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_6862cb5cf570832f8e0d054da0107e4d