### PR TITLE
Fix failing tests

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -3,6 +3,13 @@ sys.path.insert(0, "src")
 
 from pathlib import Path
 from pageql.pageql import PageQL
+import re
+
+
+def extract_tweets(body: str) -> str:
+    match = re.search(r'<ul id="tweets">(.*?)</ul>', body, re.S)
+    assert match is not None
+    return match.group(1)
 
 
 def test_twitter_post_and_render():
@@ -45,7 +52,7 @@ def test_twitter_follow_filter():
         params={"username": "alice", "filter": "following"},
         reactive=False,
     )
-    assert "bob</strong>: hi" not in result.body
+    assert "bob</strong>: hi" not in extract_tweets(result.body)
 
     r.render(
         "/twitter/index",
@@ -58,7 +65,7 @@ def test_twitter_follow_filter():
         params={"username": "alice", "filter": "following"},
         reactive=False,
     )
-    assert "bob</strong>: hi" in result.body
+    assert "bob</strong>: hi" in extract_tweets(result.body)
 
     r.render(
         "/twitter/index",
@@ -71,7 +78,7 @@ def test_twitter_follow_filter():
         params={"username": "alice", "filter": "following"},
         reactive=False,
     )
-    assert "bob</strong>: hi" not in result.body
+    assert "bob</strong>: hi" not in extract_tweets(result.body)
 
 def test_twitter_follow_filter_reactive_anonymous():
     src = Path("website/twitter/index.pageql").read_text()
@@ -91,7 +98,7 @@ def test_twitter_follow_filter_reactive_anonymous():
         params={"filter": "following"},
         reactive=True,
     )
-    assert "hello" not in result.body
+    assert "hello" not in extract_tweets(result.body)
 
 
 def test_twitter_follow_button_updates():

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -83,7 +83,7 @@ let current_id = select (select id from users where username=:username);
       {%end from%}
     </ul>
   </div>
-  </div>
+</div>
   {%dump tweets %}
   {%dump following%}
 </body>


### PR DESCRIPTION
## Summary
- restore debug dumps on the demo twitter page
- ignore debug dumps in twitter tests

## Testing
- `pytest -k twitter_page -vv`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6866a372b93c832f993b614877cb4bdb