### PR TITLE
Compact semicolon directives for todos

### DIFF
--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -7,10 +7,10 @@
     completed INTEGER DEFAULT 0 CHECK(completed IN (0,1))
 )%}
 
-{%let active_count    = COUNT(*) from todos WHERE completed = 0%}
-{%let completed_count = COUNT(*) from todos WHERE completed = 1%}
-{%let total_count     = COUNT(*) from todos%}
-{%let all_complete    = (:active_count == 0 AND :total_count > 0)%}
+{%let active_count    = COUNT(*) from todos WHERE completed = 0;
+   let completed_count = COUNT(*) from todos WHERE completed = 1;
+   let total_count     = COUNT(*) from todos;
+   let all_complete    = (:active_count == 0 AND :total_count > 0)%}
 
 
 <!doctype html>
@@ -107,32 +107,27 @@
 {%showsource%}
 </body>
 </html>
-{%partial post add%}
-  {%param text maxlength=100%}
-  {%let current_total = COUNT(*) from todos%}
-  {%if :current_total < 20%}
-    {%insert into todos(text) values (:text)%}
-  {%endif%}
+{%partial post add;
+   param text maxlength=100;
+   let current_total = COUNT(*) from todos;
+   if :current_total < 20;
+     insert into todos(text) values (:text);
+   endif%}
 {%endpartial%}
 
-{%partial post :id/toggle%}
-  {%update todos set completed = 1 - completed WHERE id = :id%}
+{%partial post :id/toggle; update todos set completed = 1 - completed WHERE id = :id%}
 {%endpartial%}
 
-{%partial patch :id%}
-  {%param text maxlength=100%}
-  {%update todos set text = :text WHERE id = :id%}
+{%partial patch :id; param text maxlength=100; update todos set text = :text WHERE id = :id%}
 {%endpartial%}
 
-{%partial post toggle_all%}
-  {%let active_count = COUNT(*) from todos WHERE completed = 0%}
-  {%update todos set completed =  IIF(:active_count = 0, 0, 1)%}
+{%partial post toggle_all;
+   let active_count = COUNT(*) from todos WHERE completed = 0;
+   update todos set completed =  IIF(:active_count = 0, 0, 1)%}
 {%endpartial%}
 
-{%partial delete :id%}
-  {%delete from todos WHERE id = :id%}
+{%partial delete :id; delete from todos WHERE id = :id%}
 {%endpartial%}
 
-{%partial post clear_completed%}
-  {%delete from todos WHERE completed = 1%}
+{%partial post clear_completed; delete from todos WHERE completed = 1%}
 {%endpartial%}


### PR DESCRIPTION
## Summary
- condense PageQL directives in `todos.pageql` using semicolons

## Testing
- `pytest` *(fails: test_infinite_scroll_browser, test_reactive_stateful)*

------
https://chatgpt.com/codex/tasks/task_e_6863cc0da90c832f868aaca4ee3258b5