### PR TITLE
Implement unique columns tracking

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -208,7 +208,14 @@ class ReactiveTable(Signal):
         self.conn = conn
         self.table_name = table_name
         cur = execute(self.conn, f"PRAGMA table_info({self.table_name})", [])
-        self.columns = [col[1] for col in cur]
+        cols_info = list(cur)
+        self.columns = [col[1] for col in cols_info]
+        self.unique_columns = {col[1] for col in cols_info if col[5]}
+        cur = execute(self.conn, f"PRAGMA index_list({self.table_name})", [])
+        for idx in cur:
+            if idx[2]:
+                for col in execute(self.conn, f"PRAGMA index_info({idx[1]})", []):
+                    self.unique_columns.add(col[2])
         self.sql = f"SELECT * FROM {self.table_name}"
 
     def remove_listener(self, listener):

--- a/tests/test_unique_columns.py
+++ b/tests/test_unique_columns.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+import sqlite3
+
+# Ensure the package can be imported without optional dependencies
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from pageql.reactive import ReactiveTable
+
+
+def test_reactive_table_unique_columns():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE items(id INTEGER PRIMARY KEY, "
+        "email TEXT UNIQUE, phone TEXT, UNIQUE(phone))"
+    )
+    rt = ReactiveTable(conn, "items")
+    assert rt.unique_columns == {"id", "email", "phone"}


### PR DESCRIPTION
## Summary
- add support for tracking unique columns in `ReactiveTable`
- add regression test covering unique column discovery

## Testing
- `pytest tests/test_unique_columns.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686693138a90832f9158985e745d6f54