### PR TITLE
Add following selector to twitter example

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -17,3 +17,58 @@ def test_twitter_post_and_render():
     body = result.body
     assert "alice" in body
     assert "hello" in body
+
+
+def test_twitter_follow_filter():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    r.render("/twitter/index", reactive=False)
+
+    r.render(
+        "/twitter/index",
+        params={"username": "alice", "text": "hello"},
+        partial="tweet",
+        http_verb="POST",
+    )
+    r.render(
+        "/twitter/index",
+        params={"username": "bob", "text": "hi"},
+        partial="tweet",
+        http_verb="POST",
+    )
+
+    bob_id = r.db.execute("select id from users where username='bob'").fetchone()[0]
+
+    result = r.render(
+        "/twitter/index",
+        params={"username": "alice", "filter": "following"},
+        reactive=False,
+    )
+    assert "bob</strong>: hi" not in result.body
+
+    r.render(
+        "/twitter/index",
+        params={"username": "alice", "filter": "all", "follow": bob_id},
+        reactive=False,
+    )
+
+    result = r.render(
+        "/twitter/index",
+        params={"username": "alice", "filter": "following"},
+        reactive=False,
+    )
+    assert "bob</strong>: hi" in result.body
+
+    r.render(
+        "/twitter/index",
+        params={"username": "alice", "filter": "all", "unfollow": bob_id},
+        reactive=False,
+    )
+
+    result = r.render(
+        "/twitter/index",
+        params={"username": "alice", "filter": "following"},
+        reactive=False,
+    )
+    assert "bob</strong>: hi" not in result.body

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -1,4 +1,8 @@
 {%
+param filter default='all' pattern="^(all|following)$";
+param username default='';
+param follow type=integer optional;
+param unfollow type=integer optional;
 -- Ensure tables exist
 create table if not exists users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -10,6 +14,28 @@ create table if not exists tweets (
     text TEXT NOT NULL,
     created_at TEXT DEFAULT (strftime('%Y-%m-%d %H:%M:%S','now'))
 );
+create table if not exists following (
+    follower_id INTEGER,
+    following_id INTEGER,
+    primary key(follower_id, following_id)
+);
+let current_id = select (select id from users where username=:username);
+if :follow is not null;
+  let uid_temp = select (select id from users where username=:username);
+  if :uid_temp is null;
+    insert into users(username) values (:username);
+    let uid last_insert_rowid();
+  else;
+    let uid :uid_temp;
+  end if;
+  insert or ignore into following(follower_id, following_id) values(:uid, :follow);
+end if;
+if :unfollow is not null;
+  let uid = select (select id from users where username=:username);
+  if :uid is not null;
+    delete from following where follower_id=:uid and following_id=:unfollow;
+  end if;
+end if;
 %}
 
 <!doctype html>
@@ -20,17 +46,49 @@ create table if not exists tweets (
 </head>
 <body>
   <h1>Mini Twitter</h1>
-  <input name="username" placeholder="Username" autocomplete="off">
-  <input name="text" placeholder="What's happening?" maxlength="280"
-         hx-post="/twitter/index/tweet"
-         hx-trigger="keyup[key=='Enter']"
-         hx-include="[name=username]"
-         hx-on:htmx:after-on-load="this.value=''" autofocus>
-  <ul id="tweets">
-  {%from tweets join users on tweets.user_id=users.id order by tweets.id desc%}
-    <li><strong>{{username}}</strong>: {{text}}</li>
-  {%end from%}
-  </ul>
+  <div style="display:flex; gap:2rem; align-items:flex-start;">
+    <div style="flex:1;">
+      <input name="username" placeholder="Username" value="{{:username}}" autocomplete="off">
+      <select name="filter" hx-get="/twitter/index" hx-target="#tweets" hx-include="[name=username]">
+        <option value="all" {%if :filter=='all'%}selected{%end if%}>All</option>
+        <option value="following" {%if :filter=='following'%}selected{%end if%}>Following</option>
+      </select>
+      <input name="text" placeholder="What's happening?" maxlength="280"
+             hx-post="/twitter/index/tweet"
+             hx-trigger="keyup[key=='Enter']"
+             hx-include="[name=username]"
+             hx-on:htmx:after-on-load="this.value=''" autofocus>
+      <ul id="tweets">
+      {%from tweets join users on tweets.user_id=users.id
+             where (:filter='all') or
+                   (:filter='following' and :current_id is not null and exists(select 1 from following where follower_id=:current_id and following_id=tweets.user_id))
+             order by tweets.id desc%}
+        <li><strong>{{username}}</strong>: {{text}}</li>
+      {%end from%}
+      </ul>
+    </div>
+    <div>
+      <h2>Users</h2>
+      <ul id="users">
+      {%from (
+        select u.id, u.username,
+               (select count(*) from following f where f.follower_id=:current_id and f.following_id=u.id) as is_following
+        from users u
+        where u.username != :username
+        order by u.username
+      )%}
+        <li>
+          {{username}}
+          {%if :is_following == 0%}
+            <button hx-get="/twitter/index?username={{:username}}&follow={{id}}&filter={{:filter}}">Follow</button>
+          {%else%}
+            <button hx-get="/twitter/index?username={{:username}}&unfollow={{id}}&filter={{:filter}}">Unfollow</button>
+          {%end if%}
+        </li>
+      {%end from%}
+    </ul>
+  </div>
+  </div>
 </body>
 </html>
 
@@ -38,13 +96,12 @@ create table if not exists tweets (
 partial post tweet;
   param username maxlength=32;
   param text maxlength=280;
-  let uid_temp = id from users where username=:username;
+  let uid_temp = select (select id from users where username=:username);
   if :uid_temp is null;
     insert into users(username) values (:username);
-    let uid last_insert_rowid();
-  else;
-    let uid :uid_temp;
   end if;
+  let uid = id from users where username=:username;
   insert into tweets(user_id, text) values (:uid, :text);
 end partial
+
 %}


### PR DESCRIPTION
## Summary
- add follow/unfollow support to Twitter example
- filter tweets by followed users
- list users with follow/unfollow buttons
- test following functionality

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_686666d08890832f85ba2d74daf9a921