### PR TITLE
Mark sqlglot bug test as xfail

### DIFF
--- a/tests/test_sqlglot_bug.py
+++ b/tests/test_sqlglot_bug.py
@@ -1,7 +1,9 @@
+import pytest
 import sqlglot
 from sqlglot import expressions as exp
 
 
+@pytest.mark.xfail(reason="sqlglot incorrectly handles EXISTS subquery counting")
 def test_findall_exists_subquery():
     sql = "select * from tweets where exists(select 1 from tweets t2 where t2.id = tweets.id)"
     expr = sqlglot.parse_one(sql, read="sqlite")


### PR DESCRIPTION
## Summary
- mark the sqlglot subquery bug test as `xfail`

## Testing
- `PYTHONPATH=src pytest tests/test_sqlglot_bug.py`

------
https://chatgpt.com/codex/tasks/task_e_687dde71faa0832f87e733d1894bfc95