### PR TITLE
Remove watchfiles stubs from tests

### DIFF
--- a/tests/test_add_reactive_elements.py
+++ b/tests/test_add_reactive_elements.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 import sqlglot

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-import types
 import tempfile
 import http.client
 import pageql.pageqlapp
@@ -10,8 +9,6 @@ import base64
 import html
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from playwright_helpers import run_server_in_task
 

--- a/tests/test_ast_dependencies.py
+++ b/tests/test_ast_dependencies.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies

--- a/tests/test_attach_directive.py
+++ b/tests/test_attach_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -2,20 +2,14 @@ import sys
 import importlib.util
 import tempfile
 import asyncio
-import types
 from pathlib import Path
 import pytest
 
 pytestmark = pytest.mark.anyio
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 
-async def _awatch_stub(*args, **kwargs):
-    if False:
-        yield None
 
-sys.modules["watchfiles"].awatch = _awatch_stub
 
 from pageql.pageqlapp import PageQLApp
 from playwright_helpers import _load_page_async, run_server_in_task

--- a/tests/test_cachable_onevent.py
+++ b/tests/test_cachable_onevent.py
@@ -1,10 +1,7 @@
 import sys
 from pathlib import Path
-import types
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,8 @@
 import sys
 from pathlib import Path
-import types
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 import pageql.cli as cli
 

--- a/tests/test_each.py
+++ b/tests/test_each.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL

--- a/tests/test_error_directive.py
+++ b/tests/test_error_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 import pytest

--- a/tests/test_evalone.py
+++ b/tests/test_evalone.py
@@ -1,12 +1,9 @@
 import sqlite3
-import types
 import sys
 from pathlib import Path
 
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 import pytest
 

--- a/tests/test_fetch_directive.py
+++ b/tests/test_fetch_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies

--- a/tests/test_from_dependencies.py
+++ b/tests/test_from_dependencies.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast

--- a/tests/test_from_first_row.py
+++ b/tests/test_from_first_row.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL

--- a/tests/test_from_infinite.py
+++ b/tests/test_from_infinite.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast

--- a/tests/test_from_infinite_console.py
+++ b/tests/test_from_infinite_console.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL, _row_hash

--- a/tests/test_from_infinite_wraps_order.py
+++ b/tests/test_from_infinite_wraps_order.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL

--- a/tests/test_header_directive.py
+++ b/tests/test_header_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies

--- a/tests/test_infinite_load_more.py
+++ b/tests/test_infinite_load_more.py
@@ -1,8 +1,6 @@
 import sqlite3
 from pathlib import Path
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 import asyncio

--- a/tests/test_infinite_scroll.py
+++ b/tests/test_infinite_scroll.py
@@ -1,6 +1,4 @@
-import sys, types
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pathlib import Path

--- a/tests/test_infinite_scroll_browser.py
+++ b/tests/test_infinite_scroll_browser.py
@@ -1,7 +1,6 @@
 import sys
 import tempfile
 import asyncio
-import types
 from pathlib import Path
 import pytest
 
@@ -9,13 +8,8 @@ pytestmark = pytest.mark.anyio
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
 
-async def _awatch_stub(*args, **kwargs):
-    if False:
-        yield None
 
-sys.modules["watchfiles"].awatch = _awatch_stub
 
 from pageql.pageqlapp import PageQLApp
 from playwright_helpers import _load_page_async, run_server_in_task

--- a/tests/test_infinite_scroll_infinite_page.py
+++ b/tests/test_infinite_scroll_infinite_page.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pathlib import Path

--- a/tests/test_json_page.py
+++ b/tests/test_json_page.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL

--- a/tests/test_jws_utils.py
+++ b/tests/test_jws_utils.py
@@ -1,8 +1,5 @@
 import sys
-import types
 from pathlib import Path
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
 from pageql import jws_serialize_compact, jws_deserialize_compact

--- a/tests/test_jwt_token.py
+++ b/tests/test_jwt_token.py
@@ -1,9 +1,6 @@
 import sys
-import types
 import json
 
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
 from pageql.pageql import PageQL

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -1,4 +1,4 @@
-import sys, types, gc, tracemalloc
+import sys, gc, tracemalloc
 from pathlib import Path
 import pytest
 
@@ -10,9 +10,6 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 sys.path.insert(0, str(ROOT))
 
-# Stub watchfiles so it doesn't require optional dependency
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
 from benchmarks.benchmark_pageql import MODULES, SCENARIOS, bench_factory, reset_items, PARAMS

--- a/tests/test_mysql_hex_literal.py
+++ b/tests/test_mysql_hex_literal.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 import sqlglot

--- a/tests/test_onevent_cache.py
+++ b/tests/test_onevent_cache.py
@@ -1,9 +1,7 @@
-import sys, types
+import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *a, **k: None
 
 from pageql.pageql import PageQL
 

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -1,6 +1,4 @@
-import sys, types
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *a, **k: None
+import sys
 sys.path.insert(0, "src")
 
 import pytest

--- a/tests/test_parse_param_attrs.py
+++ b/tests/test_parse_param_attrs.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.database import parse_param_attrs

--- a/tests/test_quote_state.py
+++ b/tests/test_quote_state.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -1,12 +1,9 @@
 import sys
 from pathlib import Path
-import types
 import pytest
 
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 def assert_eq(a, b):
     assert a == b, f"{a} != {b}"
 

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -1,13 +1,9 @@
 import sqlite3
 from pathlib import Path
-import types
 import sys
 import sqlglot
 
-# Ensure import path and stub watchfiles
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.reactive import Tables, ReactiveTable, Select, Where, Aggregate, UnionAll, Join
 from pageql.reactive_sql import parse_reactive, FallbackReactive

--- a/tests/test_reactive_stateful.py
+++ b/tests/test_reactive_stateful.py
@@ -1,15 +1,11 @@
 import sqlite3
 import sys
-import types
 import pytest
 from pathlib import Path
 from hypothesis.stateful import RuleBasedStateMachine, rule, run_state_machine_as_test
 from hypothesis import strategies as st, assume, settings, HealthCheck
 
-# Ensure import path and stub watchfiles
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 if sys.platform == "darwin":
     pytest.skip("unsupported platform", allow_module_level=True)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -2,9 +2,6 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-import types
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL, RenderContext, _row_hash
 from pageql.reactive import DerivedSignal

--- a/tests/test_render_docstring.py
+++ b/tests/test_render_docstring.py
@@ -1,13 +1,10 @@
 import sys
 from pathlib import Path
-import types
 import pytest
 
 # Originally disabled due to intermittent failures; reenable the doctest now
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 __doc__ = """
 >>> from pageql.pageql import PageQL

--- a/tests/test_respond_directive.py
+++ b/tests/test_respond_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast, ast_param_dependencies

--- a/tests/test_scroll_load_more_js.py
+++ b/tests/test_scroll_load_more_js.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pathlib import Path

--- a/tests/test_showsource_directive.py
+++ b/tests/test_showsource_directive.py
@@ -1,6 +1,4 @@
-import sys, types
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *a, **k: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast

--- a/tests/test_sqlglot_cte_alias_bug.py
+++ b/tests/test_sqlglot_cte_alias_bug.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 import pytest

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,12 +1,9 @@
 import sys
 from pathlib import Path
 import sqlite3
-import types
 
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.reactive import Tables, ReactiveTable
 

--- a/tests/test_test_directive.py
+++ b/tests/test_test_directive.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pageql.parser import tokenize, build_ast

--- a/tests/test_todos_ordered_page.py
+++ b/tests/test_todos_ordered_page.py
@@ -1,6 +1,4 @@
-import types, sys
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
+import sys
 sys.path.insert(0, "src")
 
 from pathlib import Path

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,8 +1,5 @@
 import sys
-import types
 
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 sys.path.insert(0, "src")
 
 import pytest

--- a/tests/test_unknown_directive.py
+++ b/tests/test_unknown_directive.py
@@ -1,11 +1,8 @@
 import sys
 from pathlib import Path
-import types
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-sys.modules.setdefault("watchfiles", types.ModuleType("watchfiles"))
-sys.modules["watchfiles"].awatch = lambda *args, **kwargs: None
 
 from pageql.pageql import PageQL
 


### PR DESCRIPTION
## Summary
- centralize watchfiles awatch stub in tests/conftest.py
- drop duplicated stubs from individual tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_686549700208832f9342e0672c476f98