### PR TITLE
Add --debug alias for CLI

### DIFF
--- a/src/pageql/cli.py
+++ b/src/pageql/cli.py
@@ -94,6 +94,11 @@ def main():
         help='Delay before cleaning up HTTP disconnects.',
     )
     parser.add_argument('--log-level', default='info', help="Log level")
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Shortcut for --log-level debug',
+    )
 
     # If no arguments were provided (only the script name), print help and exit.
     if len(sys.argv) == 1:
@@ -101,6 +106,9 @@ def main():
         sys.exit(1)
 
     args = parser.parse_args()
+
+    if args.debug:
+        args.log_level = "debug"
 
     if args.parse:
         success = run_pageql_parse(args.templates_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,3 +158,20 @@ def test_cli_parse_website(monkeypatch):
     assert exc.value.code == 0
 
 
+def test_cli_debug_alias(monkeypatch, tmp_path):
+    created = {}
+
+    class DummyApp:
+        def __init__(self, db_file, templates_dir, **kwargs):
+            created["instance"] = self
+            self.log_level = None
+
+    monkeypatch.setattr(cli, "PageQLApp", DummyApp)
+    monkeypatch.setattr(cli.uvicorn, "run", lambda *a, **kw: None)
+
+    argv = ["pageql", str(tmp_path), "db", "--debug"]
+    monkeypatch.setattr(sys, "argv", argv)
+    cli.main()
+    assert created["instance"].log_level == "debug"
+
+


### PR DESCRIPTION
## Summary
- add `--debug` CLI option that sets log level to `debug`
- test that `--debug` maps to `--log-level debug`

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866864ea1c0832fa1a65ffb3ea55675