### PR TITLE
Add subdirectory index support

### DIFF
--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -627,6 +627,20 @@ class PageQLApp:
             await self._serve_static_file(file_to_serve, include_scripts, client_id, send)
             return
 
+        if (
+            path_cleaned not in self.pageql_engine._modules
+            and path_cleaned not in self.static_files
+        ):
+            index_module = f"{path_cleaned}/index"
+            index_html = f"{path_cleaned}/index.html"
+            index_md = f"{path_cleaned}/index.md"
+            if index_module in self.pageql_engine._modules:
+                path_cleaned = index_module
+            elif index_html in self.static_files or index_md in self.static_files:
+                file_to_serve = index_html if index_html in self.static_files else index_md
+                await self._serve_static_file(file_to_serve, include_scripts, client_id, send)
+                return
+
         if await self._serve_static_file(path_cleaned, include_scripts, client_id, send):
             return
 

--- a/tests/test_directory_index.py
+++ b/tests/test_directory_index.py
@@ -1,0 +1,43 @@
+import asyncio
+from pathlib import Path
+
+from pageql.http_utils import _http_get
+from playwright_helpers import run_server_in_task
+
+
+def test_directory_index_pageql_served(tmp_path):
+    d = Path(tmp_path) / "foo"
+    d.mkdir()
+    (d / "index.pageql").write_text("hello", encoding="utf-8")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, body_bytes = await _http_get(
+            f"http://127.0.0.1:{port}/foo"
+        )
+        server.should_exit = True
+        await task
+        return status, body_bytes.decode()
+
+    status, body = asyncio.run(run_test())
+    assert status == 200
+    assert "hello" in body
+
+
+def test_directory_index_html_served(tmp_path):
+    d = Path(tmp_path) / "bar"
+    d.mkdir()
+    (d / "index.html").write_text("<h1>Bar</h1>", encoding="utf-8")
+
+    async def run_test():
+        server, task, port = await run_server_in_task(str(tmp_path))
+        status, _headers, body_bytes = await _http_get(
+            f"http://127.0.0.1:{port}/bar"
+        )
+        server.should_exit = True
+        await task
+        return status, body_bytes.decode()
+
+    status, body = asyncio.run(run_test())
+    assert status == 200
+    assert "<h1>Bar</h1>" in body


### PR DESCRIPTION
## Summary
- support serving `index.pageql` or `index.html` within subdirectories
- test directory index handling

## Testing
- `PYTHONPATH=src pytest tests/test_directory_index.py`

------
https://chatgpt.com/codex/tasks/task_e_68665bf45f98832fac3ca424c6800ca2