### PR TITLE
Add failing test for sqlglot subquery detection in EXISTS

### DIFF
--- a/tests/test_sqlglot_bug.py
+++ b/tests/test_sqlglot_bug.py
@@ -1,0 +1,9 @@
+import sqlglot
+from sqlglot import expressions as exp
+
+
+def test_findall_exists_subquery():
+    sql = "select * from tweets where exists(select 1 from tweets t2 where t2.id = tweets.id)"
+    expr = sqlglot.parse_one(sql, read="sqlite")
+    subqueries = list(expr.find_all(exp.Subquery))
+    assert len(subqueries) == 1


### PR DESCRIPTION
## Summary
- add regression test for `find_all` on EXISTS with a subquery

## Testing
- `pytest tests/test_sqlglot_bug.py::test_findall_exists_subquery -vv` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_687dd7e74418832f866a779dca1d921e