### PR TITLE
Remove available parameter hint from error messages

### DIFF
--- a/src/pageql/database.py
+++ b/src/pageql/database.py
@@ -124,10 +124,9 @@ def db_execute_dot(db, exp, params):
     ]
     missing = [n for n in param_names if n not in params]
     if missing:
-        avail = ", ".join(sorted(params.keys()))
         raise ValueError(
             f"Missing parameter(s) {', '.join(m.replace('__', '.') for m in missing)} "
-            f"for SQL expression `{exp}`. Available parameters: {avail}"
+            f"for SQL expression `{exp}`."
         )
 
     converted_params = {}
@@ -161,8 +160,7 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
                 return signal
             return val.value if isinstance(val, Signal) else val
         raise ValueError(
-            f"Missing parameter '{original}' for expression `{exp}`. "
-            f"Available parameters: {', '.join(sorted(params.keys()))}"
+            f"Missing parameter '{original}' for expression `{exp}`."
         )
 
     if not re.match(r"(?i)^\s*(select|\(select)", exp):
@@ -175,10 +173,9 @@ def evalone(db, exp, params, reactive=False, tables=None, expr=None):
         dep_names = [name.replace(".", "__") for name in get_dependencies(sql)]
         missing = [n for n in dep_names if n not in params]
         if missing:
-            avail = ", ".join(sorted(params.keys()))
             raise ValueError(
                 f"Missing parameter(s) {', '.join(m.replace('__', '.') for m in missing)} "
-                f"for SQL expression `{exp}`. Available parameters: {avail}"
+                f"for SQL expression `{exp}`."
             )
         for name in dep_names:
             val = params.get(name)

--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -34,11 +34,9 @@ def _replace_placeholders(
     placeholders = list(expr.find_all(exp.Placeholder))
     missing = [ph.this for ph in placeholders if ph.this not in params]
     if missing:
-        avail = ", ".join(sorted(params.keys()))
         names = ", ".join(missing)
         raise ValueError(
-            f"Missing parameter(s) {names} for SQL expression `{expr.sql()}`. "
-            f"Available parameters: {avail}"
+            f"Missing parameter(s) {names} for SQL expression `{expr.sql()}`."
         )
 
     for ph in placeholders:

--- a/tests/test_missing_parameter_messages.py
+++ b/tests/test_missing_parameter_messages.py
@@ -1,0 +1,28 @@
+import sqlite3
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import pytest
+import sqlglot
+
+from pageql.database import evalone
+from pageql.reactive_sql import _replace_placeholders
+
+
+def test_evalone_missing_param_message():
+    conn = sqlite3.connect(":memory:")
+    with pytest.raises(ValueError) as excinfo:
+        evalone(conn, ":foo", {})
+    msg = str(excinfo.value)
+    assert "Missing parameter 'foo'" in msg
+    assert "Available parameters" not in msg
+
+
+def test_replace_placeholders_missing_param_message():
+    expr = sqlglot.parse_one("SELECT :a + :b", read="sqlite")
+    with pytest.raises(ValueError) as excinfo:
+        _replace_placeholders(expr, {"a": 1}, "sqlite")
+    msg = str(excinfo.value)
+    assert "Missing parameter(s) b" in msg
+    assert "Available parameters" not in msg

--- a/tests/test_param_validation.py
+++ b/tests/test_param_validation.py
@@ -29,7 +29,7 @@ def test_missing_param_error():
         r.render("/m", reactive=False)
     msg = str(exc.value).lower()
     assert "missing parameter 'non_existent'" in msg
-    assert "available parameters" in msg
+    assert "available parameters" not in msg
 
 
 
@@ -46,5 +46,5 @@ def test_missing_param_error_reactive():
         r.render("/m", reactive=True)
     msg = str(exc.value).lower()
     assert "missing parameter(s) c" in msg
-    assert "available parameters" in msg
+    assert "available parameters" not in msg
 


### PR DESCRIPTION
## Summary
- don't mention available parameters when raising missing parameter errors
- test that the shortened message is produced

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6873c446ea70832fab0474afe30890eb