### PR TITLE
Fix attach directive

### DIFF
--- a/tests/test_attach_directive.py
+++ b/tests/test_attach_directive.py
@@ -32,3 +32,36 @@ def test_attach_directive_render(tmp_path):
     out = r.render("/m", {"p": str(other)}, reactive=False).body.strip()
     assert out == "1"
 
+
+def test_attach_directive_reuse_same_file(tmp_path):
+    db = tmp_path / "a.db"
+    sqlite3.connect(db).close()
+
+    r = PageQL(":memory:")
+    r.load_module("m", "{%attach database :p as other%}")
+    r.render("/m", {"p": str(db)}, reactive=False)
+    r.render("/m", {"p": str(db)}, reactive=False)
+    assert r._attached["other"] == str(db)
+
+
+def test_attach_directive_switch_file(tmp_path):
+    db1 = tmp_path / "a.db"
+    db2 = tmp_path / "b.db"
+    conn1 = sqlite3.connect(db1)
+    conn1.execute("create table t(x int)")
+    conn1.execute("insert into t values (1)")
+    conn1.commit(); conn1.close()
+    conn2 = sqlite3.connect(db2)
+    conn2.execute("create table t(x int)")
+    conn2.execute("insert into t values (1)")
+    conn2.execute("insert into t values (2)")
+    conn2.commit(); conn2.close()
+
+    r = PageQL(":memory:")
+    r.load_module("m", "{%attach database :p as other%}{{count(*) from other.t}}")
+    out1 = r.render("/m", {"p": str(db1)}, reactive=False).body.strip()
+    out2 = r.render("/m", {"p": str(db2)}, reactive=False).body.strip()
+    assert out1 == "1"
+    assert out2 == "2"
+    assert r._attached["other"] == str(db2)
+

--- a/tests/test_reactive.py
+++ b/tests/test_reactive.py
@@ -82,16 +82,25 @@ def check_component(comp, callback):
             expected = [(ev,)]
             continue
         if ev[0] == 1:
-            row = tuple(ev[1])
+            row = ev[2] if len(ev) > 2 else ev[1]
+            row = tuple(row)
             if len(row) != cols_len:
                 raise Exception("bad number of columns on insert")
             expected.append(row)
         elif ev[0] == 2:
-            row = tuple(ev[1])
-            if row not in expected:
-                raise Exception("deleting nonexistent row")
-            expected.remove(row)
+            if len(ev) == 2 and isinstance(ev[1], int):
+                del expected[ev[1]]
+            else:
+                row = tuple(ev[1])
+                if row not in expected:
+                    raise Exception("deleting nonexistent row")
+                expected.remove(row)
         elif ev[0] == 3:
+            if len(ev) == 4:
+                old_idx, new_idx, row = ev[1], ev[2], tuple(ev[3])
+                expected.pop(old_idx)
+                expected.insert(new_idx, row)
+                continue
             old, new = tuple(ev[1]), tuple(ev[2])
             if old not in expected:
                 alt_old = tuple(0 if v is None else v for v in old)


### PR DESCRIPTION
## Summary
- keep track of attached databases so the same file isn't attached twice
- add tests covering reusing and switching attached database files
- allow reactive tests to handle events that include indices

## Testing
- `PYTHONPATH=src pytest` *(fails: tests/test_reactive.py::test_component_sqls[relation_join_order]* etc.)

------
https://chatgpt.com/codex/tasks/task_e_68666e72559c832fa912cfdb419f650c