### PR TITLE
Fix infinite Order handling

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -951,8 +951,17 @@ class PageQL:
                 comp = parse_reactive(expr, self.tables, params)
                 if cache_allowed:
                     self._from_cache[cache_key] = comp
-            if infinite and not isinstance(comp, Order):
-                comp = Order(comp, "", limit=100)
+            if infinite:
+                if isinstance(comp, Order):
+                    limit = comp.limit if comp.limit is not None else 50
+                    comp = Order(
+                        comp.parent,
+                        comp.order_sql,
+                        limit=limit,
+                        offset=getattr(comp, "offset", 0),
+                    )
+                else:
+                    comp = Order(comp, "", limit=100)
             if comp.sql is not None:
                 try:
                     cursor = self.db.execute(comp.sql, converted_params)

--- a/tests/test_infinite_load_more.py
+++ b/tests/test_infinite_load_more.py
@@ -30,6 +30,27 @@ def test_infinite_from_adds_order_to_context():
     assert order.limit == 1
 
 
+def test_order_infinite_sets_default_limit():
+    page = """
+    {%create table items(id INTEGER)%}
+    {%insert into items(id) values (1)%}
+    {%insert into items(id) values (2)%}
+    <div>
+    {%from items order by id infinite%}
+      {{id}}
+    {%endfrom%}
+    </div>
+    """
+    r = PageQL(":memory:")
+    r.load_module("test2", page)
+    result = r.render("/test2")
+    ctx = result.context
+    assert len(ctx.infinites) == 1
+    order = list(ctx.infinites.values())[0]
+    assert isinstance(order, Order)
+    assert order.limit == 50
+
+
 def test_pageqlapp_handles_infinite_load_more(tmp_path):
     app = pageql.pageqlapp.PageQLApp(":memory:", tmp_path, create_db=True, should_reload=False)
 

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -84,8 +84,6 @@ let current_id = select (select id from users where username=:username);
     </ul>
   </div>
   </div>
-  {%dump tweets %}
-  {%dump following%}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- avoid wrapping `Order` twice when using the `infinite` flag
- ensure `Order` default limit is 50 when none is specified
- test the default limit behaviour
- remove debug dumps from the Twitter example

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866a74f47b8832fb24f1c0625a302ef