### PR TITLE
Add failing reactive twitter test

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -72,3 +72,23 @@ def test_twitter_follow_filter():
         reactive=False,
     )
     assert "bob</strong>: hi" not in result.body
+
+def test_twitter_follow_filter_reactive_anonymous():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    r.render("/twitter/index", reactive=False)
+
+    r.render(
+        "/twitter/index",
+        params={"username": "alice", "text": "hello"},
+        partial="tweet",
+        http_verb="POST",
+    )
+
+    result = r.render(
+        "/twitter/index",
+        params={"filter": "following"},
+        reactive=True,
+    )
+    assert "hello" not in result.body


### PR DESCRIPTION
## Summary
- add failing test for twitter page when filtering by following in reactive mode

## Testing
- `pytest tests/test_twitter_page.py::test_twitter_post_and_render -vv`
- `pytest -k twitter_follow_filter_reactive_anonymous -vv` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68666c8f611c832f96c6d065e38b53d0