### PR TITLE
Rename auth callback route

### DIFF
--- a/tests/test_auth_page.py
+++ b/tests/test_auth_page.py
@@ -68,7 +68,7 @@ def test_auth_github_callback_fetch(monkeypatch):
                 server, task, port = await run_server_in_task(tmpdir)
                 state = jws_serialize_compact('{"ongoing":1,"path":"/auth"}')
                 status, _headers, body = await _http_get(
-                    f"http://127.0.0.1:{port}/auth/callback?code=abc&state={state}"
+                    f"http://127.0.0.1:{port}/auth/githubcallback?code=abc&state={state}"
                 )
                 server.should_exit = True
                 await task

--- a/website/auth.pageql
+++ b/website/auth.pageql
@@ -88,7 +88,7 @@ let username = username from users where id=:user_id;
 %}
 {%end partial%}
 
-{%partial GET callback%}
+{%partial GET githubcallback%}
 {%
   param code required;
   param state required;


### PR DESCRIPTION
## Summary
- rename `auth.pageql` callback partial to `githubcallback`
- update tests for new callback name

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_686667bc6a48832f9c837f4f6ce53cc3