### PR TITLE
Use read-only path when attaching imdb database

### DIFF
--- a/tests/test_imdb_page.py
+++ b/tests/test_imdb_page.py
@@ -12,7 +12,7 @@ def test_imdb_attach_parsed():
     src = Path("website/imdb.pageql").read_text()
     tokens = tokenize(src)
     body, _ = build_ast(tokens, dialect="sqlite")
-    assert ("#attach", "database '/opt/imdb.db' as imdb") in body
+    assert ("#attach", "database 'file:/opt/imdb.db?mode=ro' as imdb") in body
 
 
 def test_imdb_people_listing(tmp_path):

--- a/website/imdb.pageql
+++ b/website/imdb.pageql
@@ -1,7 +1,7 @@
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 
 {%partial people/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.people limit :offset + 50, 1)%}
 <span
@@ -17,7 +17,7 @@
 {%end partial%}
 
 {%partial titles/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.titles limit :offset + 50, 1)%}
 <span
@@ -33,7 +33,7 @@
 {%end partial%}
 
 {%partial akas/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.akas limit :offset + 50, 1)%}
 <span
@@ -49,7 +49,7 @@
 {%end partial%}
 
 {%partial crew/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.crew limit :offset + 50, 1)%}
 <span
@@ -65,7 +65,7 @@
 {%end partial%}
 
 {%partial episodes/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.episodes limit :offset + 50, 1)%}
 <span
@@ -81,7 +81,7 @@
 {%end partial%}
 
 {%partial ratings/:offset%}
-{%attach database '/opt/imdb.db' as imdb%}
+{%attach database 'file:/opt/imdb.db?mode=ro' as imdb%}
 {%param offset type=integer%}
 {%let has_more = exists(select 1 from imdb.ratings limit :offset + 50, 1)%}
 <span


### PR DESCRIPTION
## Summary
- attach the sample IMDB database using SQLite read-only URI syntax
- update tests to expect the new attach statement

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866833d2644832f8a915bd63b998969