### PR TITLE
Switch Twitter filter selector to links

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -18,6 +18,15 @@ def test_twitter_post_and_render():
     assert "alice" in body
     assert "hello" in body
 
+def test_twitter_filter_links_present():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    result = r.render("/twitter/index", reactive=False)
+    body = result.body
+    assert 'hx-get="/twitter/index?filter=all"' in body
+    assert 'hx-get="/twitter/index?filter=following"' in body
+
 
 def test_twitter_follow_filter():
     src = Path("website/twitter/index.pageql").read_text()

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -31,10 +31,9 @@ let current_id = select (select id from users where username=:username);
   <div style="display:flex; gap:2rem; align-items:flex-start;">
     <div style="flex:1;">
       <input name="username" placeholder="Username" value="{{:username}}" autocomplete="off">
-      <select name="filter" hx-get="/twitter/index" hx-target="#tweets" hx-include="[name=username]">
-        <option value="all" {%if :filter=='all'%}selected{%end if%}>All</option>
-        <option value="following" {%if :filter=='following'%}selected{%end if%}>Following</option>
-      </select>
+      <a hx-get="/twitter/index?filter=all" hx-target="#tweets" hx-include="[name=username]" {%if :filter=='all'%}style="font-weight:bold"{%end if%}>All</a>
+      /
+      <a hx-get="/twitter/index?filter=following" hx-target="#tweets" hx-include="[name=username]" {%if :filter=='following'%}style="font-weight:bold"{%end if%}>Following</a>
       <input name="text" placeholder="What's happening?" maxlength="280"
              hx-post="/twitter/index/tweet"
              hx-trigger="keyup[key=='Enter']"


### PR DESCRIPTION
## Summary
- update mini Twitter demo to use links to filter tweets
- cover new filter links in tests

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_6866a928a8d4832faa84b3f4f49eca09