### PR TITLE
Increase pytest timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ Issues = "https://github.com/adamritter/pageql/issues"
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore=examples"
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
-timeout = 2
+timeout = 5


### PR DESCRIPTION
## Summary
- update PyTest timeout setting to give tests more time

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6863b4dc0d84832fb2dedc9211cc8bf8