### PR TITLE
Add slow query logging

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -2,12 +2,17 @@ import re
 from collections import Counter
 from difflib import SequenceMatcher
 import sqlglot
+import time
 
 def execute(conn, sql, params):
+    start = time.perf_counter()
     try:
         cursor = conn.execute(sql, params)
     except Exception as e:
         raise Exception(f"Execute failed for query: {sql} with params: {params} with error: {e}")
+    duration_ms = (time.perf_counter() - start) * 1000
+    if duration_ms >= 10:
+        print(f"warning, slow query took {duration_ms:.2f}ms: {sql}")
     return cursor
 
 

--- a/tests/test_slow_query_warning.py
+++ b/tests/test_slow_query_warning.py
@@ -1,0 +1,18 @@
+import sqlite3
+import types
+
+import pageql.reactive as reactive
+
+
+def test_slow_query_warning(monkeypatch, capsys):
+    conn = sqlite3.connect(':memory:')
+    times = [0.0, 0.011]
+
+    def fake_perf_counter():
+        return times.pop(0)
+
+    monkeypatch.setattr(reactive.time, 'perf_counter', fake_perf_counter)
+    reactive.execute(conn, 'select 1', [])
+    out = capsys.readouterr().out.lower()
+    assert 'warning, slow query' in out
+    assert 'select 1' in out


### PR DESCRIPTION
## Summary
- log a warning when SQL queries take 10ms or longer
- test slow query warning functionality

## Testing
- `PYTHONPATH=src pytest tests/test_slow_query_warning.py`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_686686c98f68832fadffbb54b8b973f5