### PR TITLE
Enable SQLite foreign keys

### DIFF
--- a/src/pageql/database.py
+++ b/src/pageql/database.py
@@ -70,7 +70,12 @@ def connect_database(db_path: str):
                 )
     if db_path.startswith("sqlite://"):
         db_path = db_path.split("://", 1)[1]
-    return sqlite3.connect(db_path), "sqlite"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys=ON")
+    except sqlite3.Error:
+        pass
+    return conn, "sqlite"
 
 
 def flatten_params(params):

--- a/tests/test_connect_database.py
+++ b/tests/test_connect_database.py
@@ -16,3 +16,10 @@ def test_pageql_stores_dialect():
     p = PageQL(":memory:")
     assert p.dialect == "sqlite"
     p.db.close()
+
+
+def test_connect_database_enables_foreign_keys():
+    conn, _ = connect_database(":memory:")
+    val = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+    conn.close()
+    assert val == 1


### PR DESCRIPTION
## Summary
- activate SQLite foreign key enforcement in `connect_database`
- verify pragma via new unit test

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_686691fc9a04832f98603ca83944e951