### PR TITLE
Fix subselect handling in reactive SQL parser

### DIFF
--- a/src/pageql/reactive_sql.py
+++ b/src/pageql/reactive_sql.py
@@ -340,6 +340,16 @@ def parse_reactive(
 
     subqueries = list(expr.find_all(exp.Subquery))
     inner_subquery = any(s is not expr for s in subqueries)
+    if not inner_subquery:
+        for sel in expr.find_all(exp.Select):
+            if sel is expr:
+                continue
+            parent = sel.parent
+            if isinstance(parent, (exp.Union, exp.Subquery)) and parent is expr:
+                continue
+            if not isinstance(parent, exp.Union):
+                inner_subquery = True
+                break
     if inner_subquery:
         comp = FallbackReactive(tables, sql, expr)
     else:


### PR DESCRIPTION
## Summary
- flag any query with nested sub-selects to fallback to `FallbackReactive`
- update tests to assert fallback behaviour for subselects

## Testing
- `PYTHONPATH=src pytest tests/test_reactive_sql.py::test_parse_join_where_order_with_params -vv`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_687cacb1a460832fb10133d43bca9017