### PR TITLE
Improve like buttons in mini Twitter example

### DIFF
--- a/tests/test_twitter_page.py
+++ b/tests/test_twitter_page.py
@@ -181,7 +181,7 @@ def test_twitter_like_button_updates():
     )
 
     assert f'hx-delete="/twitter/index/like/{tid}"' in result.body
-    assert ">Unlike (1)</button>" in result.body
+    assert '>♥</button> 1' in result.body
 
     r.render(
         f"/twitter/index/like/{tid}",
@@ -197,7 +197,7 @@ def test_twitter_like_button_updates():
     )
 
     assert f'hx-post="/twitter/index/like/{tid}"' in result.body
-    assert ">Like (0)</button>" in result.body
+    assert '>♡</button> 0' in result.body
 
 
 def test_twitter_dump_headers_not_duplicated():

--- a/website/twitter/index.pageql
+++ b/website/twitter/index.pageql
@@ -71,9 +71,9 @@ let current_id = select (select id from users where username=:username);
       )%}
         <li><strong>{{username}}</strong>: {{text}}
           {%if :liked == 0%}
-            <button hx-post="/twitter/index/like/{{id}}" hx-include="[name=username]" hx-swap="none">Like ({{likes_count}})</button>
+            <button hx-post="/twitter/index/like/{{id}}" hx-include="[name=username]" hx-swap="none">♡</button> {{likes_count}}
           {%else%}
-            <button hx-delete="/twitter/index/like/{{id}}" hx-include="[name=username]" hx-swap="none">Unlike ({{likes_count}})</button>
+            <button hx-delete="/twitter/index/like/{{id}}" hx-include="[name=username]" hx-swap="none">♥</button> {{likes_count}}
           {%end if%}
         </li>
       {%end from%}


### PR DESCRIPTION
## Summary
- replace Like/Unlike text with heart icons in twitter example
- update tests for new heart-based like button

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e0d275670832faf7054f3f55c8108