### PR TITLE
Align package version with pyproject

### DIFF
--- a/src/pageql/__init__.py
+++ b/src/pageql/__init__.py
@@ -11,7 +11,7 @@ from .reactive_sql import parse_reactive
 from .jws_utils import jws_serialize_compact, jws_deserialize_compact
 from .highlighter import highlight, highlight_block
 # Define the version
-__version__ = "0.1.0"
+__version__ = "0.2.2"
 
 # Make these classes available directly from the package
 __all__ = [

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,10 @@
+import pageql
+import tomllib
+from pathlib import Path
+
+
+def test_version_matches_pyproject():
+    root = Path(__file__).resolve().parents[1]
+    pyproject_file = root / "pyproject.toml"
+    data = tomllib.loads(pyproject_file.read_text())
+    assert pageql.__version__ == data["project"]["version"]


### PR DESCRIPTION
## Summary
- update `__version__` in `pageql.__init__`
- add regression test ensuring `pageql.__version__` matches `pyproject.toml`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865496218b0832f9dea1ab4a27119aa