### PR TITLE
Remove redundant headings from Mini Twitter

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -150,3 +150,16 @@ def test_twitter_username_selector_present():
     assert '<input name="username"' in body
     assert 'list="usernames"' in body
     assert '<datalist id="usernames">' in body
+
+def test_twitter_dump_headings_not_repeated():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    r.render("/twitter/index", reactive=False)
+    body = r.render("/twitter/index", reactive=False).body
+    assert "<h2>Tweets</h2>" not in body
+    assert "<h2>Following</h2>" not in body
+    assert body.count("<h2>Users</h2>") == 1
+    assert body.count("<h2>tweets</h2>") == 1
+    assert body.count("<h2>following</h2>") == 1
+    assert body.count("<h2>users</h2>") == 1

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -90,11 +90,8 @@ ORDER BY u.username
     </ul>
   </div>
 </div>
-<h2>Tweets</h2>
   {%dump tweets %}
-  <h2>Following</h2>
   {%dump following%}
-  <h2>Users</h2>
   {%dump users%}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify mini Twitter page markup by removing redundant `<h2>` elements preceding dump outputs
- verify dumps do not have extra headings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687de002c708832f893cc8ced797ef80