### PR TITLE
Remove params from SQL error messages

### DIFF
--- a/src/pageql/database.py
+++ b/src/pageql/database.py
@@ -137,7 +137,7 @@ def db_execute_dot(db, exp, params):
         return db.execute(converted_exp, converted_params)
     except sqlite3.Error as e:
         raise ValueError(
-            f"Error executing SQL `{converted_exp}` with params {converted_params}: {e}"
+            f"Error executing SQL `{converted_exp}`: {e}"
         )
 
 
@@ -214,11 +214,11 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         r = db_execute_dot(db, exp, params).fetchone()
         if len(r) != 1:
             raise ValueError(
-                f"SQL expression `{exp}` with params `{params}` returned {len(r)} rows, expected 1"
+                f"SQL expression `{exp}` returned {len(r)} rows, expected 1"
             )
         return r[0]
     except sqlite3.Error as e:
         raise ValueError(
-            f"Error evaluating SQL expression `{exp}` with params `{params}`: {e}"
+            f"Error evaluating SQL expression `{exp}`: {e}"
         )
 

--- a/src/pageql/pageql.py
+++ b/src/pageql/pageql.py
@@ -143,7 +143,7 @@ def _run_sql(exec_func, node_type, content, params):
         exec_func(node_type[1:] + " " + content, params)
     except sqlite3.Error as e:
         raise ValueError(
-            f"Error executing {node_type[1:]} {content} with params {params}: {e}"
+            f"Error executing {node_type[1:]} {content}: {e}"
         )
 
 
@@ -969,7 +969,7 @@ class PageQL:
                     cursor = self.db.execute(comp.sql, converted_params)
                 except sqlite3.Error as e:
                     raise ValueError(
-                        f"Error executing SQL `{comp.sql}` with params {converted_params}: {e}"
+                        f"Error executing SQL `{comp.sql}`: {e}"
                     )
                 rows = cursor.fetchall()
             else:


### PR DESCRIPTION
## Summary
- stop including parameters in SQL error messages to avoid excessively large responses
- update database error handling to omit parameter dumps
- adjust error message tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6873ae1e49c0832fab7e949bad82f051