### PR TITLE
Fix tokenize test syntax

### DIFF
--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -35,7 +35,10 @@ def test_tokenize_skip_block_comments_with_braces():
 
 def test_tokenize_sql_comment_in_directive():
     assert tokenize("{%let x=1 -- comment\n%}") == [
-        ("#let", "x=1")
+        ("#let", "x=1"),
+    ]
+
+
 def test_tokenize_joined_directives():
     assert tokenize("{%param a; param b%}") == [
         ("#param", "a"),


### PR DESCRIPTION
## Summary
- fix `tests/test_tokenize.py`

## Testing
- `pytest tests/test_tokenize.py`

------
https://chatgpt.com/codex/tasks/task_e_6863aabc521c832fab516d5fcf9c0f08