### PR TITLE
Fix tests

### DIFF
--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -105,8 +105,8 @@ def check_component(comp, callback):
             expected[idx] = new
         else:
             raise Exception(f"unknown event type {ev[0]}")
-    expected.sort()
-    final = sorted(conn.execute(comp.sql).fetchall())
+    expected.sort(key=repr)
+    final = sorted(conn.execute(comp.sql).fetchall(), key=repr)
     assert_eq(expected, final)
 
 


### PR DESCRIPTION
## Summary
- adjust sorting in `check_component` to handle `None` values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686563759198832fa979147bd860764f