### PR TITLE
Fix async fetch browser test

### DIFF
--- a/tests/playwright_helpers.py
+++ b/tests/playwright_helpers.py
@@ -80,6 +80,7 @@ async def _load_page_async(
         body = None
 
     status = response.status if response is not None else None
-    body = strip_not_none(await app.get_text_body(client_id))
+    if body is None and client_id:
+        body = strip_not_none(await app.get_text_body(client_id))
 
     return status, body, client_id


### PR DESCRIPTION
## Summary
- avoid overwriting fetched body text when loading pages

## Testing
- `pytest tests/test_browser_integration.py::test_fetch_async_directive_in_browser -vv`

------
https://chatgpt.com/codex/tasks/task_e_6863a5a8d088832faa36853e8e972888