### PR TITLE
Add user selector datalist for Mini Twitter

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -141,3 +141,14 @@ def test_twitter_follow_button_updates():
 
     assert 'hx-delete="/twitter/index/follow/' in result.body
     assert ">Unfollow</button>" in result.body
+
+
+def test_twitter_username_selector_present():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    result = r.render("/twitter/index", reactive=False)
+    body = result.body
+    assert '<input name="username"' in body
+    assert 'list="usernames"' in body
+    assert '<datalist id="usernames">' in body

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -30,7 +30,12 @@ let current_id = select (select id from users where username=:username);
   <h1>Mini Twitter</h1>
   <div style="display:flex; gap:2rem; align-items:flex-start;">
     <div style="flex:1;">
-      <input name="username" placeholder="Username" value="{{:username}}" autocomplete="off">
+      <input name="username" placeholder="Username" value="{{:username}}" autocomplete="off" list="usernames">
+      <datalist id="usernames">
+      {%from users order by username%}
+        <option value="{{username}}">
+      {%end from%}
+      </datalist>
       <a hx-get="/twitter/index?filter=all" hx-target="#tweets" hx-include="[name=username]" {%if :filter=='all'%}style="font-weight:bold"{%end if%}>All</a>
       /
       <a hx-get="/twitter/index?filter=following" hx-target="#tweets" hx-include="[name=username]" {%if :filter=='following'%}style="font-weight:bold"{%end if%}>Following</a>


### PR DESCRIPTION
## Summary
- improve mini twitter demo with a `datalist` for choosing an existing user or typing a new one
- test for the username selector

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866cd97a558832f8d33fc5e83e60dde