### PR TITLE
Fix user auth table collisions

### DIFF
--- a/examples/templates/basic_auth.pageql
+++ b/examples/templates/basic_auth.pageql
@@ -1,21 +1,21 @@
-{%create table if not exists users (
+{%create table if not exists auth_users (
     id INTEGER PRIMARY KEY,
     username TEXT UNIQUE,
     password TEXT
 )%}
 
-{%create table if not exists sessions (
+{%create table if not exists auth_sessions (
     token TEXT PRIMARY KEY,
     user_id INTEGER
 )%}
 
-{%insert or ignore into users(id, username, password) values (1, 'alice', 'password')%}
-{%insert or ignore into users(id, username, password) values (2, 'bob', 'pass')%}
+{%insert or ignore into auth_users(id, username, password) values (1, 'alice', 'password')%}
+{%insert or ignore into auth_users(id, username, password) values (2, 'bob', 'pass')%}
 
 {{!-- Helper to load the logged in user from session cookie --}}
 {%param session optional%}
-{%let user_id = user_id from sessions where token=:session%}
-{%let username = username from users where id=:user_id%}
+{%let user_id = user_id from auth_sessions where token=:session%}
+{%let username = username from auth_users where id=:user_id%}
 
 {%if username%}
 <p>Logged in as {{username}}. <a href="/basic_auth/profile">Profile</a> <a href="/basic_auth/logout">Logout</a></p>
@@ -27,11 +27,11 @@
   {%param username required%}
   {%param password required%}
   {%param session optional%}
-  {%delete from sessions where token=:session%}
-  {%let uid = id from users where username=:username and password=:password%}
+  {%delete from auth_sessions where token=:session%}
+  {%let uid = id from auth_users where username=:username and password=:password%}
   {%if uid%}
     {%let token = lower(hex(randomblob(16)))%}
-    {%insert into sessions(token, user_id) values(:token, :uid)%}
+    {%insert into auth_sessions(token, user_id) values(:token, :uid)%}
     {%cookie session :token path='/' httponly%}
     {%redirect '/basic_auth'%}
   {%else%}
@@ -41,8 +41,8 @@
 
 {%partial GET login%}
   {%param session optional%}
-  {%let user_id = user_id from sessions where token=:session%}
-  {%let username = username from users where id=:user_id%}
+  {%let user_id = user_id from auth_sessions where token=:session%}
+  {%let username = username from auth_users where id=:user_id%}
 
   <h1>Login</h1>
   <form method="POST" action="/basic_auth/login">
@@ -54,8 +54,8 @@
 
 {%partial GET profile%}
   {%param session optional%}
-  {%let user_id = user_id from sessions where token=:session%}
-  {%let username = username from users where id=:user_id%}
+  {%let user_id = user_id from auth_sessions where token=:session%}
+  {%let username = username from auth_users where id=:user_id%}
 
   {%if username%}
     <h1>Hello {{username}}</h1>
@@ -67,7 +67,7 @@
 
 {%partial public logout%}
   {%param session optional%}
-  {%delete from sessions where token=:session%}
+  {%delete from auth_sessions where token=:session%}
   {%cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT'%}
   {%redirect '/basic_auth'%}
 {%endpartial%}

--- a/website/auth.pageql
+++ b/website/auth.pageql
@@ -1,15 +1,15 @@
 {%
-create table if not exists users (
+create table if not exists auth_users (
     id INTEGER PRIMARY KEY,
     username TEXT UNIQUE,
     password TEXT
 );
-create table if not exists sessions (
+create table if not exists auth_sessions (
     token TEXT PRIMARY KEY,
     user_id INTEGER
 );
-insert or ignore into users(id, username, password) values (1, 'alice', 'password');
-insert or ignore into users(id, username, password) values (2, 'bob', 'pass');
+insert or ignore into auth_users(id, username, password) values (1, 'alice', 'password');
+insert or ignore into auth_users(id, username, password) values (2, 'bob', 'pass');
 let payload json_set('{}', '$.ongoing', 1, '$.path', :path);
 let state jws_serialize_compact(:payload);
 let client_id = env.GITHUB_CLIENT_ID;
@@ -18,8 +18,8 @@ let client_id = env.GITHUB_CLIENT_ID;
 {%
 -- Helper to load the logged in user from session cookie
 param session optional;
-let user_id = user_id from sessions where token=:session;
-let username = username from users where id=:user_id;
+let user_id = user_id from auth_sessions where token=:session;
+let username = username from auth_users where id=:user_id;
 %}
 
 {%if username%}
@@ -36,12 +36,12 @@ let username = username from users where id=:user_id;
   param username required;
   param password required;
   param session optional;
-  delete from sessions where token=:session;
-  let uid = id from users where username=:username and password=:password;
+  delete from auth_sessions where token=:session;
+  let uid = id from auth_users where username=:username and password=:password;
 %}
   {%if uid%}
     {%let token = lower(hex(randomblob(16)))%}
-    {%insert into sessions(token, user_id) values(:token, :uid)%}
+    {%insert into auth_sessions(token, user_id) values(:token, :uid)%}
     {%cookie session :token path='/' httponly%}
     {%redirect '/auth'%}
   {%else%}
@@ -52,8 +52,8 @@ let username = username from users where id=:user_id;
 {%partial GET login%}
 {%
   param session optional;
-  let user_id = user_id from sessions where token=:session;
-  let username = username from users where id=:user_id;
+  let user_id = user_id from auth_sessions where token=:session;
+  let username = username from auth_users where id=:user_id;
 %}
 
   <h1>Login</h1>
@@ -67,8 +67,8 @@ let username = username from users where id=:user_id;
 {%partial GET profile%}
 {%
   param session optional;
-  let user_id = user_id from sessions where token=:session;
-  let username = username from users where id=:user_id;
+  let user_id = user_id from auth_sessions where token=:session;
+  let username = username from auth_users where id=:user_id;
 %}
 
   {%if username%}
@@ -82,7 +82,7 @@ let username = username from users where id=:user_id;
 {%partial public logout%}
 {%
   param session optional;
-  delete from sessions where token=:session;
+  delete from auth_sessions where token=:session;
   cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT';
   redirect '/auth';
 %}

--- a/website/basic_auth.pageql
+++ b/website/basic_auth.pageql
@@ -1,22 +1,22 @@
 {%
-create table if not exists users (
+create table if not exists auth_users (
     id INTEGER PRIMARY KEY,
     username TEXT UNIQUE,
     password TEXT
 );
-create table if not exists sessions (
+create table if not exists auth_sessions (
     token TEXT PRIMARY KEY,
     user_id INTEGER
 );
-insert or ignore into users(id, username, password) values (1, 'alice', 'password');
-insert or ignore into users(id, username, password) values (2, 'bob', 'pass');
+insert or ignore into auth_users(id, username, password) values (1, 'alice', 'password');
+insert or ignore into auth_users(id, username, password) values (2, 'bob', 'pass');
 %}
 
 {%
 -- Helper to load the logged in user from session cookie
 param session optional;
-let user_id = user_id from sessions where token=:session;
-let username = username from users where id=:user_id;
+let user_id = user_id from auth_sessions where token=:session;
+let username = username from auth_users where id=:user_id;
 %}
 
 {%if username%}
@@ -30,12 +30,12 @@ let username = username from users where id=:user_id;
   param username required;
   param password required;
   param session optional;
-  delete from sessions where token=:session;
-  let uid = id from users where username=:username and password=:password;
+  delete from auth_sessions where token=:session;
+  let uid = id from auth_users where username=:username and password=:password;
 %}
   {%if uid%}
     {%let token = lower(hex(randomblob(16)))%}
-    {%insert into sessions(token, user_id) values(:token, :uid)%}
+    {%insert into auth_sessions(token, user_id) values(:token, :uid)%}
     {%cookie session :token path='/' httponly%}
     {%redirect '/basic_auth'%}
   {%else%}
@@ -46,8 +46,8 @@ let username = username from users where id=:user_id;
 {%partial GET login%}
 {%
   param session optional;
-  let user_id = user_id from sessions where token=:session;
-  let username = username from users where id=:user_id;
+  let user_id = user_id from auth_sessions where token=:session;
+  let username = username from auth_users where id=:user_id;
 %}
 
   <h1>Login</h1>
@@ -61,8 +61,8 @@ let username = username from users where id=:user_id;
 {%partial GET profile%}
 {%
   param session optional;
-  let user_id = user_id from sessions where token=:session;
-  let username = username from users where id=:user_id;
+  let user_id = user_id from auth_sessions where token=:session;
+  let username = username from auth_users where id=:user_id;
 %}
 
   {%if username%}
@@ -76,7 +76,7 @@ let username = username from users where id=:user_id;
 {%partial public logout%}
 {%
   param session optional;
-  delete from sessions where token=:session;
+  delete from auth_sessions where token=:session;
   cookie session '' path='/' expires='Thu, 01 Jan 1970 00:00:00 GMT';
   redirect '/basic_auth';
 %}

--- a/website/basic_auth_sessionless.pageql
+++ b/website/basic_auth_sessionless.pageql
@@ -1,11 +1,11 @@
 {%
-create table if not exists users (
+create table if not exists auth_users (
     id INTEGER PRIMARY KEY,
     username TEXT UNIQUE,
     password TEXT
 );
-insert or ignore into users(id, username, password) values (1, 'alice', 'password');
-insert or ignore into users(id, username, password) values (2, 'bob', 'pass');
+insert or ignore into auth_users(id, username, password) values (1, 'alice', 'password');
+insert or ignore into auth_users(id, username, password) values (2, 'bob', 'pass');
 %}
 
 {%
@@ -15,7 +15,7 @@ let payload = jws_deserialize_compact(:cookies.session);
 let uid = cast(json_extract(:payload, '$.uid') as integer);
 let expiry = cast(json_extract(:payload, '$.exp') as integer);
 let jwt_valid = (:expiry > cast(strftime('%s','now') as integer));
-let sess_username = username from users where id=:uid;
+let sess_username = username from auth_users where id=:uid;
 %}
 
 {%if :uid and :jwt_valid%}
@@ -28,7 +28,7 @@ let sess_username = username from users where id=:uid;
 {%
   param username required;
   param password required;
-  let uid id from users where username=:username and password=:password;
+  let uid id from auth_users where username=:username and password=:password;
 %}
   {%if uid%}
     {%let expiry (cast(strftime('%s','now') as integer) + 3600)%}
@@ -55,12 +55,12 @@ let sess_username = username from users where id=:uid;
 {%
   param username required;
   param password required;
-  let existing id from users where username=:username;
+  let existing id from auth_users where username=:username;
 %}
   {%if existing%}
     <p>User already exists</p>
   {%else%}
-    {%insert into users(username, password) values(:username, :password)%}
+    {%insert into auth_users(username, password) values(:username, :password)%}
     {%let uid last_insert_rowid()%}
     {%let expiry (cast(strftime('%s','now') as integer) + 3600)%}
     {%let payload json_set('{"role":"member"}', '$.exp', :expiry, '$.uid', :uid)%}
@@ -87,7 +87,7 @@ let sess_username = username from users where id=:uid;
   let uid cast(json_extract(:payload, '$.uid') as integer);
   let expiry cast(json_extract(:payload, '$.exp') as integer);
   let jwt_valid (:expiry > cast(strftime('%s','now') as integer));
-  let sess_username username from users where id=:uid;
+  let sess_username username from auth_users where id=:uid;
 %}
 
   {%if :uid and :jwt_valid%}


### PR DESCRIPTION
## Summary
- rename `users` and `sessions` tables used by auth templates
- keep example template in sync

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866ab0a1e80832fb518e6d310d72a3b