### PR TITLE
Add complex join test cases

### DIFF
--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -143,6 +143,22 @@ def test_parse_join_order():
     assert_sql_equivalent(conn, sql, comp.sql)
 
 
+def test_parse_join_alias_order():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE tweets(id INTEGER PRIMARY KEY, user_id INTEGER, text TEXT)")
+    conn.execute("CREATE TABLE users(id INTEGER PRIMARY KEY, username TEXT)")
+    tables = Tables(conn)
+    sql = (
+        "SELECT t.id AS tid, u.username AS uname FROM tweets t "
+        "JOIN users u ON t.user_id=u.id ORDER BY t.id DESC"
+    )
+    expr = sqlglot.parse_one(sql, read="sqlite")
+    comp = parse_reactive(expr, tables, {})
+    assert isinstance(comp, Order)
+    assert isinstance(comp.parent, Join)
+    assert_sql_equivalent(conn, sql, comp.sql)
+
+
 def test_parse_select_with_params():
     conn = _db()
     tables = Tables(conn)


### PR DESCRIPTION
## Summary
- extend relation tests with tweets/users join scenarios
- add alias-heavy join test for SQL parsing
- reuse relation sequence for join ordering

## Testing
- `pytest` *(fails: tests/test_reactive.py::test_component_sqls[relation_join_order] ...)*

------
https://chatgpt.com/codex/tasks/task_e_686668291850832f969da7208c31d093