### PR TITLE
Fix long lines in example code

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -418,8 +418,15 @@ pageql data.db templates --create</code></pre>
   &lt;div class=&quot;back-link&quot;&gt;&lt;a href=&quot;/&quot;&gt;&amp;larr; PageQL&lt;/a&gt; &lt;span style=&quot;font-size: 1.8rem; font-weight: bold; color:rgb(40, 170, 190);&quot;&gt;TODOMVC&lt;/span&gt;&lt;/div&gt;
   &lt;div&gt;
       {%if :total_count &lt; 20%}
-      &lt;input name=&quot;text&quot; placeholder=&quot;What needs to be done?&quot; maxlength=&quot;100&quot; autofocus autocomplete=&quot;off&quot;
-        hx-post=&quot;/todos/add&quot; hx-trigger=&quot;keyup[key==&#x27;Enter&#x27;]&quot; hx-on:htmx:after-on-load=&quot;this.value=&#x27;&#x27;&quot;&gt;
+      &lt;input
+        name=&quot;text&quot;
+        placeholder=&quot;What needs to be done?&quot;
+        maxlength=&quot;100&quot;
+        autofocus
+        autocomplete=&quot;off&quot;
+        hx-post=&quot;/todos/add&quot;
+        hx-trigger=&quot;keyup[key==&#x27;Enter&#x27;]&quot;
+        hx-on:htmx:after-on-load=&quot;this.value=&#x27;&#x27;&quot;&gt;
       {%end if%}
       &lt;ul&gt;
         {%from todos
@@ -428,7 +435,11 @@ pageql data.db templates --create</code></pre>
                 OR (:filter == &#x27;completed&#x27; AND completed = 1)
           %}
             &lt;li {%if completed%}class=&quot;completed&quot;{%end if%}&gt;
-                &lt;input hx-post=&quot;/todos/{{id}}/toggle&quot; class=&quot;toggle&quot; type=&quot;checkbox&quot; {%if completed%}checked{%end if%}&gt;
+                &lt;input
+                  hx-post=&quot;/todos/{{id}}/toggle&quot;
+                  class=&quot;toggle&quot;
+                  type=&quot;checkbox&quot;
+                  {%if completed%}checked{%end if%}&gt;
                 &lt;label
                   contenteditable=&quot;false&quot;
                   onclick=&quot;this.contentEditable=true;this.focus();&quot;
@@ -441,12 +452,20 @@ pageql data.db templates --create</code></pre>
                   hx-swap=&quot;none&quot;
                 &gt;{{text}}&lt;/label&gt;
 
-                &lt;button hx-delete=&quot;/todos/{{id}}&quot; class=&quot;destroy&quot; style=&quot;cursor:pointer; background:none; border:none; color:#ac4a1a;&quot;&gt;✕&lt;/button&gt;
+                &lt;button
+                  hx-delete=&quot;/todos/{{id}}&quot;
+                  class=&quot;destroy&quot;
+                  style=&quot;cursor:pointer; background:none; border:none; color:#ac4a1a;&quot;&gt;✕&lt;/button&gt;
             &lt;/li&gt;
         {%end from%}
       &lt;/ul&gt;
 
-  &lt;input id=&quot;toggle-all&quot; class=&quot;toggle-all&quot; type=&quot;checkbox&quot; {%if all_complete%}checked{%end if%} hx-post=&quot;/todos/toggle_all&quot;&gt;
+  &lt;input
+    id=&quot;toggle-all&quot;
+    class=&quot;toggle-all&quot;
+    type=&quot;checkbox&quot;
+    {%if all_complete%}checked{%end if%}
+    hx-post=&quot;/todos/toggle_all&quot;&gt;
   &lt;label for=&quot;toggle-all&quot;&gt;Mark all as complete&lt;/label&gt;
 
 &lt;span class=&quot;todo-count&quot;&gt;
@@ -456,7 +475,9 @@ pageql data.db templates --create</code></pre>
 
 
 {%if :completed_count &gt; 0%}
-  &lt;button class=&quot;clear-completed&quot; hx-post=&quot;/todos/clear_completed&quot;&gt;Clear completed&lt;/button&gt;
+  &lt;button
+    class=&quot;clear-completed&quot;
+    hx-post=&quot;/todos/clear_completed&quot;&gt;Clear completed&lt;/button&gt;
 {%end if%}
 &lt;div class=&quot;filters&quot;&gt;
   &lt;a {%if :filter == &#x27;all&#x27;%}class=&quot;selected&quot;{%end if%} href=&quot;/todos?filter=all&quot;&gt;All&lt;/a&gt; |


### PR DESCRIPTION
## Summary
- tidy index.html example code by splitting long attribute lines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686413eddfa8832f85e9cd0808f7cd4a