### PR TITLE
Propagate log level for SQL execution

### DIFF
--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -35,6 +35,7 @@ from pageql.reactive import (
     ReadOnly,
     _convert_dot_sql,
     Order,
+    set_log_level,
 )
 from pageql.render_context import (
     RenderContext,
@@ -199,6 +200,7 @@ class PageQL:
         if sqlite_file is not None:
             new_db = sqlite_file == ":memory:" or not os.path.exists(sqlite_file)
         self.db, self.dialect = connect_database(db_path)
+        set_log_level(self.db, "info")
         if isinstance(self.db, sqlite3.Connection) and new_db:
             # Configure SQLite for web server usage
             with self.db:

--- a/src/pageql/pageqlapp.py
+++ b/src/pageql/pageqlapp.py
@@ -17,6 +17,7 @@ from typing import Callable, Awaitable, Dict, List, Optional
 # Assuming pageql.py is in the same directory or Python path
 from . import pageql
 from .pageql import PageQL
+from .reactive import set_log_level
 from .http_utils import (
     _http_get,
     _read_chunked_body,
@@ -739,6 +740,7 @@ class PageQLApp:
         try:
             self.pageql_engine = PageQL(db_path)
             self.conn = self.pageql_engine.db
+            set_log_level(self.conn, self.log_level)
             try:
                 self.conn.create_function(
                     "base64_encode", 1,

--- a/src/pageql/reactive.py
+++ b/src/pageql/reactive.py
@@ -3,8 +3,15 @@ from collections import Counter
 from difflib import SequenceMatcher
 import sqlglot
 import time
+_LOG_LEVELS: dict[int, str] = {}
 
-def execute(conn, sql, params, log_level: str = "info"):
+def set_log_level(conn, log_level: str) -> None:
+    """Associate *log_level* with *conn* for SQL execution."""
+    _LOG_LEVELS[id(conn)] = log_level
+
+def execute(conn, sql, params, log_level: str | None = None):
+    if log_level is None:
+        log_level = _LOG_LEVELS.get(id(conn), "info")
     if log_level == "debug":
         print(f"SQL: {sql} {params}")
     start = time.perf_counter()

--- a/tests/test_connection_log_level.py
+++ b/tests/test_connection_log_level.py
@@ -1,0 +1,10 @@
+import os
+from pageql.pageqlapp import PageQLApp
+from pageql.reactive import execute
+
+
+def test_connection_log_level(tmp_path, capsys):
+    app = PageQLApp(':memory:', tmp_path, create_db=True, should_reload=False, log_level='debug')
+    execute(app.conn, 'select 1', [])
+    out = capsys.readouterr().out.lower()
+    assert 'sql: select 1' in out

--- a/tests/test_debug_sql_logging.py
+++ b/tests/test_debug_sql_logging.py
@@ -3,6 +3,7 @@ import pageql.reactive as reactive
 
 def test_debug_sql_logging(capsys):
     conn = sqlite3.connect(':memory:')
-    reactive.execute(conn, 'select 1', [], log_level='debug')
+    reactive.set_log_level(conn, 'debug')
+    reactive.execute(conn, 'select 1', [])
     out = capsys.readouterr().out.lower()
     assert 'sql: select 1' in out


### PR DESCRIPTION
## Summary
- centralize SQL log level with `set_log_level`
- ensure new connections inherit application log level
- test debug SQL logging and log level propagation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866b5bef14c832faba949aee123261b