### PR TITLE
Support spaced end directives

### DIFF
--- a/src/pageql/parser.py
+++ b/src/pageql/parser.py
@@ -125,6 +125,9 @@ def tokenize(source):
             inner = _strip_sql_line_comments(inner).strip()
             for seg in _split_directives(inner):
                 first, rest = parsefirstword(seg)
+                if first == 'end' and rest:
+                    second, rest = parsefirstword(rest)
+                    first = f'end{second}'
                 if first == 'param' and rest:
                     pn, attrs = parsefirstword(rest)
                     pn = pn.replace('.', '__')

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -44,3 +44,19 @@ def test_tokenize_joined_directives():
         ("#param", "a"),
         ("#param", "b"),
     ]
+
+
+def test_tokenize_end_space_directives():
+    assert tokenize("{%from items%}{%end from%}") == [
+        ("#from", "items"),
+        ("#endfrom", None),
+    ]
+    assert tokenize("{%partial x%}{%end partial%}") == [
+        ("#partial", "x"),
+        ("#endpartial", None),
+    ]
+    assert tokenize("{%if 1%}a{%end if%}") == [
+        ("#if", "1"),
+        ("text", "a"),
+        ("#endif", None),
+    ]


### PR DESCRIPTION
## Summary
- support `end <directive>` forms in the parser
- test that spaced end directives tokenize correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6863e8d56d68832f8a4fe588db42b102