### PR TITLE
Fix follow button update

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -92,3 +92,27 @@ def test_twitter_follow_filter_reactive_anonymous():
         reactive=True,
     )
     assert "hello" not in result.body
+
+
+def test_twitter_follow_button_updates():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    r.render("/twitter/index", reactive=False)
+
+    r.render(
+        "/twitter/index",
+        params={"username": "bob", "text": "hi"},
+        partial="tweet",
+        http_verb="POST",
+    )
+    bob_id = r.db.execute("select id from users where username='bob'").fetchone()[0]
+
+    result = r.render(
+        "/twitter/index",
+        params={"username": "alice", "follow": bob_id},
+        reactive=False,
+    )
+
+    assert "unfollow=" in result.body
+    assert ">Unfollow</button>" in result.body

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -19,23 +19,18 @@ create table if not exists following (
     following_id INTEGER,
     primary key(follower_id, following_id)
 );
-let current_id = select (select id from users where username=:username);
 if :follow is not null;
-  let uid_temp = select (select id from users where username=:username);
-  if :uid_temp is null;
-    insert into users(username) values (:username);
-    let uid last_insert_rowid();
-  else;
-    let uid :uid_temp;
-  end if;
+  insert or ignore into users(username) values (:username);
+  let uid = select (select id from users where username=:username);
   insert or ignore into following(follower_id, following_id) values(:uid, :follow);
 end if;
 if :unfollow is not null;
-  let uid = select (select id from users where username=:username);
-  if :uid is not null;
-    delete from following where follower_id=:uid and following_id=:unfollow;
+  let uid_unfollow = select (select id from users where username=:username);
+  if :uid_unfollow is not null;
+    delete from following where follower_id=:uid_unfollow and following_id=:unfollow;
   end if;
 end if;
+let current_id = select (select id from users where username=:username);
 %}
 
 <!doctype html>


### PR DESCRIPTION
## Summary
- ensure user insertions occur before computing `current_id`
- simplify follow/unfollow logic to avoid redeclaring variables
- add unit test covering follow button update

## Testing
- `pytest`
- `pytest tests/test_twitter_page.py::test_twitter_follow_button_updates -vv`

------
https://chatgpt.com/codex/tasks/task_e_68668535b548832fb5c769fe0a736360