### PR TITLE
Fix fallback reactive for subselect queries

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -338,10 +338,15 @@ def parse_reactive(
         comp.columns = [d[0] for d in cur.description]
         return comp
 
-    try:
-        comp = build_reactive(expr, tables)
-    except NotImplementedError:
+    subqueries = list(expr.find_all(exp.Subquery))
+    inner_subquery = any(s is not expr for s in subqueries)
+    if inner_subquery:
         comp = FallbackReactive(tables, sql, expr)
+    else:
+        try:
+            comp = build_reactive(expr, tables)
+        except NotImplementedError:
+            comp = FallbackReactive(tables, sql, expr)
 
     if one_value:
         comp = OneValue(comp)

--- a/tests/test_reactive_sql.py
+++ b/tests/test_reactive_sql.py
@@ -207,6 +207,17 @@ def test_parse_recursive_cte_with_table_deps():
     assert {d.table_name for d in comp.deps} == {"items"}
 
 
+def test_parse_select_subselect_fallback():
+    conn = _db()
+    conn.execute("CREATE TABLE nums(id INTEGER PRIMARY KEY)")
+    tables = Tables(conn)
+    sql = "SELECT name FROM items WHERE id IN (SELECT id FROM nums)"
+    expr = sqlglot.parse_one(sql, read="sqlite")
+    comp = parse_reactive(expr, tables, {})
+    assert isinstance(comp, FallbackReactive)
+    assert_sql_equivalent(conn, sql, comp.sql)
+
+
 def test_parse_group_by_aggregate():
     conn = sqlite3.connect(":memory:")
     conn.execute("CREATE TABLE nums(id INTEGER PRIMARY KEY, grp INTEGER, n INTEGER)")


### PR DESCRIPTION
## Summary
- trigger fallback reactive when a subquery appears inside the query
- test parsing queries with subselects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6874a3ea6ec8832f8d89b4cf9a2dc78b