### PR TITLE
Add --parse command to PageQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It was inspired by ColdFusion language that allows embedding SQL and Handlebars 
 
 PageQL is **reactive-first**: rendered HTML automatically updates when the underlying database data changes.
 
-Usage: ```pageql templates <database> [--create] [--test]```
+Usage: ```pageql templates <database> [--create] [--test] [--parse]```
 
 Install: pip install pageql  # uvicorn[standard] is installed automatically
 
@@ -76,6 +76,7 @@ pageql ./templates path/to/your/database.sqlite
 *   `--no-csrf`: (Optional) Disable CSRF protection. Useful for local testing but not recommended in production.
 *   `--static-html`: (Optional) Serve HTML files without injecting the client script.
 *   `--test`: (Optional) Run template tests and exit instead of serving.
+*   `--parse`: (Optional) Check templates for parse errors and exit.
 *   `--http-disconnect-cleanup-timeout <seconds>`: (Optional) Delay before cleaning up HTTP disconnect contexts.
 *   `--profile`: (Optional) Profile the server using `cProfile` and print statistics when it stops.
 *   `--host <address>`: (Optional) Host interface to bind.

--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -112,20 +112,20 @@ partial post add;
    let current_total = COUNT(*) from todos;
    if :current_total < 20;
      insert into todos(text) values (:text);
-   endif
+   endif;
 endpartial;
 
-partial post :id/toggle
-  update todos set completed = 1 - completed WHERE id = :id
+partial post :id/toggle;
+  update todos set completed = 1 - completed WHERE id = :id;
 endpartial;
 
-partial patch :id
+partial patch :id;
   param text maxlength=100;
   -- Update todo text
-  update todos set text = :text WHERE id = :id
+  update todos set text = :text WHERE id = :id;
 endpartial;
 
-partial post toggle_all
+partial post toggle_all;
   let active_count = COUNT(*) from todos WHERE completed = 0;
     -- Set all todos completed state based on active count
     update todos set completed =  IIF(:active_count = 0, 0, 1);


### PR DESCRIPTION
## Summary
- add `--parse` flag to PageQL CLI to validate templates
- document the new flag in README
- extend CLI unit tests for `--parse`
- fix todos example template so parsing succeeds

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_6863ddd3d848832fa550897027921dac