### PR TITLE
Remove redundant headers in mini Twitter dumps

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -198,3 +198,19 @@ def test_twitter_like_button_updates():
 
     assert f'hx-post="/twitter/index/like/{tid}"' in result.body
     assert ">Like (0)</button>" in result.body
+
+
+def test_twitter_dump_headers_not_duplicated():
+    src = Path("website/twitter/index.pageql").read_text()
+    r = PageQL(":memory:")
+    r.load_module("twitter/index", src)
+    result = r.render("/twitter/index", reactive=False)
+    body = result.body
+
+    assert "<h2>Tweets</h2>" not in body
+    assert "<h2>Following</h2>" not in body
+    assert body.count("<h2>Users</h2>") == 1
+
+    assert "<h2>tweets</h2>" in body
+    assert "<h2>following</h2>" in body
+    assert "<h2>users</h2>" in body

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -107,12 +107,9 @@ ORDER BY u.username
     </ul>
   </div>
 </div>
-<h2>Tweets</h2>
-  {%dump tweets %}
-  <h2>Following</h2>
-  {%dump following%}
-  <h2>Users</h2>
-  {%dump users%}
+{%dump tweets %}
+{%dump following%}
+{%dump users%}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- remove duplicate `<h2>` tags before `{%dump %}` calls in `website/twitter/index.pageql`
- add regression test to ensure mini Twitter page only contains dump-provided headers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687de2135ac8832f862f366a81efde1b