### PR TITLE
Update end directive syntax in website templates

### DIFF
--- a/website/03_updating_state.html
+++ b/website/03_updating_state.html
@@ -430,8 +430,8 @@
            &#123;&#123;<span class="keyword">#if</span> completed&#125;&#125;checked&#123;&#123;/<span class="keyword">if</span>&#125;&#125;&gt;
   &lt;<span class="keyword">label</span> <span class="attribute">hx-get</span>=<span class="string">"/?edit_id=&#123;&#123;id&#125;&#125;"</span>&gt;&#123;&#123;text&#125;&#125;&lt;/<span class="keyword">label</span>&gt;
 &lt;/<span class="keyword">li</span>&gt;
-</code><div class="clean-code">&lt;li {%if completed%}class="completed"{%endif%}&gt;
-  &lt;input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}&gt;
+</code><div class="clean-code">&lt;li {%if completed%}class="completed"{%end if%}&gt;
+  &lt;input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}&gt;
   &lt;label hx-get="/?edit_id={{id}}"&gt;{{text}}&lt;/label&gt;
 &lt;/li&gt;</div></pre>
 
@@ -464,7 +464,7 @@
   &lt;/li&gt;
 {%else%}
   …view version from 2.2…
-{%endif%}</div></pre>
+{%end if%}</div></pre>
 
   <p>This conditional section demonstrates how PageQL handles more complex expressions. Notice that when comparing variables (<code>:edit_id == :id</code>), the colon prefix is required on both sides because we're using a complex expression rather than a simple variable check.</p>
   
@@ -487,13 +487,13 @@
 &lt;/<span class="keyword">span</span>&gt;
 </code><div class="clean-code">&lt;form hx-post="/todos/toggle_all" id="toggle-all-form" style="display:block"&gt;
   &lt;input id="toggle-all" class="toggle-all" type="checkbox"
-         {%if all_complete%}checked{%endif%}&gt;
+         {%if all_complete%}checked{%end if%}&gt;
   &lt;label for="toggle-all"&gt;Mark all as complete&lt;/label&gt;
 &lt;/form&gt;
 
 &lt;span class="todo-count"&gt;
   &lt;strong&gt;{{active_count}}&lt;/strong&gt;
-  item{%if :active_count != 1%}s{%endif%} left
+  item{%if :active_count != 1%}s{%end if%} left
 &lt;/span&gt;</div></pre>
 
   <p>This section showcases how PageQL variables can be used to:</p>
@@ -529,20 +529,20 @@
   {%param id required type=integer min=1%}
   {%update todos set completed = 1 - completed WHERE id = :id%}
   {%redirect '/todos'%}
-{%endpartial%}
+{%end partial%}
 
 {%partial public save%}
   {%param id required type=integer min=1%}
   {%param text required minlength=1%}
   {%update todos set text = :text WHERE id = :id%}
   {%redirect '/todos'%}
-{%endpartial%}
+{%end partial%}
 
 {%partial public toggle_all%}
   {%let active_count = COUNT(*) from todos WHERE completed = 0%}
   {%update todos set completed = IIF(:active_count = 0, 0, 1)%}
   {%redirect '/todos'%}
-{%endpartial%}</div></pre>
+{%end partial%}</div></pre>
 
   <p>These partials define server-side endpoints that handle data modifications. The <code>public</code> keyword exposes them directly via HTTP POST requests, making them accessible at paths like <code>/todos/toggle</code>.</p>
   

--- a/website/04_deleting_and_bulk.html
+++ b/website/04_deleting_and_bulk.html
@@ -413,12 +413,12 @@
 
   <pre class="code-block"><code class="language-diff">
 &lt;<span class="keyword">li</span> &#123;&#123;<span class="keyword">#if</span> completed&#125;&#125;<span class="attribute">class</span>=<span class="string">"completed"</span>&#123;&#123;/<span class="keyword">if</span>&#125;&#125;&gt;
-  &lt;<span class="keyword">input</span> hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}&gt;
+  &lt;<span class="keyword">input</span> hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}&gt;
   &lt;<span class="keyword">label</span> hx-get="/?edit_id={{id}}"&gt;{{text}}&lt;/<span class="keyword">label</span>&gt;
   &lt;<span class="keyword">button</span> hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;"&gt;✕&lt;/<span class="keyword">button</span>&gt;
 &lt;/<span class="keyword">li</span>&gt;
-</code><div class="clean-code">&lt;li {%if completed%}class="completed"{%endif%}&gt;
-  &lt;input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}&gt;
+</code><div class="clean-code">&lt;li {%if completed%}class="completed"{%end if%}&gt;
+  &lt;input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}&gt;
   &lt;label hx-get="/?edit_id={{id}}"&gt;{{text}}&lt;/label&gt;
   &lt;button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;"&gt;✕&lt;/button&gt;
 &lt;/li&gt;</div></pre>
@@ -435,7 +435,7 @@
 &#123;&#123;/<span class="keyword">if</span>&#125;&#125;
 </code><div class="clean-code">{%if :completed_count > 0%}
   &lt;button class="clear-completed" hx-post="/todos/clear_completed"&gt;Clear completed&lt;/button&gt;
-{%endif%}</div></pre>
+{%end if%}</div></pre>
 
   <!-- 3 -->
   <h2>3 New public partials</h2>
@@ -452,11 +452,11 @@
 &#123;&#123;/<span class="keyword">partial</span>&#125;&#125;
 </code><div class="clean-code">{%partial delete :id%}
   {%delete from todos WHERE id = :id%}
-{%endpartial%}
+{%end partial%}
 
 {%partial post clear_completed%}
   {%delete from todos WHERE completed = 1%}
-{%endpartial%}</div></pre>
+{%end partial%}</div></pre>
 
   <p><em>Notice:</em> there is <strong>no</strong> explicit <code>BEGIN</code>/<code>COMMIT</code>. If an error occurs during the partial, PageQL aborts the whole request and rolls back the delete.</p>
 

--- a/website/05_adding_filters.html
+++ b/website/05_adding_filters.html
@@ -436,7 +436,7 @@
         OR (:filter == 'completed'  AND completed = 1)
   ORDER BY id%}
   … list‑item markup …
-{%endfrom%}</div></pre>
+{%end from%}</div></pre>
 
   <p>The entire boolean expression is <strong>sent to SQLite</strong>; <code>:filter</code> is safely bound.</p>
 
@@ -452,9 +452,9 @@
   &lt;<span class="keyword">a</span> &#123;&#123;<span class="keyword">#if</span> :<span class="variable">filter</span> == <span class="string">'completed'</span>&#125;&#125;<span class="attribute">class</span>=<span class="string">"selected"</span>&#123;&#123;/<span class="keyword">if</span>&#125;&#125; <span class="attribute">href</span>=<span class="string">"/todos?filter=completed"</span>&gt;Completed&lt;/<span class="keyword">a</span>&gt;
 &lt;/<span class="keyword">div</span>&gt;
 </code><div class="clean-code">&lt;div class="filters"&gt;
-  &lt;a {%if :filter == 'all'%}class="selected"{%endif%} href="/todos?filter=all"&gt;All&lt;/a&gt; |
-  &lt;a {%if :filter == 'active'%}class="selected"{%endif%} href="/todos?filter=active"&gt;Active&lt;/a&gt; |
-  &lt;a {%if :filter == 'completed'%}class="selected"{%endif%} href="/todos?filter=completed"&gt;Completed&lt;/a&gt;
+  &lt;a {%if :filter == 'all'%}class="selected"{%end if%} href="/todos?filter=all"&gt;All&lt;/a&gt; |
+  &lt;a {%if :filter == 'active'%}class="selected"{%end if%} href="/todos?filter=active"&gt;Active&lt;/a&gt; |
+  &lt;a {%if :filter == 'completed'%}class="selected"{%end if%} href="/todos?filter=completed"&gt;Completed&lt;/a&gt;
 &lt;/div&gt;</div></pre>
 
   <p>The CSS from TodoMVC highlights the link that carries <code>class="selected"</code>.</p>

--- a/website/basic_auth.pageql
+++ b/website/basic_auth.pageql
@@ -23,7 +23,7 @@ let username = username from users where id=:user_id;
 <p>Logged in as {{username}}. <a href="/basic_auth/profile">Profile</a> <a href="/basic_auth/logout">Logout</a></p>
 {%else%}
 <p>You are not logged in. <a href="/basic_auth/login">Login</a></p>
-{%endif%}
+{%end if%}
 
 {%partial POST login%}
 {%
@@ -40,8 +40,8 @@ let username = username from users where id=:user_id;
     {%redirect '/basic_auth'%}
   {%else%}
     <p>Invalid credentials</p>
-  {%endif%}
-{%endpartial%}
+  {%end if%}
+{%end partial%}
 
 {%partial GET login%}
 {%
@@ -56,7 +56,7 @@ let username = username from users where id=:user_id;
     <input name="password" type="password" placeholder="Password">
     <button type="submit">Login</button>
   </form>
-{%endpartial%}
+{%end partial%}
 
 {%partial GET profile%}
 {%
@@ -70,8 +70,8 @@ let username = username from users where id=:user_id;
     <p><a href="/basic_auth/logout">Logout</a></p>
   {%else%}
     {%redirect '/basic_auth/login'%}
-  {%endif%}
-{%endpartial%}
+  {%end if%}
+{%end partial%}
 
 {%partial public logout%}
 {%
@@ -80,4 +80,4 @@ let username = username from users where id=:user_id;
   cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT';
   redirect '/basic_auth';
 %}
-{%endpartial%}
+{%end partial%}

--- a/website/basic_auth_sessionless.pageql
+++ b/website/basic_auth_sessionless.pageql
@@ -22,7 +22,7 @@ let sess_username = username from users where id=:uid;
 <p>Logged in as {{sess_username}}. <a href="/basic_auth_sessionless/profile">Profile</a> <a href="/basic_auth_sessionless/logout">Logout</a></p>
 {%else%}
 <p>You are not logged in. <a href="/basic_auth_sessionless/login">Login</a> or <a href="/basic_auth_sessionless/register">Register</a></p>
-{%endif%}
+{%end if%}
 
 {%partial POST login%}
 {%
@@ -38,8 +38,8 @@ let sess_username = username from users where id=:uid;
     {%redirect '/basic_auth_sessionless'%}
   {%else%}
     <p>Invalid credentials</p>
-  {%endif%}
-{%endpartial%}
+  {%end if%}
+{%end partial%}
 
 {%partial GET login%}
   <h1>Login</h1>
@@ -49,7 +49,7 @@ let sess_username = username from users where id=:uid;
     <button type="submit">Login</button>
   </form>
   <p><a href="/basic_auth_sessionless/register">Register</a></p>
-{%endpartial%}
+{%end partial%}
 
 {%partial POST register%}
 {%
@@ -67,8 +67,8 @@ let sess_username = username from users where id=:uid;
     {%let token jws_serialize_compact(:payload)%}
     {%cookie session :token path='/' httponly%}
     {%redirect '/basic_auth_sessionless'%}
-  {%endif%}
-{%endpartial%}
+  {%end if%}
+{%end partial%}
 
 {%partial GET register%}
   <h1>Register</h1>
@@ -78,7 +78,7 @@ let sess_username = username from users where id=:uid;
     <button type="submit">Register</button>
   </form>
   <p><a href="/basic_auth_sessionless/login">Login</a></p>
-{%endpartial%}
+{%end partial%}
 
 {%partial GET profile%}
 {%
@@ -95,12 +95,12 @@ let sess_username = username from users where id=:uid;
     <p><a href="/basic_auth_sessionless/logout">Logout</a></p>
   {%else%}
     {%redirect '/basic_auth_sessionless/login'%}
-  {%endif%}
-{%endpartial%}
+  {%end if%}
+{%end partial%}
 
 {%
 partial public logout;
   cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT';
   redirect '/basic_auth_sessionless';
-endpartial;
+end partial;
 %}

--- a/website/facebookauth.pageql
+++ b/website/facebookauth.pageql
@@ -40,10 +40,10 @@ let redirect_uri = 'http://'||:headers.host||replace(:path, '"', '')||'/callback
           <p>Error: {{:user.status_code}} {{:user.body}}</p>
         {%else%}
           <p>Loading user...</p>
-        {%endif%}
+        {%end if%}
       {{/fetch}}
     {%else%}
       <p>Loading token...</p>
-    {%endif%}
+    {%end if%}
   {{/fetch}}
-{%endpartial%}
+{%end partial%}

--- a/website/fetchhealth.pageql
+++ b/website/fetchhealth.pageql
@@ -5,9 +5,9 @@
         Fetched twice
       {%else%}
         Loading inner... {{inner__body}}
-      {%endif%}
+      {%end if%}
     {{/fetch}}
   {%else%}
     Loading outer... {{outer__body}}
-  {%endif%}
+  {%end if%}
 {{/fetch}}

--- a/website/githubauth.pageql
+++ b/website/githubauth.pageql
@@ -36,10 +36,10 @@ let client_id = env.GITHUB_CLIENT_ID;
           <p>Error: {{:user.status_code}} {{:user.body}}</p>
         {%else%}
           <p>Loading user...</p>
-        {%endif%}
+        {%end if%}
       {{/fetch}}
     {%else%}
       <p>Loading token...</p>
-    {%endif%}
+    {%end if%}
   {{/fetch}}
-{%endpartial%}
+{%end partial%}

--- a/website/googleauth.pageql
+++ b/website/googleauth.pageql
@@ -39,10 +39,10 @@ let redirect_uri = 'https://'||:headers.host||replace(:path, '"', '')||'/callbac
           <p>Error: {{:user.status_code}} {{:user.body}}</p>
         {%else%}
           <p>Loading user...</p>
-        {%endif%}
+        {%end if%}
       {{/fetch}}
     {%else%}
       <p>Loading token...</p>
-    {%endif%}
+    {%end if%}
   {{/fetch}}
-{%endpartial%}
+{%end partial%}

--- a/website/index.html
+++ b/website/index.html
@@ -420,15 +420,15 @@ pageql data.db templates --create</code></pre>
       {%if :total_count &lt; 20%}
       &lt;input name=&quot;text&quot; placeholder=&quot;What needs to be done?&quot; maxlength=&quot;100&quot; autofocus autocomplete=&quot;off&quot;
         hx-post=&quot;/todos/add&quot; hx-trigger=&quot;keyup[key==&#x27;Enter&#x27;]&quot; hx-on:htmx:after-on-load=&quot;this.value=&#x27;&#x27;&quot;&gt;
-      {%endif%}
+      {%end if%}
       &lt;ul&gt;
         {%from todos
           WHERE (:filter == &#x27;all&#x27;)
                 OR (:filter == &#x27;active&#x27;    AND completed = 0)
                 OR (:filter == &#x27;completed&#x27; AND completed = 1)
           %}
-            &lt;li {%if completed%}class=&quot;completed&quot;{%endif%}&gt;
-                &lt;input hx-post=&quot;/todos/{{id}}/toggle&quot; class=&quot;toggle&quot; type=&quot;checkbox&quot; {%if completed%}checked{%endif%}&gt;
+            &lt;li {%if completed%}class=&quot;completed&quot;{%end if%}&gt;
+                &lt;input hx-post=&quot;/todos/{{id}}/toggle&quot; class=&quot;toggle&quot; type=&quot;checkbox&quot; {%if completed%}checked{%end if%}&gt;
                 &lt;label
                   contenteditable=&quot;false&quot;
                   onclick=&quot;this.contentEditable=true;this.focus();&quot;
@@ -443,25 +443,25 @@ pageql data.db templates --create</code></pre>
 
                 &lt;button hx-delete=&quot;/todos/{{id}}&quot; class=&quot;destroy&quot; style=&quot;cursor:pointer; background:none; border:none; color:#ac4a1a;&quot;&gt;✕&lt;/button&gt;
             &lt;/li&gt;
-        {%endfrom%}
+        {%end from%}
       &lt;/ul&gt;
 
-  &lt;input id=&quot;toggle-all&quot; class=&quot;toggle-all&quot; type=&quot;checkbox&quot; {%if all_complete%}checked{%endif%} hx-post=&quot;/todos/toggle_all&quot;&gt;
+  &lt;input id=&quot;toggle-all&quot; class=&quot;toggle-all&quot; type=&quot;checkbox&quot; {%if all_complete%}checked{%end if%} hx-post=&quot;/todos/toggle_all&quot;&gt;
   &lt;label for=&quot;toggle-all&quot;&gt;Mark all as complete&lt;/label&gt;
 
 &lt;span class=&quot;todo-count&quot;&gt;
   &lt;strong&gt;{{active_count}}&lt;/strong&gt;
-  item{%if :active_count != 1%}s{%endif%} left
+  item{%if :active_count != 1%}s{%end if%} left
 &lt;/span&gt;
 
 
 {%if :completed_count &gt; 0%}
   &lt;button class=&quot;clear-completed&quot; hx-post=&quot;/todos/clear_completed&quot;&gt;Clear completed&lt;/button&gt;
-{%endif%}
+{%end if%}
 &lt;div class=&quot;filters&quot;&gt;
-  &lt;a {%if :filter == &#x27;all&#x27;%}class=&quot;selected&quot;{%endif%} href=&quot;/todos?filter=all&quot;&gt;All&lt;/a&gt; |
-  &lt;a {%if :filter == &#x27;active&#x27;%}class=&quot;selected&quot;{%endif%} href=&quot;/todos?filter=active&quot;&gt;Active&lt;/a&gt; |
-  &lt;a {%if :filter == &#x27;completed&#x27;%}class=&quot;selected&quot;{%endif%} href=&quot;/todos?filter=completed&quot;&gt;Completed&lt;/a&gt;
+  &lt;a {%if :filter == &#x27;all&#x27;%}class=&quot;selected&quot;{%end if%} href=&quot;/todos?filter=all&quot;&gt;All&lt;/a&gt; |
+  &lt;a {%if :filter == &#x27;active&#x27;%}class=&quot;selected&quot;{%end if%} href=&quot;/todos?filter=active&quot;&gt;Active&lt;/a&gt; |
+  &lt;a {%if :filter == &#x27;completed&#x27;%}class=&quot;selected&quot;{%end if%} href=&quot;/todos?filter=completed&quot;&gt;Completed&lt;/a&gt;
 &lt;/div&gt;
 &lt;/div&gt;
   &lt;h2 style=&quot;color:rgb(50, 56, 86); margin-top: 2rem; margin-bottom: 0.5rem;&quot;&gt;Source code&lt;/h2&gt;
@@ -474,32 +474,32 @@ partial post add;
    let current_total = COUNT(*) from todos;
    if :current_total &lt; 20;
      insert into todos(text) values (:text);
-   endif;
-endpartial;
+   end if;
+end partial;
 
 partial post :id/toggle;
   update todos set completed = 1 - completed WHERE id = :id;
-endpartial;
+end partial;
 
 partial patch :id;
   param text maxlength=100;
   -- Update todo text
   update todos set text = :text WHERE id = :id;
-endpartial;
+end partial;
 
 partial post toggle_all;
   let active_count = COUNT(*) from todos WHERE completed = 0;
     -- Set all todos completed state based on active count
     update todos set completed =  IIF(:active_count = 0, 0, 1);
-endpartial;
+end partial;
 
 partial delete :id;
   delete from todos WHERE id = :id;
-endpartial;
+end partial;
 
 partial post clear_completed;
   delete from todos WHERE completed = 1;
-endpartial
+end partial
 %}
 </code></pre>
         </div>

--- a/website/infinite_scroll.pageql
+++ b/website/infinite_scroll.pageql
@@ -18,11 +18,11 @@ if :f < 1000;
     ) SELECT n FROM numbers
   ) limit :f,100%}
     {{n}}<br>
-  {%endfrom%}
+  {%end from%}
 </span>
 {%
-endif;
-endpartial;
+end if;
+end partial;
 %}
 
 <div id="list">

--- a/website/infinite_scroll_infinite.pageql
+++ b/website/infinite_scroll_infinite.pageql
@@ -8,5 +8,5 @@
   ) SELECT n FROM numbers
 ) infinite%}
   {{n}}<br>
-{%endfrom%}
+{%end from%}
 </div>

--- a/website/json.pageql
+++ b/website/json.pageql
@@ -14,9 +14,9 @@ create table if not exists todos (
 ), '[]') from todos}}},
 [
 {%from todos order by id%}
-{%if NOT :__first_row%},{%endif%}
+{%if NOT :__first_row%},{%end if%}
 {"id":{{id}},"text":"{{text}}","completed":{{completed}} }
-{%endfrom%}
+{%end from%}
 ]
 ]
 

--- a/website/todos.pageql
+++ b/website/todos.pageql
@@ -58,15 +58,15 @@
       {%if :total_count < 20%}
       <input name="text" placeholder="What needs to be done?" maxlength="100" autofocus autocomplete="off"
         hx-post="/todos/add" hx-trigger="keyup[key=='Enter']" hx-on:htmx:after-on-load="this.value=''">
-      {%endif%}
+      {%end if%}
       <ul>
         {%from todos
           WHERE (:filter == 'all')
                 OR (:filter == 'active'    AND completed = 0)
                 OR (:filter == 'completed' AND completed = 1)
           %}
-            <li {%if completed%}class="completed"{%endif%}>
-                <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}>
+            <li {%if completed%}class="completed"{%end if%}>
+                <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}>
                 <label
                   contenteditable="false"
                   onclick="this.contentEditable=true;this.focus();"
@@ -81,25 +81,25 @@
 
                 <button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;">✕</button>
             </li>
-        {%endfrom%}
+        {%end from%}
       </ul>
 
-  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%endif%} hx-post="/todos/toggle_all">
+  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%end if%} hx-post="/todos/toggle_all">
   <label for="toggle-all">Mark all as complete</label>
 
 <span class="todo-count">
   <strong>{{active_count}}</strong>
-  item{%if :active_count != 1%}s{%endif%} left
+  item{%if :active_count != 1%}s{%end if%} left
 </span>
 
 
 {%if :completed_count > 0%}
   <button class="clear-completed" hx-post="/todos/clear_completed">Clear completed</button>
-{%endif%}
+{%end if%}
 <div class="filters">
-  <a {%if :filter == 'all'%}class="selected"{%endif%} href="/todos?filter=all">All</a> |
-  <a {%if :filter == 'active'%}class="selected"{%endif%} href="/todos?filter=active">Active</a> |
-  <a {%if :filter == 'completed'%}class="selected"{%endif%} href="/todos?filter=completed">Completed</a>
+  <a {%if :filter == 'all'%}class="selected"{%end if%} href="/todos?filter=all">All</a> |
+  <a {%if :filter == 'active'%}class="selected"{%end if%} href="/todos?filter=active">Active</a> |
+  <a {%if :filter == 'completed'%}class="selected"{%end if%} href="/todos?filter=completed">Completed</a>
 </div>
 </div>
   <h2 style="color:rgb(50, 56, 86); margin-top: 2rem; margin-bottom: 0.5rem;">Source code</h2>
@@ -112,30 +112,30 @@ partial post add;
    let current_total = COUNT(*) from todos;
    if :current_total < 20;
      insert into todos(text) values (:text);
-   endif;
-endpartial;
+   end if;
+end partial;
 
 partial post :id/toggle;
   update todos set completed = 1 - completed WHERE id = :id;
-endpartial;
+end partial;
 
 partial patch :id;
   param text maxlength=100;
   -- Update todo text
   update todos set text = :text WHERE id = :id;
-endpartial;
+end partial;
 
 partial post toggle_all;
   let active_count = COUNT(*) from todos WHERE completed = 0;
     -- Set all todos completed state based on active count
     update todos set completed =  IIF(:active_count = 0, 0, 1);
-endpartial;
+end partial;
 
 partial delete :id;
   delete from todos WHERE id = :id;
-endpartial;
+end partial;
 
 partial post clear_completed;
   delete from todos WHERE completed = 1;
-endpartial
+end partial
 %}

--- a/website/todos_ordered.pageql
+++ b/website/todos_ordered.pageql
@@ -60,15 +60,15 @@ let all_complete    = (:active_count == 0 AND :total_count > 0)
       {%if :total_count < 20%}
       <input name="text" placeholder="What needs to be done?" maxlength="100" autofocus autocomplete="off"
         hx-post="/todos/add" hx-trigger="keyup[key=='Enter']" hx-on:htmx:after-on-load="this.value=''">
-      {%endif%}
+      {%end if%}
       <ul>
         {%from todos
           WHERE (:filter == 'all')
                 OR (:filter == 'active'    AND completed = 0)
                 OR (:filter == 'completed' AND completed = 1)
           ORDER BY text%}
-            <li {%if completed%}class="completed"{%endif%}>
-                <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}>
+            <li {%if completed%}class="completed"{%end if%}>
+                <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}>
                 <label
                   contenteditable="false"
                   onclick="this.contentEditable=true;this.focus();"
@@ -83,25 +83,25 @@ let all_complete    = (:active_count == 0 AND :total_count > 0)
 
                 <button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;">✕</button>
             </li>
-        {%endfrom%}
+        {%end from%}
       </ul>
 
-  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%endif%} hx-post="/todos/toggle_all">
+  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%end if%} hx-post="/todos/toggle_all">
   <label for="toggle-all">Mark all as complete</label>
 
 <span class="todo-count">
   <strong>{{active_count}}</strong>
-  item{%if :active_count != 1%}s{%endif%} left
+  item{%if :active_count != 1%}s{%end if%} left
 </span>
 
 
 {%if :completed_count > 0%}
   <button class="clear-completed" hx-post="/todos/clear_completed">Clear completed</button>
-{%endif%}
+{%end if%}
 <div class="filters">
-  <a {%if :filter == 'all'%}class="selected"{%endif%} href="/todos?filter=all">All</a> |
-  <a {%if :filter == 'active'%}class="selected"{%endif%} href="/todos?filter=active">Active</a> |
-  <a {%if :filter == 'completed'%}class="selected"{%endif%} href="/todos?filter=completed">Completed</a>
+  <a {%if :filter == 'all'%}class="selected"{%end if%} href="/todos?filter=all">All</a> |
+  <a {%if :filter == 'active'%}class="selected"{%end if%} href="/todos?filter=active">Active</a> |
+  <a {%if :filter == 'completed'%}class="selected"{%end if%} href="/todos?filter=completed">Completed</a>
 </div>
 </div>
   <h2 style="color:rgb(50, 56, 86); margin-top: 2rem; margin-bottom: 0.5rem;">Source code</h2>
@@ -114,28 +114,28 @@ partial post add;
   let current_total = COUNT(*) from todos;
   if :current_total < 20;
     insert into todos(text) values (:text);
-  endif;
-endpartial;
+  end if;
+end partial;
 
 partial post :id/toggle;
   update todos set completed = 1 - completed WHERE id = :id;
-endpartial;
+end partial;
 
 partial patch :id;
   param text maxlength=100;
   update todos set text = :text WHERE id = :id;
-endpartial;
+end partial;
 
 partial post toggle_all;
   let active_count = COUNT(*) from todos WHERE completed = 0;
   update todos set completed =  IIF(:active_count = 0, 0, 1);
-endpartial;
+end partial;
 
 partial delete :id;
   delete from todos WHERE id = :id;
-endpartial;
+end partial;
 
 partial post clear_completed;
   delete from todos WHERE completed = 1;
-endpartial
+end partial
 %}

--- a/website/todos_without_edit_id.pageql
+++ b/website/todos_without_edit_id.pageql
@@ -1,28 +1,28 @@
 {%
 partial post add;
   insert into todos(text) values (:text);
-endpartial;
+end partial;
 
 partial post :id/toggle;
   update todos set completed = 1 - completed WHERE id = :id;
-endpartial;
+end partial;
 
 partial patch :id;
   update todos set text = :text WHERE id = :id;
-endpartial;
+end partial;
 
 partial post toggle_all;
   let active_count = COUNT(*) from todos WHERE completed = 0;
   update todos set completed =  IIF(:active_count = 0, 0, 1);
-endpartial;
+end partial;
 
 partial delete :id;
   delete from todos WHERE id = :id;
-endpartial;
+end partial;
 
 partial post clear_completed;
   delete from todos WHERE completed = 1;
-endpartial
+end partial
 %}
 
 {%
@@ -59,30 +59,30 @@ let all_complete    = (:active_count == 0 AND :total_count > 0)
         OR (:filter == 'active'    AND completed = 0)
         OR (:filter == 'completed' AND completed = 1)
   ORDER BY id%}
-    <li {%if completed%}class="completed"{%endif%}>
-        <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%endif%}>
+    <li {%if completed%}class="completed"{%end if%}>
+        <input hx-post="/todos/{{id}}/toggle" class="toggle" type="checkbox" {%if completed%}checked{%end if%}>
         <label hx-get="/?edit_id={{id}}">{{text}}</label>
         <button hx-delete="/todos/{{id}}" class="destroy" style="cursor:pointer; background:none; border:none; color:#ac4a1a;">✕</button>
     </li>
-{%endfrom%}
+{%end from%}
   </ul>
 
-  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%endif%} hx-post="/todos/toggle_all">
+  <input id="toggle-all" class="toggle-all" type="checkbox" {%if all_complete%}checked{%end if%} hx-post="/todos/toggle_all">
   <label for="toggle-all">Mark all as complete</label>
 
 <span class="todo-count">
   <strong>{{active_count}}</strong>
-  item{%if :active_count != 1%}s{%endif%} left
+  item{%if :active_count != 1%}s{%end if%} left
 </span>
 
 
 {%if :completed_count > 0%}
   <button class="clear-completed" hx-post="/todos/clear_completed">Clear completed</button>
-{%endif%}
+{%end if%}
 <div class="filters">
-  <a {%if :filter == 'all'%}class="selected"{%endif%} href="/todos?filter=all">All</a> |
-  <a {%if :filter == 'active'%}class="selected"{%endif%} href="/todos?filter=active">Active</a> |
-  <a {%if :filter == 'completed'%}class="selected"{%endif%} href="/todos?filter=completed">Completed</a>
+  <a {%if :filter == 'all'%}class="selected"{%end if%} href="/todos?filter=all">All</a> |
+  <a {%if :filter == 'active'%}class="selected"{%end if%} href="/todos?filter=active">Active</a> |
+  <a {%if :filter == 'completed'%}class="selected"{%end if%} href="/todos?filter=completed">Completed</a>
 </div>
 </body>
 </html>

--- a/website/upload.pageql
+++ b/website/upload.pageql
@@ -8,7 +8,7 @@ create table if not exists uploads (
 partial post add;
   insert into uploads(filename, data) values (:file.filename, :file.body);
   redirect '/upload';
-endpartial;
+end partial;
 %}
 
 <form method="POST" action="/upload/add" enctype="multipart/form-data">
@@ -22,5 +22,5 @@ endpartial;
     {{filename}} - {{length(:data)}} bytes<br>
     <img src="data:image;base64,{{base64_encode(:data)}}" width="150"/>
   </li>
-{%endfrom%}
+{%end from%}
 </ul>


### PR DESCRIPTION
## Summary
- switch to space-separated `end` directives in website example templates
- keep tests green

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686406c23940832fa3407cb4c89fbd21