### PR TITLE
Switch PageQL comment syntax

### DIFF
--- a/examples/templates/basic_auth.pageql
+++ b/examples/templates/basic_auth.pageql
@@ -12,7 +12,7 @@
 {%insert or ignore into users(id, username, password) values (1, 'alice', 'password')%}
 {%insert or ignore into users(id, username, password) values (2, 'bob', 'pass')%}
 
-{{!-- Helper to load the logged in user from session cookie --}}
+{%-- Helper to load the logged in user from session cookie --%}
 {%param session optional%}
 {%let user_id = user_id from sessions where token=:session%}
 {%let username = username from users where id=:user_id%}

--- a/examples/templates/todos.pageql
+++ b/examples/templates/todos.pageql
@@ -26,7 +26,7 @@
 {%param edit_id optional%}
 {%param filter default='all' pattern="^(all|active|completed)$"%}
 
-{{!-- Ensure the table exists (harmless if already created) --}}
+{%-- Ensure the table exists (harmless if already created) --%}
 {%create table if not exists todos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,

--- a/examples/templates/todos_noreactive.pageql
+++ b/examples/templates/todos_noreactive.pageql
@@ -1,66 +1,66 @@
 
 
-{{!-- ============================================= --}}
-{{!--          ACTION PARTIALS (CRUD etc.)        --}}
-{{!-- ============================================= --}}
+{%-- ============================================= --%}
+{%--          ACTION PARTIALS (CRUD etc.)        --%}
+{%-- ============================================= --%}
 {%reactive off%}
 
-{{!-- Add a new Todo --}}
+{%-- Add a new Todo --%}
 {%partial public add%}
   {%param text required minlength=0%}
   {%insert into todos (text, completed) values (:text, 0)%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
-{{!-- Delete a Todo --}}
+{%-- Delete a Todo --%}
 {%partial public delete%}
   {%param id required type=integer min=1%}
   {%delete from todos WHERE id = :id%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
-{{!-- Toggle a single Todo's completion status --}}
+{%-- Toggle a single Todo's completion status --%}
 {%partial public toggle%}
   {%param id required type=integer min=1%}
   {%update todos set completed = 1 - completed WHERE id = :id%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
-{{!-- Save edited Todo text --}}
+{%-- Save edited Todo text --%}
 {%partial public save%}
   {%param id required type=integer min=1%}
   {%param text required minlength=1%}
-  {%param filter default='all'%} {{!-- Preserve filter for redirect --}}
+  {%param filter default='all'%} {%-- Preserve filter for redirect --%}
   {%update todos set text = :text WHERE id = :id%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
-{{!-- Delete all completed Todos --}}
+{%-- Delete all completed Todos --%}
 {%partial public clear_completed%}
-  {%param filter default='all'%} {{!-- Preserve filter for redirect --}}
+  {%param filter default='all'%} {%-- Preserve filter for redirect --%}
   {%delete from todos WHERE completed = 1%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
-{{!-- Toggle all Todos' completion status --}}
+{%-- Toggle all Todos' completion status --%}
 {%partial public toggle_all%}
-  {%param filter default='all'%} {{!-- Preserve filter for redirect --}}
-  {{!-- Check if all are currently complete to decide toggle direction --}}
+  {%param filter default='all'%} {%-- Preserve filter for redirect --%}
+  {%-- Check if all are currently complete to decide toggle direction --%}
   {%let :active_count = COUNT(*) from todos WHERE completed = 0%}
-  {%let :new_status = 1%} {{!-- Default to marking all complete --}}
-  {%if :active_count == 0%} {{!-- If none active, mark all incomplete --}}
+  {%let :new_status = 1%} {%-- Default to marking all complete --%}
+  {%if :active_count == 0%} {%-- If none active, mark all incomplete --%}
     {%let :new_status = 0%}
   {%endif%}
   {%update todos set completed = :new_status%}
-  {%redirect '/todos?filter=' || :filter%} {{!-- Redirect to base path --}}
+  {%redirect '/todos?filter=' || :filter%} {%-- Redirect to base path --%}
 {%endpartial%}
 
 
-{{!-- ============================================= --}}
-{{!--           MAIN DISPLAY PARTIAL              --}}
-{{!-- ============================================= --}}
+{%-- ============================================= --%}
+{%--           MAIN DISPLAY PARTIAL              --%}
+{%-- ============================================= --%}
 
-{{!-- Ensure the 'todos' table exists before proceeding --}}
+{%-- Ensure the 'todos' table exists before proceeding --%}
 {%create table if not exists todos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,
@@ -68,12 +68,12 @@
 )%}
 
 
-{{!-- Default view (maps to /todos), displays the list and handles edit state --}}
+{%-- Default view (maps to /todos), displays the list and handles edit state --%}
 {%param filter default='all' pattern="^(all|active|completed)$" optional%}
 {%param edit_id type=integer optional%}
 
 
-{{!-- Get counts for footer and toggle-all logic --}}
+{%-- Get counts for footer and toggle-all logic --%}
 {%let active_count = COUNT(*) from todos WHERE completed = 0%}
 {%let completed_count = COUNT(*) from todos WHERE completed = 1%}
 {%let total_count  = COUNT(*) from todos%}
@@ -101,7 +101,7 @@
     </form>
     </header>
 
-    {{!-- This section should be hidden if there are no todos --}}
+    {%-- This section should be hidden if there are no todos --%}
     {%if :total_count > 0%}
     <section class="main">
         <form method="POST" action="/todos/toggle_all" id="toggle-all-form" style="display: block;">
@@ -118,21 +118,21 @@
             <li {%if completed%}class="completed"{%endif%} {%if :edit_id == :id%}class="editing"{%endif%}>
 
             {%if :edit_id == :id%}
-                {{!-- Edit State --}}
+                {%-- Edit State --%}
                 <form method="POST" action="/todos/save" style="margin: 0; padding: 0; display: inline;">
                 <input type="hidden" name="id" value="{{id}}">
                 <input type="hidden" name="filter" value="{{filter}}">
                 <input class="edit" name="text" value="{{text}}" autofocus>
                 </form>
             {%else%}
-                {{!-- View State --}}
+                {%-- View State --%}
                 <div class="view">
                 <form method="POST" action="/todos/toggle" style="display: inline;">
                     <input type="hidden" name="id" value="{{id}}">
                     <input type="hidden" name="filter" value="{{filter}}">
                     <input class="toggle" type="checkbox" {%if completed%}checked{%endif%} onchange="this.form.submit();">
                 </form>
-                {{!-- Edit link points to base path --}}
+                {%-- Edit link points to base path --%}
                 <label ondblclick="window.location.href='/todos?filter={{filter}}&edit_id={{id}}'">{{text}}</label>
                     <form method="POST" action="/todos/delete" style="display: inline;">
                     <input type="hidden" name="id" value="{{id}}">
@@ -147,18 +147,18 @@
         </ul>
     </section>
 
-    {{!-- This footer should be hidden if there are no todos --}}
+    {%-- This footer should be hidden if there are no todos --%}
     <footer class="footer">
         <span class="todo-count"><strong>{{active_count}}</strong> item{%if :active_count != 1%}s{%endif%} left
          {%if :total_count > :active_count%}from {{ total_count}}{%endif%}</span>
        
         <ul class="filters">
-            {{!-- Filter links point to base path --}}
+            {%-- Filter links point to base path --%}
         <li><a {%if :filter == 'all'%}class="selected"{%endif%} href="/todos?filter=all">All</a></li>
         <li><a {%if :filter == 'active'%}class="selected"{%endif%} href="/todos?filter=active">Active</a></li>
         <li><a {%if :filter == 'completed'%}class="selected"{%endif%} href="/todos?filter=completed">Completed</a></li>
         </ul>
-        {{!-- This should be hidden if there are no completed todos --}}
+        {%-- This should be hidden if there are no completed todos --%}
         {%if :completed_count > 0%}
         <form method="POST" action="/todos/clear_completed" style="display: inline;">
             <input type="hidden" name="filter" value="{{filter}}">
@@ -166,7 +166,7 @@
         </form>
         {%endif%}
     </footer>
-    {%endif%} {{!-- End total_count > 0 --}}
+    {%endif%} {%-- End total_count > 0 --%}
 
 </section>
 <footer class="info">

--- a/src/pageql/highlighter.py
+++ b/src/pageql/highlighter.py
@@ -46,7 +46,7 @@ _HTML_ATTR = "#92c5f8;"
 _HTML_TAG = "#569cd6; font-weight: bold;"
 
 _TOKEN_SPLIT_RE = re.compile(
-    r"({{!--.*?--}}|{{{.*?}}}|{{.*?}}|{%.*?%}|<[^>\"']*(?:\"[^\"]*\"|'[^']*'|[^>\"']*)*>)",
+    r"({%--.*?--%}|{{!--.*?--}}|{{{.*?}}}|{{.*?}}|{%.*?%}|<[^>\"']*(?:\"[^\"]*\"|'[^']*'|[^>\"']*)*>)",
     re.DOTALL,
 )
 
@@ -142,6 +142,9 @@ def _highlight_pageql_expr(text: str) -> str:
 
 
 def _highlight_pageql(token: str) -> str:
+    if token.startswith('{%--'):
+        content = escape(token[4:-4])
+        return f"&#123;%{_span('--' + content + '--', _COMMENT_COLOR)}%&#125;"
     if token.startswith('{{!--'):
         content = escape(token[5:-4])
         return f"&#123;&#123;{_span('!--' + content + '--', _COMMENT_COLOR)}&#125;&#125;"

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -221,7 +221,7 @@ class PageQL:
             >>> r = PageQL(":memory:")
             >>> source_with_comment = '''
             ... Start Text.
-            ... {{!-- This is a comment --}}
+            ... {%-- This is a comment --%}
             ... End Text.
             ... '''
             >>> # Verify loading doesn't raise an error

--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -106,11 +106,11 @@ def tokenize(source):
         [('text', 'Count: '), ('render_raw', '1+1')]
         >>> tokenize("{%if x > 5%}Big{%endif%}")
         [('#if', 'x > 5'), ('text', 'Big'), ('#endif', None)]
-        >>> tokenize("{{!-- Comment --}}Visible")
+        >>> tokenize("{%-- Comment --%}Visible")
         [('text', 'Visible')]
     """
     nodes = []
-    parts = re.split(r'({{!--.*?--}}|{%.*?%}|{{.*?}}}?)', source, flags=re.DOTALL)
+    parts = re.split(r'({%--.*?--%}|{{!--.*?--}}|{%.*?%}|{{.*?}}}?)', source, flags=re.DOTALL)
     for part in parts:
         if not part:  # Skip empty strings from split
             continue

--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -26,7 +26,7 @@ __doc__ = """
 >>> source_with_comment = '''
 ... {%let :ww = 3+3%}
 ... Start Text.
-... {{!-- This is a comment --}}
+... {%-- This is a comment --%}
 ... {{ :hello }}
 ... {{ :ww + 4 }}
 ... {%partial public add%}

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -27,7 +27,7 @@ def test_tokenize_skip_comments():
 
 
 def test_tokenize_skip_block_comments_with_braces():
-    assert tokenize("Hello {{!-- comment with }} braces --}}World") == [
+    assert tokenize("Hello {%-- comment with }} braces --%}World") == [
         ("text", "Hello "),
         ("text", "World"),
     ]

--- a/website/basic_auth.pageql
+++ b/website/basic_auth.pageql
@@ -12,7 +12,7 @@
 {%insert or ignore into users(id, username, password) values (1, 'alice', 'password')%}
 {%insert or ignore into users(id, username, password) values (2, 'bob', 'pass')%}
 
-{{!-- Helper to load the logged in user from session cookie --}}
+{%-- Helper to load the logged in user from session cookie --%}
 {%param session optional%}
 {%let user_id = user_id from sessions where token=:session%}
 {%let username = username from users where id=:user_id%}

--- a/website/basic_auth_sessionless.pageql
+++ b/website/basic_auth_sessionless.pageql
@@ -7,7 +7,7 @@
 {%insert or ignore into users(id, username, password) values (1, 'alice', 'password')%}
 {%insert or ignore into users(id, username, password) values (2, 'bob', 'pass')%}
 
-{{!-- Load JWT from session cookie --}}
+{%-- Load JWT from session cookie --%}
 {%param cookies.session optional%}
 {%let payload = jws_deserialize_compact(:cookies.session)%}
 {%let uid = cast(json_extract(:payload, '$.uid') as integer)%}

--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -1,6 +1,6 @@
 {%param filter default='all' pattern="^(all|active|completed)$"%}
 
-{{!-- Ensure the table exists (harmless if already created) --}}
+{%-- Ensure the table exists (harmless if already created) --%}
 {%create table if not exists todos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,

--- a/website/todos_ordered.pageql
+++ b/website/todos_ordered.pageql
@@ -1,6 +1,6 @@
 {%param filter default='all' pattern="^(all|active|completed)$"%}
 
-{{!-- Ensure the table exists (harmless if already created) --}}
+{%-- Ensure the table exists (harmless if already created) --%}
 {%create table if not exists todos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,

--- a/website/todos_without_edit_id.pageql
+++ b/website/todos_without_edit_id.pageql
@@ -26,7 +26,7 @@
 {%param edit_id optional%}
 {%param filter default='all' pattern="^(all|active|completed)$"%}
 
-{{!-- Ensure the table exists (harmless if already created) --}}
+{%-- Ensure the table exists (harmless if already created) --%}
 {%create table if not exists todos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     text TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- switch line comments in *.pageql templates to `{%-- ... --%}`
- parse new comment syntax in the parser and highlighter
- update docstrings and unit tests for new syntax

## Testing
- `pytest tests/test_tokenize.py::test_tokenize_skip_block_comments_with_braces -vv`
- `pytest tests/test_highlighter.py::test_highlight_roundtrip -vv`
- `pytest tests/test_render_docstring.py::test_render_docstring -vv`
- `pytest` *(fails: Timeout in test_infinite_scroll_in_browser)*

------
https://chatgpt.com/codex/tasks/task_e_6863ba794f14832fb2b19351c9b352cc