### PR TITLE
Handle closing script tag case insensitively

### DIFF
--- a/src/pageql/render_context.py
+++ b/src/pageql/render_context.py
@@ -1,11 +1,12 @@
 """Utilities and classes for managing rendering state."""
 
 import json
+import re
 
 
 def escape_script(content: str) -> str:
     """Escape closing ``</script>`` tags in *content* for safe embedding."""
-    return content.replace("</script>", "<\\/script>")
+    return re.sub(r"</script>", "<\\/script>", content, flags=re.IGNORECASE)
 
 
 def embed_html_in_js(content: str) -> str:

--- a/tests/test_embed_html_in_js.py
+++ b/tests/test_embed_html_in_js.py
@@ -5,3 +5,7 @@ from pageql.render_context import embed_html_in_js, escape_script
 def test_embed_html_in_js_matches_escape_script_plus_json_dumps():
     s = "<div><script></script></div>"
     assert embed_html_in_js(s) == escape_script(json.dumps(s))
+
+
+def test_escape_script_ignores_case():
+    assert escape_script("</SCRIPT>") == "<\\/script>"


### PR DESCRIPTION
## Summary
- escape closing `</script>` tags without caring about case
- test escaping of uppercase `</SCRIPT>` tags

## Testing
- `pytest tests/test_embed_html_in_js.py`

------
https://chatgpt.com/codex/tasks/task_e_6865496817ac832fa32aa58fa1e88733