### PR TITLE
Add combined auth.page

### DIFF
--- a/tests/test_auth_page.py
+++ b/tests/test_auth_page.py
@@ -1,0 +1,97 @@
+import asyncio
+from pathlib import Path
+import tempfile
+
+from pageql.http_utils import _http_get
+from pageql import jws_serialize_compact, jws_deserialize_compact
+from playwright_helpers import run_server_in_task
+import json
+import re
+
+
+def test_auth_page_renders_form_and_github(monkeypatch):
+    src = Path("website/auth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "auth.pageql").write_text(src, encoding="utf-8")
+        monkeypatch.setenv("GITHUB_CLIENT_ID", "Iv23liGYF2X5uR4izdC3")
+
+        async def run_test():
+            server, task, port = await run_server_in_task(tmpdir)
+            status, _headers, body = await _http_get(f"http://127.0.0.1:{port}/auth")
+            server.should_exit = True
+            await task
+            return status, body.decode()
+
+        status, body = asyncio.run(run_test())
+
+        assert status == 200
+        assert "github.com/login/oauth/authorize" in body
+        assert "Iv23liGYF2X5uR4izdC3" in body
+        assert "/auth/login" in body
+
+        m = re.search(r"state=([^\"]+)", body)
+        assert m is not None
+        token = m.group(1)
+        data = json.loads(jws_deserialize_compact(token).decode())
+        assert data["ongoing"] == 1
+        assert data["path"] == "/auth"
+
+
+def test_auth_github_callback_fetch(monkeypatch):
+    src = Path("website/auth.pageql").read_text()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Path(tmpdir, "auth.pageql").write_text(src, encoding="utf-8")
+
+        async def run_test():
+            from pageql import pageql as pql_mod
+            seen = []
+
+            async def fake_fetch(url: str, headers=None, method="GET", body=None, **kwargs):
+                seen.append((url, headers, method))
+                if "api.github.com/user" in url:
+                    return {
+                        "status_code": 200,
+                        "headers": [],
+                        "body": '{"login": "octocat"}',
+                    }
+                return {
+                    "status_code": 200,
+                    "headers": [],
+                    "body": 'access_token=t&token_type=bearer&scope=',
+                }
+
+            old_fetch = pql_mod.fetch
+            pql_mod.fetch = fake_fetch
+            monkeypatch.setenv("GITHUB_CLIENT_SECRET", "secret")
+            monkeypatch.setenv("GITHUB_CLIENT_ID", "Iv23liGYF2X5uR4izdC3")
+            try:
+                server, task, port = await run_server_in_task(tmpdir)
+                state = jws_serialize_compact('{"ongoing":1,"path":"/auth"}')
+                status, _headers, body = await _http_get(
+                    f"http://127.0.0.1:{port}/auth/callback?code=abc&state={state}"
+                )
+                server.should_exit = True
+                await task
+            finally:
+                pql_mod.fetch = old_fetch
+            return status, body.decode(), seen, state
+
+        status, body, urls, state = asyncio.run(run_test())
+
+        assert status == 200
+        assert "Loading token" in body
+        assert "access_token" not in body
+        assert "octocat" not in body
+        (token_url, token_headers, token_method), (user_url, user_headers, user_method) = urls
+        assert token_url.startswith("https://github.com/login/oauth/access_token")
+        assert "Iv23liGYF2X5uR4izdC3" in token_url
+        assert "client_secret=secret" in token_url
+        assert "code=abc" in token_url
+        assert f"state={state}" in token_url
+        assert user_url == "https://api.github.com/user"
+        assert user_headers == {
+            "Authorization": "Bearer t",
+            "User-Agent": "PageQL",
+        }
+        assert token_method == "GET"
+        assert user_method == "GET"

--- a/website/auth.pageql
+++ b/website/auth.pageql
@@ -1,0 +1,125 @@
+{%
+create table if not exists users (
+    id INTEGER PRIMARY KEY,
+    username TEXT UNIQUE,
+    password TEXT
+);
+create table if not exists sessions (
+    token TEXT PRIMARY KEY,
+    user_id INTEGER
+);
+insert or ignore into users(id, username, password) values (1, 'alice', 'password');
+insert or ignore into users(id, username, password) values (2, 'bob', 'pass');
+let payload json_set('{}', '$.ongoing', 1, '$.path', :path);
+let state jws_serialize_compact(:payload);
+let client_id = env.GITHUB_CLIENT_ID;
+%}
+
+{%
+-- Helper to load the logged in user from session cookie
+param session optional;
+let user_id = user_id from sessions where token=:session;
+let username = username from users where id=:user_id;
+%}
+
+{%if username%}
+<p>Logged in as {{username}}. <a href="/auth/profile">Profile</a> <a href="/auth/logout">Logout</a></p>
+{%else%}
+<p>You are not logged in. <a href="/auth/login">Login</a></p>
+<a href="https://github.com/login/oauth/authorize?client_id={{client_id}}&state={{state}}">
+  <button>Login with GitHub</button>
+</a>
+{%end if%}
+
+{%partial POST login%}
+{%
+  param username required;
+  param password required;
+  param session optional;
+  delete from sessions where token=:session;
+  let uid = id from users where username=:username and password=:password;
+%}
+  {%if uid%}
+    {%let token = lower(hex(randomblob(16)))%}
+    {%insert into sessions(token, user_id) values(:token, :uid)%}
+    {%cookie session :token path='/' httponly%}
+    {%redirect '/auth'%}
+  {%else%}
+    <p>Invalid credentials</p>
+  {%end if%}
+{%end partial%}
+
+{%partial GET login%}
+{%
+  param session optional;
+  let user_id = user_id from sessions where token=:session;
+  let username = username from users where id=:user_id;
+%}
+
+  <h1>Login</h1>
+  <form method="POST" action="/auth/login">
+    <input name="username" placeholder="Username">
+    <input name="password" type="password" placeholder="Password">
+    <button type="submit">Login</button>
+  </form>
+{%end partial%}
+
+{%partial GET profile%}
+{%
+  param session optional;
+  let user_id = user_id from sessions where token=:session;
+  let username = username from users where id=:user_id;
+%}
+
+  {%if username%}
+    <h1>Hello {{username}}</h1>
+    <p><a href="/auth/logout">Logout</a></p>
+  {%else%}
+    {%redirect '/auth/login'%}
+  {%end if%}
+{%end partial%}
+
+{%partial public logout%}
+{%
+  param session optional;
+  delete from sessions where token=:session;
+  cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT';
+  redirect '/auth';
+%}
+{%end partial%}
+
+{%partial GET callback%}
+{%
+  param code required;
+  param state required;
+  let payload jws_deserialize_compact(:state);
+  let payload_path = json_extract(:payload, '$.path');
+%}
+  <p>Payload: {{:payload}}</p>
+  <p>Payload path: {{:payload_path}}</p>
+{%
+  let client_id = env.GITHUB_CLIENT_ID;
+  let client_secret = env.GITHUB_CLIENT_SECRET;
+%}
+  {%fetch async token from 'https://github.com/login/oauth/access_token?client_id='||:client_id||'&client_secret='||:client_secret||'&code='||:code||'&state='||:state%}
+    {%if :token.status_code == 200%}
+      {%let access_token = query_param(:token.body, 'access_token')%}
+      <p>Extracted access token: {{access_token}}</p>
+      {%
+        let header = 'Authorization: Bearer '||:access_token;
+        let user_agent_header = 'User-Agent: PageQL';
+      %}
+      {%fetch async user from 'https://api.github.com/user' header=:header header=:user_agent_header%}
+        {%if :user.status_code == 200%}
+          {{user.body}}
+        {%elif :user.status_code IS NOT NULL%}
+          <p>Error: {{:user.status_code}} {{:user.body}}</p>
+        {%else%}
+          <p>Loading user...</p>
+        {%end if%}
+      {{/fetch}}
+    {%else%}
+      <p>Loading token...</p>
+    {%end if%}
+  {{/fetch}}
+{%end partial%}


### PR DESCRIPTION
## Summary
- create `auth.pageql` that combines username/password auth with GitHub OAuth
- add tests covering the new page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686660bfd4f0832f8db958813368ba7d