### PR TITLE
Propagate unique columns to derived tables

### DIFF
--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -300,6 +300,8 @@ class Where(Signal):
         self.parent = parent
         self.where_sql = where_sql
         self.columns = self.parent.columns
+        if hasattr(self.parent, "unique_columns"):
+            self.unique_columns = set(self.parent.unique_columns)
         self.conn = self.parent.conn
         self.filter_sql = f"SELECT {', '.join([f'? as {col}' for col in self.columns])} WHERE {self.where_sql}"
         self.sql = f"SELECT * FROM ({self.parent.sql}) WHERE {self.where_sql}"
@@ -874,6 +876,9 @@ class Order(Signal):
         self.order_sql = order_sql
         self.limit = limit
         self.offset = offset
+
+        if hasattr(self.parent, "unique_columns"):
+            self.unique_columns = set(self.parent.unique_columns)
 
         self.deps = [self.parent]
         self.update = self.onevent

--- a/tests/test_unique_columns.py
+++ b/tests/test_unique_columns.py
@@ -5,7 +5,7 @@ import sqlite3
 # Ensure the package can be imported without optional dependencies
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
-from pageql.reactive import ReactiveTable
+from pageql.reactive import ReactiveTable, Where, Order
 
 
 def test_reactive_table_unique_columns():
@@ -16,3 +16,9 @@ def test_reactive_table_unique_columns():
     )
     rt = ReactiveTable(conn, "items")
     assert rt.unique_columns == {"id", "email", "phone"}
+
+    w = Where(rt, "email IS NOT NULL")
+    assert w.unique_columns == {"id", "email", "phone"}
+
+    o = Order(rt, "id")
+    assert o.unique_columns == {"id", "email", "phone"}


### PR DESCRIPTION
## Summary
- track unique columns in `Where` and `Order` components
- test that derived tables preserve unique column information

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866973fd7e4832fa0c79c9cc737607a