### PR TITLE
Support semicolon separated directives

### DIFF
--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -31,3 +31,10 @@ def test_tokenize_skip_block_comments_with_braces():
         ("text", "Hello "),
         ("text", "World"),
     ]
+
+
+def test_tokenize_joined_directives():
+    assert tokenize("{%param a; param b%}") == [
+        ("#param", "a"),
+        ("#param", "b"),
+    ]


### PR DESCRIPTION
## Summary
- allow multiple directives inside `{% ... %}` by splitting on `;`
- test tokenization of joined directives

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6863a67cb180832fa3dcf407a9a50af0